### PR TITLE
Unify workspace projects and scenes storage

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,9 @@
 
 @layer base {
   :root {
+    --font-inter: 'Avenir Next', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+    --font-space-grotesk: 'Trebuchet MS', 'Avenir Next', 'Segoe UI', sans-serif;
+    --font-merriweather: Georgia, 'Times New Roman', serif;
     --background: 0 0% 100%;
     --foreground: 240 10% 3.9%;
     --card: 0 0% 100%;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,9 +4,9 @@
 
 @layer base {
   :root {
-    --font-inter: 'Avenir Next', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+    --font-inter: 'Avenir Next', 'Segoe UI', 'Helvetica Neue', arial, sans-serif;
     --font-space-grotesk: 'Trebuchet MS', 'Avenir Next', 'Segoe UI', sans-serif;
-    --font-merriweather: Georgia, 'Times New Roman', serif;
+    --font-merriweather: georgia, 'Times New Roman', serif;
     --background: 0 0% 100%;
     --foreground: 240 10% 3.9%;
     --card: 0 0% 100%;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,18 +1,6 @@
 import type { Metadata } from 'next';
 import type { ReactElement, ReactNode } from 'react';
-import { Inter, Merriweather, Space_Grotesk } from 'next/font/google';
 import './globals.css';
-
-const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
-const spaceGrotesk = Space_Grotesk({
-  subsets: ['latin'],
-  variable: '--font-space-grotesk',
-});
-const merriweather = Merriweather({
-  subsets: ['latin'],
-  weight: ['300', '400', '700'],
-  variable: '--font-merriweather',
-});
 
 export const metadata: Metadata = {
   title: 'Ainkwell',
@@ -25,12 +13,8 @@ export default function RootLayout({
   children: ReactNode;
 }>): ReactElement {
   return (
-    <html lang="en">
-      <body
-        className={`${inter.variable} ${spaceGrotesk.variable} ${merriweather.variable} font-body antialiased`}
-      >
-        {children}
-      </body>
+    <html lang="en" suppressHydrationWarning>
+      <body className="font-body antialiased">{children}</body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,12 +25,6 @@ export default function HomePage(): ReactElement {
           >
             Open Project Workspace
           </Link>
-          <Link
-            href="/workspace/demo-project/scene/scene-1"
-            className="inline-flex rounded-md border px-4 py-2 text-sm font-semibold"
-          >
-            Open Demo Scene
-          </Link>
         </div>
       </div>
     </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from 'react';
+import Link from 'next/link';
 
 export default function HomePage(): ReactElement {
   return (
@@ -11,6 +12,14 @@ export default function HomePage(): ReactElement {
             Start development with <code className="rounded bg-muted px-2 py-1">npm run dev</code>.
           </p>
           <p>Next step: build the local-first writing workspace and data model.</p>
+        </div>
+        <div className="mt-6 flex items-center gap-3">
+          <Link
+            href="/workspace/demo-project"
+            className="inline-flex rounded-md border border-primary bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground"
+          >
+            Open Demo Workspace
+          </Link>
         </div>
       </div>
     </main>

--- a/src/app/workspace/[projectId]/page.tsx
+++ b/src/app/workspace/[projectId]/page.tsx
@@ -2,10 +2,13 @@
 
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
-import type { ReactElement } from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import type { Dispatch, ReactElement, SetStateAction } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
 import { createProjectService } from '@/application/project/project-service';
 import type { ProjectService } from '@/application/project/project-service';
+import { SceneEditorService } from '@/application/scene/scene-editor-service';
+import { SceneStatusBadge } from '@/components/scene/scene-status-badge';
 import { LocalProjectRepository } from '@/data/project/local-project-repository';
 import { projectIdSchema } from '@/domain/project/schemas';
 import type { WritingProject } from '@/domain/project/types';
@@ -17,71 +20,144 @@ type ProjectDetailResult = {
   state: DetailState;
   errorMessage: string | null;
   project: WritingProject | null;
+  reload: () => Promise<void>;
 };
 
-function getProjectIdParam(input: string | string[] | undefined): string {
+type SceneActions = {
+  isCreatingScene: boolean;
+  sceneActionError: string | null;
+  createScene: () => Promise<void>;
+};
+
+type ProjectLoadHandlers = {
+  start: () => void;
+  applyReady: (project: WritingProject) => void;
+  applyNotFound: () => void;
+  applyError: (error: unknown) => void;
+  shouldApply: () => boolean;
+};
+
+const getProjectIdParam = (input: string | string[] | undefined): string => {
   if (Array.isArray(input)) {
     return input[0] ?? '';
   }
 
   return input ?? '';
-}
+};
 
-function readErrorMessage(error: unknown): string {
+const toErrorMessage = (error: unknown, fallbackMessage: string): string => {
   if (error instanceof Error && error.message.trim().length > 0) {
     return error.message;
   }
 
-  return 'Unable to load this project.';
-}
+  return fallbackMessage;
+};
+
+const getNextSceneTitle = (project: WritingProject): string => `Scene ${project.sceneOrder.length + 1}`;
+
+const loadProjectDetail = async (
+  projectId: string,
+  service: ProjectService,
+  handlers: ProjectLoadHandlers,
+): Promise<void> => {
+  handlers.start();
+
+  try {
+    const loadedProject = await service.getProjectById(projectId);
+    if (!handlers.shouldApply()) {
+      return;
+    }
+
+    if (!loadedProject) {
+      handlers.applyNotFound();
+      return;
+    }
+
+    handlers.applyReady(loadedProject);
+  } catch (error) {
+    if (!handlers.shouldApply()) {
+      return;
+    }
+
+    handlers.applyError(error);
+  }
+};
+
+const useProjectIdParam = (): string | null => {
+  const params = useParams<{ projectId: string }>();
+  const projectIdParam = getProjectIdParam(params.projectId);
+  const parsedProjectId = projectIdSchema.safeParse(projectIdParam);
+  return parsedProjectId.success ? parsedProjectId.data : null;
+};
+
+const useProjectLoadHandlers = (
+  setState: Dispatch<SetStateAction<DetailState>>,
+  setErrorMessage: Dispatch<SetStateAction<string | null>>,
+  setProject: Dispatch<SetStateAction<WritingProject | null>>,
+): Omit<ProjectLoadHandlers, 'shouldApply'> => {
+  const start = useCallback((): void => {
+    setState('loading');
+    setErrorMessage(null);
+  }, [setErrorMessage, setState]);
+  const applyReady = useCallback((loadedProject: WritingProject): void => {
+    setProject(loadedProject);
+    setState('ready');
+  }, [setProject, setState]);
+  const applyNotFound = useCallback((): void => {
+    setProject(null);
+    setState('not-found');
+  }, [setProject, setState]);
+  const applyError = useCallback((error: unknown): void => {
+    setProject(null);
+    setErrorMessage(toErrorMessage(error, 'Unable to load this project.'));
+    setState('error');
+  }, [setErrorMessage, setProject, setState]);
+
+  return { start, applyReady, applyNotFound, applyError };
+};
 
 function useProjectDetail(projectId: string | null, service: ProjectService): ProjectDetailResult {
   const [state, setState] = useState<DetailState>('loading');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [project, setProject] = useState<WritingProject | null>(null);
+  const { start, applyReady, applyNotFound, applyError } = useProjectLoadHandlers(
+    setState,
+    setErrorMessage,
+    setProject,
+  );
 
-  useEffect(() => {
+  const reload = useCallback(async (): Promise<void> => {
     if (!projectId) {
-      return undefined;
+      return;
     }
 
-    let isActive = true;
-
-    const loadProject = async (): Promise<void> => {
-      setState('loading');
-      setErrorMessage(null);
-      const loadedProject = await service.getProjectById(projectId);
-
-      if (!isActive) {
-        return;
-      }
-
-      if (!loadedProject) {
-        setProject(null);
-        setState('not-found');
-        return;
-      }
-
-      setProject(loadedProject);
-      setState('ready');
-    };
-
-    loadProject().catch((error: unknown) => {
-      if (!isActive) {
-        return;
-      }
-
-      setProject(null);
-      setErrorMessage(readErrorMessage(error));
-      setState('error');
+    await loadProjectDetail(projectId, service, {
+      start,
+      applyReady,
+      applyNotFound,
+      applyError,
+      shouldApply: () => true,
     });
+  }, [applyError, applyNotFound, applyReady, projectId, service, start]);
+
+  useEffect(() => {
+    let isMounted = true;
+    if (projectId) {
+      void loadProjectDetail(projectId, service, {
+        start,
+        applyReady,
+        applyNotFound,
+        applyError,
+        shouldApply: () => isMounted,
+      });
+    }
 
     return () => {
-      isActive = false;
+      isMounted = false;
     };
-  }, [projectId, service]);
+  }, [applyError, applyNotFound, applyReady, projectId, service, start]);
 
-  return { state, errorMessage, project };
+  return { state, errorMessage, project, reload };
 }
 
 function CenteredMessage({
@@ -119,26 +195,79 @@ function ProjectStats({ project }: { project: WritingProject }): ReactElement {
   );
 }
 
-function ProjectPlaceholders(): ReactElement {
+function SceneList({ projectId, project }: { projectId: string; project: WritingProject }): ReactElement {
+  const orderedScenes = project.sceneOrder
+    .map((sceneId) => project.scenes[sceneId])
+    .filter((scene): scene is NonNullable<typeof scene> => Boolean(scene));
+
+  if (orderedScenes.length === 0) {
+    return (
+      <p className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+        No scenes yet. Create your first scene.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="space-y-3">
+      {orderedScenes.map((scene) => (
+        <li key={scene.id} className="rounded-lg border p-4">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div className="space-y-2">
+              <h3 className="text-lg font-headline font-semibold">{scene.title}</h3>
+              <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+                <SceneStatusBadge status={scene.status} />
+                <span>Updated: {formatProjectDate(scene.updatedAt)}</span>
+              </div>
+            </div>
+            <Link
+              href={`/workspace/${projectId}/scene/${scene.id}`}
+              className="inline-flex rounded-md border px-3 py-2 text-sm font-medium"
+            >
+              Open
+            </Link>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ProjectScenesSection({ projectId, project, actions }: {
+  project: WritingProject;
+  projectId: string;
+  actions: SceneActions;
+}): ReactElement {
   return (
     <section className="space-y-3">
-      <div className="rounded-lg border border-dashed p-4">
-        <h2 className="text-xl font-headline font-semibold">Scene Editor (placeholder)</h2>
-        <p className="mt-1 text-sm text-muted-foreground">
-          The markdown scene editor will consume this project id and settings in a future branch.
-        </p>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-2xl font-headline font-semibold">Scenes</h2>
+        <button
+          type="button"
+          onClick={() => {
+            void actions.createScene();
+          }}
+          disabled={actions.isCreatingScene}
+          className="inline-flex rounded-md border bg-primary px-3 py-2 text-sm font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {actions.isCreatingScene ? 'Creating...' : 'Create scene'}
+        </button>
       </div>
-      <div className="rounded-lg border border-dashed p-4">
-        <h2 className="text-xl font-headline font-semibold">Story Bible (placeholder)</h2>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Story bible entities will be scoped by this project id in a future branch.
-        </p>
-      </div>
+      {actions.sceneActionError ? <p className="text-sm text-destructive">{actions.sceneActionError}</p> : null}
+      <SceneList projectId={projectId} project={project} />
     </section>
   );
 }
 
-function ProjectDetailContent({ project }: { project: WritingProject }): ReactElement {
+function ProjectDetailView({
+  project,
+  projectId,
+  actions,
+}: {
+  project: WritingProject;
+  projectId: string;
+  actions: SceneActions;
+}): ReactElement {
   return (
     <main className="mx-auto flex min-h-screen w-full max-w-4xl flex-col gap-6 px-4 py-10">
       <header className="space-y-2">
@@ -148,8 +277,10 @@ function ProjectDetailContent({ project }: { project: WritingProject }): ReactEl
         </p>
         <p className="text-xs text-muted-foreground">Last updated: {formatProjectDate(project.updatedAt)}</p>
       </header>
+
       <ProjectStats project={project} />
-      <ProjectPlaceholders />
+      <ProjectScenesSection projectId={projectId} project={project} actions={actions} />
+
       <Link className="text-sm font-medium text-primary underline" href="/workspace">
         Back to workspace
       </Link>
@@ -157,19 +288,20 @@ function ProjectDetailContent({ project }: { project: WritingProject }): ReactEl
   );
 }
 
-export default function WorkspaceProjectPage(): ReactElement {
-  const params = useParams<{ projectId: string }>();
-  const service = useMemo(() => createProjectService(new LocalProjectRepository()), []);
-  const projectIdParam = getProjectIdParam(params.projectId);
-  const parsedProjectId = projectIdSchema.safeParse(projectIdParam);
-  const projectId = parsedProjectId.success ? parsedProjectId.data : null;
-  const { state, errorMessage, project } = useProjectDetail(projectId, service);
-
+function ProjectPageState({
+  projectId,
+  detail,
+  actions,
+}: {
+  projectId: string | null;
+  detail: ProjectDetailResult;
+  actions: SceneActions;
+}): ReactElement {
   if (!projectId) {
     return <CenteredMessage description="The URL does not contain a valid project identifier." title="Invalid project id" />;
   }
 
-  if (state === 'loading') {
+  if (detail.state === 'loading') {
     return (
       <main className="mx-auto flex min-h-screen w-full max-w-4xl items-center justify-center px-4">
         <p>Loading project...</p>
@@ -177,15 +309,15 @@ export default function WorkspaceProjectPage(): ReactElement {
     );
   }
 
-  if (state === 'not-found') {
+  if (detail.state === 'not-found') {
     return <CenteredMessage description="This project does not exist in local storage." title="Project not found" />;
   }
 
-  if (state === 'error') {
-    return <CenteredMessage description={errorMessage ?? 'Unable to open project.'} title="Unable to open project" tone="destructive" />;
+  if (detail.state === 'error') {
+    return <CenteredMessage description={detail.errorMessage ?? 'Unable to open project.'} title="Unable to open project" tone="destructive" />;
   }
 
-  if (!project) {
+  if (!detail.project) {
     return (
       <main className="mx-auto flex min-h-screen w-full max-w-4xl items-center justify-center px-4">
         <p>Unable to load project.</p>
@@ -193,5 +325,48 @@ export default function WorkspaceProjectPage(): ReactElement {
     );
   }
 
-  return <ProjectDetailContent project={project} />;
+  return <ProjectDetailView project={detail.project} projectId={projectId} actions={actions} />;
+}
+
+export default function WorkspaceProjectPage(): ReactElement {
+  const projectId = useProjectIdParam();
+  const repository = useMemo(() => new LocalProjectRepository(), []);
+  const projectService = useMemo(() => createProjectService(repository), [repository]);
+  const sceneService = useMemo(() => new SceneEditorService(repository), [repository]);
+
+  const [isCreatingScene, setIsCreatingScene] = useState<boolean>(false);
+  const [sceneActionError, setSceneActionError] = useState<string | null>(null);
+  const detail = useProjectDetail(projectId, projectService);
+
+  const createScene = useCallback(async (): Promise<void> => {
+    if (!projectId || !detail.project) {
+      return;
+    }
+
+    setSceneActionError(null);
+    setIsCreatingScene(true);
+    try {
+      await sceneService.createScene({
+        projectId,
+        title: getNextSceneTitle(detail.project),
+      });
+      await detail.reload();
+    } catch (error) {
+      setSceneActionError(toErrorMessage(error, 'Unable to create scene.'));
+    } finally {
+      setIsCreatingScene(false);
+    }
+  }, [detail, projectId, sceneService]);
+
+  return (
+    <ProjectPageState
+      projectId={projectId}
+      detail={detail}
+      actions={{
+        isCreatingScene,
+        sceneActionError,
+        createScene,
+      }}
+    />
+  );
 }

--- a/src/app/workspace/[projectId]/page.tsx
+++ b/src/app/workspace/[projectId]/page.tsx
@@ -1,0 +1,15 @@
+import type { ReactElement } from 'react';
+
+import { WorkspaceSceneList } from '@/components/scene/workspace-scene-list';
+
+type WorkspacePageProps = {
+  params: Promise<{
+    projectId: string;
+  }>;
+};
+
+export default async function WorkspacePage(props: WorkspacePageProps): Promise<ReactElement> {
+  const params = await props.params;
+
+  return <WorkspaceSceneList projectId={params.projectId} />;
+}

--- a/src/app/workspace/[projectId]/page.tsx
+++ b/src/app/workspace/[projectId]/page.tsx
@@ -352,7 +352,7 @@ export default function WorkspaceProjectPage(): ReactElement {
       });
       await detail.reload();
     } catch (error) {
-      setSceneActionError(toErrorMessage(error, 'Unable to create scene.'));
+      setSceneActionError(sceneService.toUserErrorMessage(error));
     } finally {
       setIsCreatingScene(false);
     }

--- a/src/app/workspace/[projectId]/scene/[sceneId]/page.tsx
+++ b/src/app/workspace/[projectId]/scene/[sceneId]/page.tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from 'react';
+
+import { SceneEditorShell } from '@/components/scene/scene-editor-shell';
+
+type ScenePageProps = {
+  params: Promise<{
+    projectId: string;
+    sceneId: string;
+  }>;
+};
+
+export default async function ScenePage(props: ScenePageProps): Promise<ReactElement> {
+  const params = await props.params;
+
+  return <SceneEditorShell projectId={params.projectId} sceneId={params.sceneId} />;
+}

--- a/src/application/scene/scene-editor-service.ts
+++ b/src/application/scene/scene-editor-service.ts
@@ -18,6 +18,11 @@ type SaveSceneInput = {
   updatedAt: string;
 };
 
+type CreateSceneInput = {
+  projectId: string;
+  title: string;
+};
+
 type ListProjectScenesInput = {
   projectId: string;
 };
@@ -55,6 +60,7 @@ export type ProjectScenesResult =
 export interface SceneEditorServicePort {
   loadScene(input: LoadSceneInput): Promise<SceneLoadResult>;
   listProjectScenes(input: ListProjectScenesInput): Promise<ProjectScenesResult>;
+  createScene(input: CreateSceneInput): Promise<Scene>;
   saveScene(input: SaveSceneInput): Promise<Scene>;
   countWords(content: string): number;
   toUserErrorMessage(error: unknown): string;
@@ -110,6 +116,10 @@ export class SceneEditorService implements SceneEditorServicePort {
     }
 
     return { state: 'ready', scenes };
+  }
+
+  public async createScene(input: CreateSceneInput): Promise<Scene> {
+    return this.projectRepository.createScene(input);
   }
 
   public async saveScene(input: SaveSceneInput): Promise<Scene> {

--- a/src/application/scene/scene-editor-service.ts
+++ b/src/application/scene/scene-editor-service.ts
@@ -1,0 +1,170 @@
+import { ZodError } from 'zod';
+
+import { projectNotFoundCode, sceneNotFoundCode } from '@/data/project/local-project-repository';
+import type { ProjectRepository } from '@/domain/project/repository';
+import { maxSceneContentLength } from '@/domain/scene/schemas';
+import type { Scene, SceneStatus, SceneSummary } from '@/domain/scene/types';
+
+type LoadSceneInput = {
+  projectId: string;
+  sceneId: string;
+};
+
+type SaveSceneInput = {
+  projectId: string;
+  sceneId: string;
+  content: string;
+  status: SceneStatus;
+  updatedAt: string;
+};
+
+type ListProjectScenesInput = {
+  projectId: string;
+};
+
+export type SceneLoadResult =
+  | {
+      state: 'project-not-found';
+      scene: null;
+      previousSceneId: null;
+      nextSceneId: null;
+    }
+  | {
+      state: 'scene-not-found';
+      scene: null;
+      previousSceneId: null;
+      nextSceneId: null;
+    }
+  | {
+      state: 'ready';
+      scene: Scene;
+      previousSceneId: string | null;
+      nextSceneId: string | null;
+    };
+
+export type ProjectScenesResult =
+  | {
+      state: 'project-not-found';
+      scenes: [];
+    }
+  | {
+      state: 'ready';
+      scenes: SceneSummary[];
+    };
+
+export interface SceneEditorServicePort {
+  loadScene(input: LoadSceneInput): Promise<SceneLoadResult>;
+  listProjectScenes(input: ListProjectScenesInput): Promise<ProjectScenesResult>;
+  saveScene(input: SaveSceneInput): Promise<Scene>;
+  countWords(content: string): number;
+  toUserErrorMessage(error: unknown): string;
+}
+
+export class SceneEditorService implements SceneEditorServicePort {
+  public constructor(private readonly projectRepository: ProjectRepository) {}
+
+  public async loadScene(input: LoadSceneInput): Promise<SceneLoadResult> {
+    const scenes = await this.getProjectScenes(input.projectId);
+
+    if (!scenes) {
+      return {
+        state: 'project-not-found',
+        scene: null,
+        previousSceneId: null,
+        nextSceneId: null,
+      };
+    }
+
+    const sceneIndex = scenes.findIndex((scene) => scene.id === input.sceneId);
+    if (sceneIndex < 0) {
+      return {
+        state: 'scene-not-found',
+        scene: null,
+        previousSceneId: null,
+        nextSceneId: null,
+      };
+    }
+
+    const scene = await this.projectRepository.getScene(input);
+    if (!scene) {
+      return {
+        state: 'scene-not-found',
+        scene: null,
+        previousSceneId: null,
+        nextSceneId: null,
+      };
+    }
+
+    return {
+      state: 'ready',
+      scene,
+      previousSceneId: scenes[sceneIndex - 1]?.id ?? null,
+      nextSceneId: scenes[sceneIndex + 1]?.id ?? null,
+    };
+  }
+
+  public async listProjectScenes(input: ListProjectScenesInput): Promise<ProjectScenesResult> {
+    const scenes = await this.getProjectScenes(input.projectId);
+    if (!scenes) {
+      return { state: 'project-not-found', scenes: [] };
+    }
+
+    return { state: 'ready', scenes };
+  }
+
+  public async saveScene(input: SaveSceneInput): Promise<Scene> {
+    return this.projectRepository.saveScene(input);
+  }
+
+  public countWords(content: string): number {
+    const trimmedContent = content.trim();
+    if (!trimmedContent) {
+      return 0;
+    }
+
+    return trimmedContent.split(/\s+/).filter(Boolean).length;
+  }
+
+  public toUserErrorMessage(error: unknown): string {
+    if (this.isProjectNotFoundError(error)) {
+      return 'Project not found.';
+    }
+
+    if (this.isSceneNotFoundError(error)) {
+      return 'Scene not found.';
+    }
+
+    if (error instanceof ZodError) {
+      const contentTooLarge = error.issues.some(
+        (issue) => issue.path.includes('content') && issue.code === 'too_big',
+      );
+      if (contentTooLarge) {
+        return `Scene content exceeds ${maxSceneContentLength} characters.`;
+      }
+
+      return 'Invalid scene data.';
+    }
+
+    return 'Unable to save scene. Retry.';
+  }
+
+  private async getProjectScenes(projectId: string): Promise<SceneSummary[] | null> {
+    try {
+      return await this.projectRepository.listScenes({ projectId });
+    } catch (error) {
+      if (this.isProjectNotFoundError(error)) {
+        return null;
+      }
+
+      throw error;
+    }
+  }
+
+  private isProjectNotFoundError(error: unknown): boolean {
+    return error instanceof Error && error.message === projectNotFoundCode;
+  }
+
+  private isSceneNotFoundError(error: unknown): boolean {
+    return error instanceof Error && error.message === sceneNotFoundCode;
+  }
+}

--- a/src/components/scene/scene-editor-shell.tsx
+++ b/src/components/scene/scene-editor-shell.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import Link from 'next/link';
+import type { ReactElement } from 'react';
+import { useMemo } from 'react';
+
+import {
+  SceneEditorService,
+  type SceneEditorServicePort,
+} from '@/application/scene/scene-editor-service';
+import { SceneToolbar } from '@/components/scene/scene-toolbar';
+import { LocalProjectRepository } from '@/data/project/local-project-repository';
+import { useSceneEditor, type UseSceneEditorResult } from '@/hooks/use-scene-editor';
+
+type SceneEditorShellProps = {
+  projectId: string;
+  sceneId: string;
+  service?: SceneEditorServicePort;
+};
+
+const createSceneEditorService = (): SceneEditorServicePort =>
+  new SceneEditorService(new LocalProjectRepository());
+
+type SceneStateViewProps = {
+  projectId: string;
+  sceneId: string;
+  loadState: UseSceneEditorResult['loadState'];
+};
+
+const getLoadingSceneView = (): ReactElement => (
+  <main className="mx-auto flex min-h-screen w-full max-w-5xl items-center justify-center px-4 py-8">
+    <p className="text-muted-foreground">Loading scene...</p>
+  </main>
+);
+
+const getProjectNotFoundView = (projectId: string): ReactElement => (
+  <main className="mx-auto flex min-h-screen w-full max-w-3xl items-center justify-center px-4 py-8">
+    <div className="space-y-4 rounded-xl border bg-card p-6 text-card-foreground">
+      <h1 className="text-2xl font-headline font-bold">Project not found</h1>
+      <p className="text-muted-foreground">
+        The project <code>{projectId}</code> does not exist.
+      </p>
+      <Link href="/" className="inline-flex rounded-md border px-3 py-2 text-sm font-medium">
+        Back to home
+      </Link>
+    </div>
+  </main>
+);
+
+const getSceneNotFoundView = (props: Pick<SceneStateViewProps, 'projectId' | 'sceneId'>): ReactElement => (
+  <main className="mx-auto flex min-h-screen w-full max-w-3xl items-center justify-center px-4 py-8">
+    <div className="space-y-4 rounded-xl border bg-card p-6 text-card-foreground">
+      <h1 className="text-2xl font-headline font-bold">Scene not found</h1>
+      <p className="text-muted-foreground">
+        The scene <code>{props.sceneId}</code> was not found in this project.
+      </p>
+      <Link
+        href={`/workspace/${props.projectId}`}
+        className="inline-flex rounded-md border px-3 py-2 text-sm font-medium"
+      >
+        Back to workspace
+      </Link>
+    </div>
+  </main>
+);
+
+const getSceneStateView = (props: SceneStateViewProps): ReactElement | null => {
+  if (props.loadState === 'loading') {
+    return getLoadingSceneView();
+  }
+
+  if (props.loadState === 'project-not-found') {
+    return getProjectNotFoundView(props.projectId);
+  }
+
+  if (props.loadState === 'scene-not-found') {
+    return getSceneNotFoundView(props);
+  }
+
+  return null;
+};
+
+type SceneEditorNavigationProps = {
+  projectId: string;
+  previousSceneId: string | null;
+  nextSceneId: string | null;
+};
+
+function SceneEditorNavigation(props: SceneEditorNavigationProps): ReactElement {
+  return (
+    <nav className="flex items-center justify-between">
+      {props.previousSceneId ? (
+        <Link
+          href={`/workspace/${props.projectId}/scene/${props.previousSceneId}`}
+          className="inline-flex rounded-md border px-3 py-2 text-sm font-medium"
+        >
+          Previous
+        </Link>
+      ) : (
+        <button type="button" disabled className="inline-flex rounded-md border px-3 py-2 text-sm text-muted-foreground">
+          Previous
+        </button>
+      )}
+
+      <Link href={`/workspace/${props.projectId}`} className="inline-flex rounded-md border px-3 py-2 text-sm font-medium">
+        Back to workspace
+      </Link>
+
+      {props.nextSceneId ? (
+        <Link
+          href={`/workspace/${props.projectId}/scene/${props.nextSceneId}`}
+          className="inline-flex rounded-md border px-3 py-2 text-sm font-medium"
+        >
+          Next
+        </Link>
+      ) : (
+        <button type="button" disabled className="inline-flex rounded-md border px-3 py-2 text-sm text-muted-foreground">
+          Next
+        </button>
+      )}
+    </nav>
+  );
+}
+
+type SceneEditorLoadedViewProps = {
+  projectId: string;
+  sceneEditor: UseSceneEditorResult;
+};
+
+function SceneEditorLoadedView(props: SceneEditorLoadedViewProps): ReactElement {
+  if (!props.sceneEditor.scene) {
+    return (
+      <main className="mx-auto flex min-h-screen w-full max-w-5xl items-center justify-center px-4 py-8">
+        <p className="text-muted-foreground">Scene not found</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-5xl flex-col gap-4 px-4 py-8">
+      <SceneToolbar
+        title={props.sceneEditor.scene.title}
+        status={props.sceneEditor.status}
+        wordCount={props.sceneEditor.wordCount}
+        isDirty={props.sceneEditor.isDirty}
+        isSaving={props.sceneEditor.isSaving}
+        lastSavedAt={props.sceneEditor.lastSavedAt}
+        saveError={props.sceneEditor.saveError}
+        onStatusChange={props.sceneEditor.setStatus}
+        onRetrySave={props.sceneEditor.retrySave}
+      />
+
+      <section className="flex-1 rounded-xl border bg-card p-4 text-card-foreground">
+        <label htmlFor="scene-content" className="mb-2 block text-sm font-medium">
+          Markdown content
+        </label>
+        <textarea
+          id="scene-content"
+          value={props.sceneEditor.content}
+          onChange={(event) => props.sceneEditor.setContent(event.target.value)}
+          className="min-h-[60vh] w-full resize-y rounded-md border bg-background p-3 font-mono text-sm"
+        />
+      </section>
+
+      <SceneEditorNavigation
+        projectId={props.projectId}
+        previousSceneId={props.sceneEditor.previousSceneId}
+        nextSceneId={props.sceneEditor.nextSceneId}
+      />
+    </main>
+  );
+}
+
+export function SceneEditorShell(props: SceneEditorShellProps): ReactElement {
+  const service = useMemo<SceneEditorServicePort>(
+    () => props.service ?? createSceneEditorService(),
+    [props.service],
+  );
+
+  const sceneEditor = useSceneEditor({ projectId: props.projectId, sceneId: props.sceneId, service });
+  const stateView = getSceneStateView({
+    projectId: props.projectId,
+    sceneId: props.sceneId,
+    loadState: sceneEditor.loadState,
+  });
+
+  if (stateView) {
+    return stateView;
+  }
+
+  return <SceneEditorLoadedView projectId={props.projectId} sceneEditor={sceneEditor} />;
+}

--- a/src/components/scene/scene-editor-shell.tsx
+++ b/src/components/scene/scene-editor-shell.tsx
@@ -25,6 +25,7 @@ type SceneStateViewProps = {
   projectId: string;
   sceneId: string;
   loadState: UseSceneEditorResult['loadState'];
+  saveError: string | null;
 };
 
 const getLoadingSceneView = (): ReactElement => (
@@ -64,6 +65,23 @@ const getSceneNotFoundView = (props: Pick<SceneStateViewProps, 'projectId' | 'sc
   </main>
 );
 
+const getSceneLoadErrorView = (
+  props: Pick<SceneStateViewProps, 'projectId' | 'saveError'>,
+): ReactElement => (
+  <main className="mx-auto flex min-h-screen w-full max-w-3xl items-center justify-center px-4 py-8">
+    <div className="space-y-4 rounded-xl border bg-card p-6 text-card-foreground">
+      <h1 className="text-2xl font-headline font-bold">Unable to load scene</h1>
+      <p className="text-muted-foreground">{props.saveError ?? 'An unexpected error occurred.'}</p>
+      <Link
+        href={`/workspace/${props.projectId}`}
+        className="inline-flex rounded-md border px-3 py-2 text-sm font-medium"
+      >
+        Back to workspace
+      </Link>
+    </div>
+  </main>
+);
+
 const getSceneStateView = (props: SceneStateViewProps): ReactElement | null => {
   if (props.loadState === 'loading') {
     return getLoadingSceneView();
@@ -75,6 +93,10 @@ const getSceneStateView = (props: SceneStateViewProps): ReactElement | null => {
 
   if (props.loadState === 'scene-not-found') {
     return getSceneNotFoundView(props);
+  }
+
+  if (props.loadState === 'error') {
+    return getSceneLoadErrorView(props);
   }
 
   return null;
@@ -182,6 +204,7 @@ export function SceneEditorShell(props: SceneEditorShellProps): ReactElement {
     projectId: props.projectId,
     sceneId: props.sceneId,
     loadState: sceneEditor.loadState,
+    saveError: sceneEditor.saveError,
   });
 
   if (stateView) {

--- a/src/components/scene/scene-status-badge.tsx
+++ b/src/components/scene/scene-status-badge.tsx
@@ -1,0 +1,33 @@
+import type { ReactElement } from 'react';
+
+import { cn } from '@/lib/utils';
+import type { SceneStatus } from '@/domain/scene/types';
+
+type SceneStatusBadgeProps = {
+  status: SceneStatus;
+};
+
+const statusLabels: Record<SceneStatus, string> = {
+  draft: 'Draft',
+  revise: 'Revise',
+  final: 'Final',
+};
+
+const statusClasses: Record<SceneStatus, string> = {
+  draft: 'border-slate-300 bg-slate-100 text-slate-700',
+  revise: 'border-amber-300 bg-amber-100 text-amber-700',
+  final: 'border-emerald-300 bg-emerald-100 text-emerald-700',
+};
+
+export function SceneStatusBadge(props: SceneStatusBadgeProps): ReactElement {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold uppercase tracking-wide',
+        statusClasses[props.status],
+      )}
+    >
+      {statusLabels[props.status]}
+    </span>
+  );
+}

--- a/src/components/scene/scene-toolbar.tsx
+++ b/src/components/scene/scene-toolbar.tsx
@@ -1,0 +1,110 @@
+import type { ReactElement } from 'react';
+
+import { SceneStatusBadge } from '@/components/scene/scene-status-badge';
+import type { SceneStatus } from '@/domain/scene/types';
+
+type SceneToolbarProps = {
+  title: string;
+  status: SceneStatus;
+  wordCount: number;
+  isDirty: boolean;
+  isSaving: boolean;
+  lastSavedAt: string | null;
+  saveError: string | null;
+  onStatusChange: (status: SceneStatus) => void;
+  onRetrySave: () => Promise<void>;
+};
+
+const formatSavedAt = (lastSavedAt: string | null): string => {
+  if (!lastSavedAt) {
+    return 'Not saved yet';
+  }
+
+  return `Saved at ${new Date(lastSavedAt).toLocaleTimeString()}`;
+};
+
+const getSaveStateLabel = (props: Pick<SceneToolbarProps, 'isSaving' | 'isDirty' | 'lastSavedAt'>): string => {
+  if (props.isSaving) {
+    return 'Saving...';
+  }
+
+  if (props.isDirty) {
+    return 'Unsaved changes';
+  }
+
+  return formatSavedAt(props.lastSavedAt);
+};
+
+type SceneStatusSelectProps = {
+  status: SceneStatus;
+  onStatusChange: (status: SceneStatus) => void;
+};
+
+function SceneStatusSelect(props: SceneStatusSelectProps): ReactElement {
+  const handleStatusChange = (value: string): void => {
+    props.onStatusChange(value as SceneStatus);
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <label htmlFor="scene-status" className="text-sm font-medium">
+        Status
+      </label>
+      <select
+        id="scene-status"
+        value={props.status}
+        onChange={(event) => handleStatusChange(event.target.value)}
+        className="rounded-md border bg-background px-3 py-2 text-sm"
+      >
+        <option value="draft">Draft</option>
+        <option value="revise">Revise</option>
+        <option value="final">Final</option>
+      </select>
+    </div>
+  );
+}
+
+type SceneSaveErrorProps = {
+  saveError: string | null;
+  onRetrySave: () => Promise<void>;
+};
+
+function SceneSaveError(props: SceneSaveErrorProps): ReactElement | null {
+  if (!props.saveError) {
+    return null;
+  }
+
+  return (
+    <div className="mt-3 flex items-center gap-3 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+      <span>{props.saveError}</span>
+      <button
+        type="button"
+        onClick={() => void props.onRetrySave()}
+        className="rounded-md border border-destructive px-2 py-1 font-medium"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+
+export function SceneToolbar(props: SceneToolbarProps): ReactElement {
+  return (
+    <header className="rounded-xl border bg-card p-4 text-card-foreground">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-2">
+          <h1 className="text-2xl font-headline font-bold">{props.title}</h1>
+          <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+            <SceneStatusBadge status={props.status} />
+            <span aria-live="polite">{props.wordCount} words</span>
+            <span aria-live="polite">{getSaveStateLabel(props)}</span>
+          </div>
+        </div>
+
+        <SceneStatusSelect status={props.status} onStatusChange={props.onStatusChange} />
+      </div>
+
+      <SceneSaveError saveError={props.saveError} onRetrySave={props.onRetrySave} />
+    </header>
+  );
+}

--- a/src/components/scene/scene-toolbar.tsx
+++ b/src/components/scene/scene-toolbar.tsx
@@ -75,7 +75,11 @@ function SceneSaveError(props: SceneSaveErrorProps): ReactElement | null {
   }
 
   return (
-    <div className="mt-3 flex items-center gap-3 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="mt-3 flex items-center gap-3 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+    >
       <span>{props.saveError}</span>
       <button
         type="button"

--- a/src/components/scene/workspace-scene-list.tsx
+++ b/src/components/scene/workspace-scene-list.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import Link from 'next/link';
+import type { ReactElement } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+
+import { SceneEditorService } from '@/application/scene/scene-editor-service';
+import { SceneStatusBadge } from '@/components/scene/scene-status-badge';
+import { LocalProjectRepository } from '@/data/project/local-project-repository';
+import type { SceneSummary } from '@/domain/scene/types';
+
+type WorkspaceSceneListProps = {
+  projectId: string;
+};
+
+type WorkspaceLoadState = 'loading' | 'ready' | 'project-not-found' | 'error';
+
+type WorkspaceSceneState = {
+  loadState: WorkspaceLoadState;
+  scenes: SceneSummary[];
+  errorMessage: string | null;
+};
+
+const initialWorkspaceSceneState: WorkspaceSceneState = {
+  loadState: 'loading',
+  scenes: [],
+  errorMessage: null,
+};
+
+const createSceneEditorService = (): SceneEditorService => new SceneEditorService(new LocalProjectRepository());
+
+const getLoadingView = (): ReactElement => (
+  <main className="mx-auto flex min-h-screen w-full max-w-4xl items-center justify-center px-4 py-8">
+    <p className="text-muted-foreground">Loading workspace...</p>
+  </main>
+);
+
+const getProjectNotFoundView = (projectId: string): ReactElement => (
+  <main className="mx-auto flex min-h-screen w-full max-w-4xl items-center justify-center px-4 py-8">
+    <div className="space-y-4 rounded-xl border bg-card p-6 text-card-foreground">
+      <h1 className="text-2xl font-headline font-bold">Project not found</h1>
+      <p className="text-muted-foreground">
+        The project <code>{projectId}</code> does not exist.
+      </p>
+      <Link href="/" className="inline-flex rounded-md border px-3 py-2 text-sm font-medium">
+        Back to home
+      </Link>
+    </div>
+  </main>
+);
+
+const getErrorView = (errorMessage: string | null): ReactElement => (
+  <main className="mx-auto flex min-h-screen w-full max-w-4xl items-center justify-center px-4 py-8">
+    <div className="space-y-4 rounded-xl border bg-card p-6 text-card-foreground">
+      <h1 className="text-2xl font-headline font-bold">Unable to load workspace</h1>
+      <p className="text-muted-foreground">{errorMessage ?? 'Unexpected error.'}</p>
+      <Link href="/" className="inline-flex rounded-md border px-3 py-2 text-sm font-medium">
+        Back to home
+      </Link>
+    </div>
+  </main>
+);
+
+const getLoadStateView = (props: {
+  projectId: string;
+  loadState: WorkspaceLoadState;
+  errorMessage: string | null;
+}): ReactElement | null => {
+  if (props.loadState === 'loading') {
+    return getLoadingView();
+  }
+
+  if (props.loadState === 'project-not-found') {
+    return getProjectNotFoundView(props.projectId);
+  }
+
+  if (props.loadState === 'error') {
+    return getErrorView(props.errorMessage);
+  }
+
+  return null;
+};
+
+function WorkspaceSceneItems(props: WorkspaceSceneListProps & { scenes: SceneSummary[] }): ReactElement {
+  return (
+    <ul className="space-y-3">
+      {props.scenes.map((scene) => (
+        <li key={scene.id} className="rounded-lg border p-4">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div className="space-y-2">
+              <h2 className="text-lg font-headline font-semibold">{scene.title}</h2>
+              <SceneStatusBadge status={scene.status} />
+            </div>
+            <Link
+              href={`/workspace/${props.projectId}/scene/${scene.id}`}
+              className="inline-flex rounded-md border px-3 py-2 text-sm font-medium"
+            >
+              Open scene
+            </Link>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+const loadWorkspaceScenes = async (props: {
+  projectId: string;
+  service: SceneEditorService;
+  isDisposed: () => boolean;
+  setState: (state: WorkspaceSceneState) => void;
+}): Promise<void> => {
+  props.setState({ loadState: 'loading', scenes: [], errorMessage: null });
+
+  try {
+    const result = await props.service.listProjectScenes({ projectId: props.projectId });
+    if (props.isDisposed()) {
+      return;
+    }
+
+    if (result.state === 'project-not-found') {
+      props.setState({ loadState: 'project-not-found', scenes: [], errorMessage: null });
+      return;
+    }
+
+    props.setState({ loadState: 'ready', scenes: result.scenes, errorMessage: null });
+  } catch (error) {
+    if (props.isDisposed()) {
+      return;
+    }
+
+    props.setState({
+      loadState: 'error',
+      scenes: [],
+      errorMessage: props.service.toUserErrorMessage(error),
+    });
+  }
+};
+
+const useWorkspaceSceneState = (props: {
+  projectId: string;
+  service: SceneEditorService;
+}): WorkspaceSceneState => {
+  const [state, setState] = useState<WorkspaceSceneState>(initialWorkspaceSceneState);
+
+  useEffect(() => {
+    let disposed = false;
+
+    void loadWorkspaceScenes({
+      projectId: props.projectId,
+      service: props.service,
+      isDisposed: () => disposed,
+      setState,
+    });
+
+    return () => {
+      disposed = true;
+    };
+  }, [props.projectId, props.service]);
+
+  return state;
+};
+
+export function WorkspaceSceneList(props: WorkspaceSceneListProps): ReactElement {
+  const service = useMemo(() => createSceneEditorService(), []);
+  const state = useWorkspaceSceneState({
+    projectId: props.projectId,
+    service,
+  });
+
+  const stateView = getLoadStateView({
+    projectId: props.projectId,
+    loadState: state.loadState,
+    errorMessage: state.errorMessage,
+  });
+  if (stateView) {
+    return stateView;
+  }
+
+  return (
+    <main className="mx-auto min-h-screen w-full max-w-4xl px-4 py-8">
+      <section className="rounded-xl border bg-card p-6 text-card-foreground">
+        <header className="mb-6 space-y-1">
+          <h1 className="text-3xl font-headline font-bold">Workspace</h1>
+          <p className="text-muted-foreground">
+            Project <code>{props.projectId}</code>
+          </p>
+        </header>
+
+        <WorkspaceSceneItems projectId={props.projectId} scenes={state.scenes} />
+
+        {state.scenes.length === 0 ? (
+          <p className="rounded-lg border px-4 py-3 text-sm text-muted-foreground">
+            No scenes available for this project.
+          </p>
+        ) : null}
+      </section>
+    </main>
+  );
+}

--- a/src/data/project/local-project-repository-helpers.ts
+++ b/src/data/project/local-project-repository-helpers.ts
@@ -1,0 +1,348 @@
+import {
+  legacyProjectStorageSchema,
+  projectStorageSchema,
+  writingProjectSchema,
+  type LegacyProjectStorage,
+  type ProjectStorage,
+} from '@/domain/project/schemas';
+import type { ProjectSettings, ProjectStats, WritingProject } from '@/domain/project/types';
+import {
+  sceneSchema,
+  workspaceStoreSchema,
+  type WorkspaceStoreV1,
+} from '@/domain/scene/schemas';
+import type { Scene } from '@/domain/scene/types';
+import { generateProjectId } from '@/lib/utils';
+
+export const PROJECT_STORAGE_VERSION = 2 as const;
+export const browserOnlyRepositoryMessage = 'Local project repository is available only in the browser.';
+export const defaultSceneContent = '';
+const importedDemoProjectTitle = 'Imported Demo Project';
+const defaultSceneTitle = 'Scene 1';
+const defaultSceneStatus: Scene['status'] = 'draft';
+
+type MergeLegacyInput = {
+  projectStorage: ProjectStorage;
+  legacyWorkspace: WorkspaceStoreV1 | null;
+  importedAt: string;
+};
+
+type ParseStorageResult = {
+  storage: ProjectStorage;
+  needsWrite: boolean;
+};
+
+type CreateProjectSceneInput = {
+  projectId: string;
+  title: string;
+  content: string;
+  status: Scene['status'];
+  updatedAt: string;
+  id?: string;
+};
+
+const withFallbackStorage = (): ParseStorageResult => ({
+  storage: createEmptyProjectStorage(),
+  needsWrite: true,
+});
+
+const parseJson = (rawStorageValue: string): unknown | null => {
+  try {
+    return JSON.parse(rawStorageValue) as unknown;
+  } catch (error) {
+    console.error('Failed to parse project storage, fallback to empty workspace.', error);
+    return null;
+  }
+};
+
+const countWords = (content: string): number => {
+  const trimmedContent = content.trim();
+  if (!trimmedContent) {
+    return 0;
+  }
+
+  return trimmedContent.split(/\s+/).filter(Boolean).length;
+};
+
+const calculateProjectWordCount = (project: Pick<WritingProject, 'sceneOrder' | 'scenes'>): number =>
+  project.sceneOrder.reduce<number>((totalWords, sceneId) => {
+    const scene = project.scenes[sceneId];
+    if (!scene) {
+      return totalWords;
+    }
+
+    return totalWords + countWords(scene.content);
+  }, 0);
+
+const parseV2ProjectStorage = (value: unknown): ProjectStorage | null => {
+  const validatedStorage = projectStorageSchema.safeParse(value);
+  if (!validatedStorage.success) {
+    return null;
+  }
+
+  return {
+    version: validatedStorage.data.version,
+    projects: sortProjectsByUpdatedAt(validatedStorage.data.projects),
+  };
+};
+
+export const createDefaultProjectStats = (): ProjectStats => ({
+  wordCount: 0,
+  sceneCount: 0,
+  chapterCount: 0,
+});
+
+export const createDefaultProjectSettings = (): ProjectSettings => ({
+  language: 'en',
+  targetWordCount: null,
+});
+
+export const createEmptyProjectStorage = (): ProjectStorage => ({
+  version: PROJECT_STORAGE_VERSION,
+  projects: [],
+});
+
+export const sortProjectsByUpdatedAt = (projects: WritingProject[]): WritingProject[] =>
+  [...projects].sort(
+    (leftProject, rightProject) =>
+      new Date(rightProject.updatedAt).getTime() - new Date(leftProject.updatedAt).getTime(),
+  );
+
+export const withRecalculatedStats = (project: WritingProject): WritingProject =>
+  writingProjectSchema.parse({
+    ...project,
+    stats: {
+      ...project.stats,
+      wordCount: calculateProjectWordCount(project),
+      sceneCount: project.sceneOrder.length,
+    },
+  });
+
+export const createProjectScene = (input: CreateProjectSceneInput): Scene =>
+  sceneSchema.parse({
+    id: input.id ?? generateProjectId(),
+    projectId: input.projectId,
+    title: input.title.trim(),
+    content: input.content,
+    status: input.status,
+    updatedAt: input.updatedAt,
+  });
+
+export const createDefaultProjectScene = (projectId: string, updatedAt: string): Scene =>
+  createProjectScene({
+    projectId,
+    title: defaultSceneTitle,
+    content: defaultSceneContent,
+    status: defaultSceneStatus,
+    updatedAt,
+  });
+
+export const getStorage = (): Storage | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    return window.localStorage;
+  } catch (error) {
+    console.error('Local storage is not accessible in this environment.', error);
+    return null;
+  }
+};
+
+const upgradeLegacyProjectStorage = (legacyStorage: LegacyProjectStorage): ProjectStorage => ({
+  version: PROJECT_STORAGE_VERSION,
+  projects: legacyStorage.projects.map((legacyProject) => {
+    const seedScene = createDefaultProjectScene(legacyProject.id, legacyProject.updatedAt);
+    const upgradedProject = writingProjectSchema.parse({
+      ...legacyProject,
+      sceneOrder: [seedScene.id],
+      scenes: { [seedScene.id]: seedScene },
+    });
+
+    return withRecalculatedStats(upgradedProject);
+  }),
+});
+
+export const parseProjectStorageValue = (rawStorageValue: string | null): ParseStorageResult => {
+  if (!rawStorageValue) {
+    return {
+      storage: createEmptyProjectStorage(),
+      needsWrite: false,
+    };
+  }
+
+  const parsedStorageValue = parseJson(rawStorageValue);
+  if (!parsedStorageValue) {
+    return withFallbackStorage();
+  }
+
+  const validatedStorage = parseV2ProjectStorage(parsedStorageValue);
+  if (validatedStorage) {
+    return { storage: validatedStorage, needsWrite: false };
+  }
+
+  const legacyStorage = legacyProjectStorageSchema.safeParse(parsedStorageValue);
+  if (legacyStorage.success) {
+    return {
+      storage: upgradeLegacyProjectStorage(legacyStorage.data),
+      needsWrite: true,
+    };
+  }
+
+  console.error('Invalid project storage shape, fallback to empty workspace.');
+  return withFallbackStorage();
+};
+
+export const parseLegacyWorkspace = (rawWorkspaceValue: string | null): WorkspaceStoreV1 | null => {
+  if (!rawWorkspaceValue) {
+    return null;
+  }
+
+  const parsedWorkspace = parseJson(rawWorkspaceValue);
+  if (!parsedWorkspace) {
+    return null;
+  }
+
+  const validatedWorkspace = workspaceStoreSchema.safeParse(parsedWorkspace);
+  if (!validatedWorkspace.success) {
+    console.error('Invalid legacy workspace format, skipping legacy import.');
+    return null;
+  }
+
+  return validatedWorkspace.data;
+};
+
+const importScenesIntoProject = (
+  project: WritingProject,
+  legacyProject: WorkspaceStoreV1['projects'][string],
+  importedAt: string,
+): WritingProject => {
+  const nextScenes: Record<string, Scene> = { ...project.scenes };
+  const nextSceneOrder = [...project.sceneOrder];
+  let importedCount = 0;
+
+  for (const legacySceneId of legacyProject.sceneOrder) {
+    const legacyScene = legacyProject.scenes[legacySceneId];
+    if (!legacyScene) {
+      continue;
+    }
+
+    const sceneId = resolveImportedSceneId(legacyScene.id, nextScenes);
+    nextScenes[sceneId] = createProjectScene({
+      id: sceneId,
+      projectId: project.id,
+      title: legacyScene.title,
+      content: legacyScene.content,
+      status: legacyScene.status,
+      updatedAt: legacyScene.updatedAt,
+    });
+    nextSceneOrder.push(sceneId);
+    importedCount += 1;
+  }
+
+  if (importedCount === 0) {
+    return project;
+  }
+
+  return withRecalculatedStats(
+    writingProjectSchema.parse({
+      ...project,
+      scenes: nextScenes,
+      sceneOrder: nextSceneOrder,
+      updatedAt: importedAt,
+    }),
+  );
+};
+
+const resolveImportedSceneId = (initialSceneId: string, scenes: Record<string, Scene>): string => {
+  if (!(initialSceneId in scenes)) {
+    return initialSceneId;
+  }
+
+  let nextSceneId = generateProjectId();
+  while (nextSceneId in scenes) {
+    nextSceneId = generateProjectId();
+  }
+
+  return nextSceneId;
+};
+
+const createImportedProjectFromLegacy = (
+  legacyProject: WorkspaceStoreV1['projects'][string],
+  importedAt: string,
+): WritingProject => {
+  const importedProject = writingProjectSchema.parse({
+    id: generateProjectId(),
+    title:
+      legacyProject.id === 'demo-project' ? importedDemoProjectTitle : `Imported ${legacyProject.title}`,
+    description: 'Imported from legacy scene workspace.',
+    createdAt: importedAt,
+    updatedAt: importedAt,
+    stats: createDefaultProjectStats(),
+    settings: createDefaultProjectSettings(),
+    sceneOrder: [],
+    scenes: {},
+  });
+
+  return importScenesIntoProject(importedProject, legacyProject, importedAt);
+};
+
+const mergeLegacyProject = (
+  projectStorage: ProjectStorage,
+  legacyProject: WorkspaceStoreV1['projects'][string],
+  importedAt: string,
+): { projects: WritingProject[]; didMerge: boolean } => {
+  const nextProjects = [...projectStorage.projects];
+  const projectIndex = nextProjects.findIndex((project) => project.id === legacyProject.id);
+
+  if (projectIndex >= 0) {
+    nextProjects[projectIndex] = importScenesIntoProject(
+      nextProjects[projectIndex]!,
+      legacyProject,
+      importedAt,
+    );
+    return { projects: nextProjects, didMerge: true };
+  }
+
+  if (nextProjects.length === 1) {
+    nextProjects[0] = importScenesIntoProject(nextProjects[0]!, legacyProject, importedAt);
+    return { projects: nextProjects, didMerge: true };
+  }
+
+  if (nextProjects.length === 0 || legacyProject.id === 'demo-project') {
+    nextProjects.push(createImportedProjectFromLegacy(legacyProject, importedAt));
+    return { projects: nextProjects, didMerge: true };
+  }
+
+  return { projects: nextProjects, didMerge: false };
+};
+
+export const mergeLegacyWorkspaceIntoProjectStorage = (
+  input: MergeLegacyInput,
+): { storage: ProjectStorage; didMerge: boolean } => {
+  if (!input.legacyWorkspace) {
+    return { storage: input.projectStorage, didMerge: false };
+  }
+
+  let didMerge = false;
+  let projects = [...input.projectStorage.projects];
+
+  for (const legacyProject of Object.values(input.legacyWorkspace.projects)) {
+    const { projects: mergedProjects, didMerge: merged } = mergeLegacyProject(
+      { version: PROJECT_STORAGE_VERSION, projects },
+      legacyProject,
+      input.importedAt,
+    );
+    projects = mergedProjects;
+    didMerge = didMerge || merged;
+  }
+
+  return {
+    storage: {
+      version: PROJECT_STORAGE_VERSION,
+      projects: sortProjectsByUpdatedAt(projects),
+    },
+    didMerge,
+  };
+};

--- a/src/data/project/local-project-repository.ts
+++ b/src/data/project/local-project-repository.ts
@@ -46,7 +46,7 @@ const createSceneInputSchema = z.object({
   title: z.string().trim().min(1).max(120),
 });
 
-const asProjectNotFound = (projectId: string): Error => new Error(`Project not found: ${projectId}`);
+const asProjectNotFound = (): Error => new Error(projectNotFoundCode);
 
 export class LocalProjectRepository implements ProjectRepository {
   public async list(): Promise<WritingProject[]> {
@@ -100,7 +100,7 @@ export class LocalProjectRepository implements ProjectRepository {
     const targetProject = projectStorage.projects.find((project) => project.id === validProjectId);
 
     if (!targetProject) {
-      throw asProjectNotFound(validProjectId);
+      throw asProjectNotFound();
     }
 
     const updatedProject = withRecalculatedStats(

--- a/src/data/project/local-project-repository.ts
+++ b/src/data/project/local-project-repository.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 import type { ProjectRepository } from '@/domain/project/repository';
 import {
   createProjectInputSchema,
@@ -9,138 +11,42 @@ import {
 } from '@/domain/project/schemas';
 import type {
   CreateProjectInput,
-  ProjectSettings,
-  ProjectStats,
   UpdateProjectInput,
   WritingProject,
 } from '@/domain/project/types';
-import {
-  saveSceneInputSchema,
-  sceneSchema,
-  sceneSummarySchema,
-  workspaceStoreSchema,
-  type WorkspaceStoreV1,
-} from '@/domain/scene/schemas';
+import { saveSceneInputSchema, sceneSchema, sceneSummarySchema } from '@/domain/scene/schemas';
 import type { Scene, SceneSummary } from '@/domain/scene/types';
 import { generateProjectId } from '@/lib/utils';
 
-export const PROJECT_STORAGE_KEY = 'ainkwell.projects.v1';
-const PROJECT_STORAGE_VERSION = 1 as const;
+import {
+  browserOnlyRepositoryMessage,
+  createDefaultProjectScene,
+  createDefaultProjectSettings,
+  createDefaultProjectStats,
+  createEmptyProjectStorage,
+  createProjectScene,
+  defaultSceneContent,
+  getStorage,
+  mergeLegacyWorkspaceIntoProjectStorage,
+  parseLegacyWorkspace,
+  parseProjectStorageValue,
+  PROJECT_STORAGE_VERSION,
+  sortProjectsByUpdatedAt,
+  withRecalculatedStats,
+} from './local-project-repository-helpers';
 
+export const PROJECT_STORAGE_KEY = 'ainkwell.projects.v1';
 export const workspaceStorageKey = 'ainkwell:workspace:v1';
+
 export const projectNotFoundCode = 'PROJECT_NOT_FOUND';
 export const sceneNotFoundCode = 'SCENE_NOT_FOUND';
 
-const browserOnlyRepositoryMessage = 'Local project repository is available only in the browser.';
-const demoProjectId = 'demo-project';
-const demoProjectTitle = 'Demo Project';
-
-const defaultProjectStats: ProjectStats = {
-  wordCount: 0,
-  sceneCount: 0,
-  chapterCount: 0,
-};
-
-const defaultProjectSettings: ProjectSettings = {
-  language: 'en',
-  targetWordCount: null,
-};
-
-type SceneSeed = Pick<Scene, 'id' | 'title' | 'content' | 'status' | 'updatedAt'>;
-
-const demoSceneSeeds: SceneSeed[] = [
-  {
-    id: 'scene-1',
-    title: 'Scene 1',
-    content: '# Scene 1\n\nThis is the opening beat.',
-    status: 'draft',
-    updatedAt: '2026-02-25T00:00:00.000Z',
-  },
-  {
-    id: 'scene-2',
-    title: 'Scene 2',
-    content: '## Rising Tension\n\nThe stakes increase for the protagonist.',
-    status: 'revise',
-    updatedAt: '2026-02-25T00:05:00.000Z',
-  },
-  {
-    id: 'scene-3',
-    title: 'Scene 3',
-    content: 'Final confrontation notes and closing paragraph.',
-    status: 'final',
-    updatedAt: '2026-02-25T00:10:00.000Z',
-  },
-];
-
-const createDemoScenes = (): WorkspaceStoreV1['projects'][string]['scenes'] =>
-  Object.fromEntries(demoSceneSeeds.map((sceneSeed) => [sceneSeed.id, { ...sceneSeed, projectId: demoProjectId }]));
-
-const createSeedWorkspaceStore = (): WorkspaceStoreV1 => ({
-  version: 1,
-  projects: {
-    [demoProjectId]: {
-      id: demoProjectId,
-      title: demoProjectTitle,
-      sceneOrder: demoSceneSeeds.map((sceneSeed) => sceneSeed.id),
-      scenes: createDemoScenes(),
-    },
-  },
+const createSceneInputSchema = z.object({
+  projectId: projectIdSchema,
+  title: z.string().trim().min(1).max(120),
 });
 
-function sortProjectsByUpdatedAt(projects: WritingProject[]): WritingProject[] {
-  return [...projects].sort(
-    (leftProject, rightProject) =>
-      new Date(rightProject.updatedAt).getTime() - new Date(leftProject.updatedAt).getTime(),
-  );
-}
-
-function emptyStorageValue(): ProjectStorage {
-  return {
-    version: PROJECT_STORAGE_VERSION,
-    projects: [],
-  };
-}
-
-function getStorage(): Storage | null {
-  if (typeof window === 'undefined') {
-    return null;
-  }
-
-  try {
-    return window.localStorage;
-  } catch (error) {
-    console.error('Local storage is not accessible in this environment.', error);
-    return null;
-  }
-}
-
-function parseStorageValue(rawValue: string | null): ProjectStorage {
-  if (!rawValue) {
-    return emptyStorageValue();
-  }
-
-  try {
-    const parsedValue: unknown = JSON.parse(rawValue);
-    const validatedStorage = projectStorageSchema.safeParse(parsedValue);
-
-    if (!validatedStorage.success) {
-      console.error('Invalid project storage shape, fallback to empty workspace.');
-      return emptyStorageValue();
-    }
-
-    return {
-      version: validatedStorage.data.version,
-      projects: sortProjectsByUpdatedAt(validatedStorage.data.projects),
-    };
-  } catch (error) {
-    console.error('Failed to parse project storage, fallback to empty workspace.', error);
-    return emptyStorageValue();
-  }
-}
-
-function asProjectNotFound(projectId: string): Error {
-  return new Error(`Project not found: ${projectId}`);
-}
+const asProjectNotFound = (projectId: string): Error => new Error(`Project not found: ${projectId}`);
 
 export class LocalProjectRepository implements ProjectRepository {
   public async list(): Promise<WritingProject[]> {
@@ -155,76 +61,122 @@ export class LocalProjectRepository implements ProjectRepository {
 
   public async create(input: CreateProjectInput): Promise<WritingProject> {
     const validInput = createProjectInputSchema.parse(input);
-    const projects = this.readProjects();
+    const projectStorage = this.readProjectStorage();
     const timestamp = new Date().toISOString();
+    const projectId = generateProjectId();
+    const seedScene = createDefaultProjectScene(projectId, timestamp);
 
-    const project = writingProjectSchema.parse({
-      id: generateProjectId(),
-      title: validInput.title,
-      description: validInput.description,
-      createdAt: timestamp,
-      updatedAt: timestamp,
-      stats: defaultProjectStats,
-      settings: {
-        ...defaultProjectSettings,
-        ...(validInput.settings ?? {}),
-      },
+    const createdProject = withRecalculatedStats(
+      writingProjectSchema.parse({
+        id: projectId,
+        title: validInput.title,
+        description: validInput.description,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        stats: createDefaultProjectStats(),
+        settings: {
+          ...createDefaultProjectSettings(),
+          ...(validInput.settings ?? {}),
+        },
+        sceneOrder: [seedScene.id],
+        scenes: {
+          [seedScene.id]: seedScene,
+        },
+      }),
+    );
+
+    this.writeProjectStorage({
+      version: PROJECT_STORAGE_VERSION,
+      projects: sortProjectsByUpdatedAt([createdProject, ...projectStorage.projects]),
     });
 
-    const nextProjects = sortProjectsByUpdatedAt([project, ...projects]);
-    this.writeProjects(nextProjects);
-
-    return project;
+    return createdProject;
   }
 
   public async update(id: string, input: UpdateProjectInput): Promise<WritingProject> {
     const validProjectId = projectIdSchema.parse(id);
     const validInput = updateProjectInputSchema.parse(input);
-    const projects = this.readProjects();
-    const targetProject = projects.find((project) => project.id === validProjectId);
+    const projectStorage = this.readProjectStorage();
+    const targetProject = projectStorage.projects.find((project) => project.id === validProjectId);
 
     if (!targetProject) {
       throw asProjectNotFound(validProjectId);
     }
 
-    const updatedProject = writingProjectSchema.parse({
-      ...targetProject,
-      ...validInput,
-      settings: {
-        ...targetProject.settings,
-        ...(validInput.settings ?? {}),
-      },
-      stats: {
-        ...targetProject.stats,
-        ...(validInput.stats ?? {}),
-      },
-      updatedAt: new Date().toISOString(),
-    });
-
-    const nextProjects = projects.map((project) =>
-      project.id === validProjectId ? updatedProject : project,
+    const updatedProject = withRecalculatedStats(
+      writingProjectSchema.parse({
+        ...targetProject,
+        ...validInput,
+        settings: {
+          ...targetProject.settings,
+          ...(validInput.settings ?? {}),
+        },
+        stats: {
+          ...targetProject.stats,
+          ...(validInput.stats ?? {}),
+        },
+        updatedAt: new Date().toISOString(),
+      }),
     );
 
-    this.writeProjects(nextProjects);
+    this.writeProjects(
+      projectStorage.projects.map((project) =>
+        project.id === validProjectId ? updatedProject : project,
+      ),
+    );
 
     return updatedProject;
   }
 
   public async remove(id: string): Promise<void> {
     const validProjectId = projectIdSchema.parse(id);
-    const projects = this.readProjects();
-    const nextProjects = projects.filter((project) => project.id !== validProjectId);
+    const projectStorage = this.readProjectStorage();
+    const nextProjects = projectStorage.projects.filter((project) => project.id !== validProjectId);
 
-    if (nextProjects.length === projects.length) {
+    if (nextProjects.length === projectStorage.projects.length) {
       return;
     }
 
     this.writeProjects(nextProjects);
   }
 
+  public async createScene(input: { projectId: string; title: string }): Promise<Scene> {
+    const validInput = createSceneInputSchema.parse(input);
+    const projectStorage = this.readProjectStorage();
+    const project = this.getSceneProjectOrThrow(projectStorage.projects, validInput.projectId);
+
+    const scene = createProjectScene({
+      projectId: validInput.projectId,
+      title: validInput.title,
+      content: defaultSceneContent,
+      status: 'draft',
+      updatedAt: new Date().toISOString(),
+    });
+
+    const updatedProject = withRecalculatedStats(
+      writingProjectSchema.parse({
+        ...project,
+        updatedAt: scene.updatedAt,
+        sceneOrder: [...project.sceneOrder, scene.id],
+        scenes: {
+          ...project.scenes,
+          [scene.id]: scene,
+        },
+      }),
+    );
+
+    this.writeProjects(
+      projectStorage.projects.map((currentProject) =>
+        currentProject.id === validInput.projectId ? updatedProject : currentProject,
+      ),
+    );
+
+    return scene;
+  }
+
   public async getScene(input: { projectId: string; sceneId: string }): Promise<Scene | null> {
-    const workspaceStore = this.readWorkspaceStore();
-    const project = this.getSceneProjectOrThrow(workspaceStore, input.projectId);
+    const projectStorage = this.readProjectStorage();
+    const project = this.getSceneProjectOrThrow(projectStorage.projects, input.projectId);
     const scene = project.scenes[input.sceneId];
 
     if (!scene || scene.projectId !== input.projectId) {
@@ -235,8 +187,8 @@ export class LocalProjectRepository implements ProjectRepository {
   }
 
   public async listScenes(input: { projectId: string }): Promise<SceneSummary[]> {
-    const workspaceStore = this.readWorkspaceStore();
-    const project = this.getSceneProjectOrThrow(workspaceStore, input.projectId);
+    const projectStorage = this.readProjectStorage();
+    const project = this.getSceneProjectOrThrow(projectStorage.projects, input.projectId);
 
     return project.sceneOrder.map((sceneId) => {
       const scene = project.scenes[sceneId];
@@ -256,8 +208,8 @@ export class LocalProjectRepository implements ProjectRepository {
     updatedAt: string;
   }): Promise<Scene> {
     const parsedInput = saveSceneInputSchema.parse(input);
-    const workspaceStore = this.readWorkspaceStore();
-    const project = this.getSceneProjectOrThrow(workspaceStore, parsedInput.projectId);
+    const projectStorage = this.readProjectStorage();
+    const project = this.getSceneProjectOrThrow(projectStorage.projects, parsedInput.projectId);
     const existingScene = project.scenes[parsedInput.sceneId];
 
     if (!existingScene || existingScene.projectId !== parsedInput.projectId) {
@@ -271,93 +223,85 @@ export class LocalProjectRepository implements ProjectRepository {
       updatedAt: parsedInput.updatedAt,
     });
 
-    const nextStore: WorkspaceStoreV1 = {
-      ...workspaceStore,
-      projects: {
-        ...workspaceStore.projects,
-        [parsedInput.projectId]: {
-          ...project,
-          scenes: {
-            ...project.scenes,
-            [parsedInput.sceneId]: updatedScene,
-          },
+    const updatedProject = withRecalculatedStats(
+      writingProjectSchema.parse({
+        ...project,
+        updatedAt: parsedInput.updatedAt,
+        scenes: {
+          ...project.scenes,
+          [parsedInput.sceneId]: updatedScene,
         },
-      },
-    };
+      }),
+    );
 
-    this.writeWorkspaceStore(nextStore);
+    this.writeProjects(
+      projectStorage.projects.map((currentProject) =>
+        currentProject.id === parsedInput.projectId ? updatedProject : currentProject,
+      ),
+    );
+
     return updatedScene;
   }
 
   private readProjects(): WritingProject[] {
+    return this.readProjectStorage().projects;
+  }
+
+  private readProjectStorage(): ProjectStorage {
     const storage = getStorage();
 
     if (!storage) {
-      return [];
+      return createEmptyProjectStorage();
     }
 
-    const rawValue = storage.getItem(PROJECT_STORAGE_KEY);
-    const storageValue = parseStorageValue(rawValue);
+    const parsedStorage = parseProjectStorageValue(storage.getItem(PROJECT_STORAGE_KEY));
+    const legacyWorkspace = parseLegacyWorkspace(storage.getItem(workspaceStorageKey));
 
-    return sortProjectsByUpdatedAt(storageValue.projects);
+    const mergedStorage = mergeLegacyWorkspaceIntoProjectStorage({
+      projectStorage: parsedStorage.storage,
+      legacyWorkspace,
+      importedAt: new Date().toISOString(),
+    });
+
+    if (parsedStorage.needsWrite || mergedStorage.didMerge) {
+      this.writeProjectStorageToStorage(storage, mergedStorage.storage);
+    }
+
+    if (mergedStorage.didMerge) {
+      storage.removeItem(workspaceStorageKey);
+    }
+
+    return mergedStorage.storage;
   }
 
   private writeProjects(projects: WritingProject[]): void {
-    const storage = getStorage();
-
-    if (!storage) {
-      throw new Error('Storage is not available in this environment.');
-    }
-
-    const payload = projectStorageSchema.parse({
+    this.writeProjectStorage({
       version: PROJECT_STORAGE_VERSION,
       projects: sortProjectsByUpdatedAt(projects),
     });
-
-    storage.setItem(PROJECT_STORAGE_KEY, JSON.stringify(payload));
   }
 
-  private readWorkspaceStore(): WorkspaceStoreV1 {
-    this.assertBrowserContext();
-    const storedWorkspace = window.localStorage.getItem(workspaceStorageKey);
+  private writeProjectStorage(projectStorage: ProjectStorage): void {
+    const storage = getStorage();
 
-    if (!storedWorkspace) {
-      const seedWorkspace = createSeedWorkspaceStore();
-      this.writeWorkspaceStore(seedWorkspace);
-      return seedWorkspace;
+    if (!storage) {
+      throw new Error(browserOnlyRepositoryMessage);
     }
 
-    try {
-      const parsedWorkspace = JSON.parse(storedWorkspace) as unknown;
-      return workspaceStoreSchema.parse(parsedWorkspace);
-    } catch {
-      const seedWorkspace = createSeedWorkspaceStore();
-      this.writeWorkspaceStore(seedWorkspace);
-      return seedWorkspace;
-    }
+    this.writeProjectStorageToStorage(storage, projectStorage);
   }
 
-  private writeWorkspaceStore(workspaceStore: WorkspaceStoreV1): void {
-    this.assertBrowserContext();
-    const parsedWorkspace = workspaceStoreSchema.parse(workspaceStore);
-    window.localStorage.setItem(workspaceStorageKey, JSON.stringify(parsedWorkspace));
+  private writeProjectStorageToStorage(storage: Storage, projectStorage: ProjectStorage): void {
+    const parsedStorage = projectStorageSchema.parse(projectStorage);
+    storage.setItem(PROJECT_STORAGE_KEY, JSON.stringify(parsedStorage));
   }
 
-  private getSceneProjectOrThrow(
-    workspaceStore: WorkspaceStoreV1,
-    projectId: string,
-  ): WorkspaceStoreV1['projects'][string] {
-    const project = workspaceStore.projects[projectId];
+  private getSceneProjectOrThrow(projects: WritingProject[], projectId: string): WritingProject {
+    const project = projects.find((currentProject) => currentProject.id === projectId);
     if (!project) {
       throw new Error(projectNotFoundCode);
     }
 
     return project;
-  }
-
-  private assertBrowserContext(): void {
-    if (typeof window === 'undefined') {
-      throw new Error(browserOnlyRepositoryMessage);
-    }
   }
 }

--- a/src/data/project/local-project-repository.ts
+++ b/src/data/project/local-project-repository.ts
@@ -1,0 +1,171 @@
+import type { ProjectRepository } from '@/domain/project/repository';
+import {
+  saveSceneInputSchema,
+  sceneSchema,
+  sceneSummarySchema,
+  workspaceStoreSchema,
+  type WorkspaceStoreV1,
+} from '@/domain/scene/schemas';
+import type { Scene, SceneSummary } from '@/domain/scene/types';
+
+export const workspaceStorageKey = 'ainkwell:workspace:v1';
+export const projectNotFoundCode = 'PROJECT_NOT_FOUND';
+export const sceneNotFoundCode = 'SCENE_NOT_FOUND';
+
+const browserOnlyRepositoryMessage = 'Local project repository is available only in the browser.';
+const demoProjectId = 'demo-project';
+const demoProjectTitle = 'Demo Project';
+
+type SceneSeed = Pick<Scene, 'id' | 'title' | 'content' | 'status' | 'updatedAt'>;
+
+const demoSceneSeeds: SceneSeed[] = [
+  {
+    id: 'scene-1',
+    title: 'Scene 1',
+    content: '# Scene 1\n\nThis is the opening beat.',
+    status: 'draft',
+    updatedAt: '2026-02-25T00:00:00.000Z',
+  },
+  {
+    id: 'scene-2',
+    title: 'Scene 2',
+    content: '## Rising Tension\n\nThe stakes increase for the protagonist.',
+    status: 'revise',
+    updatedAt: '2026-02-25T00:05:00.000Z',
+  },
+  {
+    id: 'scene-3',
+    title: 'Scene 3',
+    content: 'Final confrontation notes and closing paragraph.',
+    status: 'final',
+    updatedAt: '2026-02-25T00:10:00.000Z',
+  },
+];
+
+const createDemoScenes = (): WorkspaceStoreV1['projects'][string]['scenes'] =>
+  Object.fromEntries(demoSceneSeeds.map((sceneSeed) => [sceneSeed.id, { ...sceneSeed, projectId: demoProjectId }]));
+
+const createSeedWorkspaceStore = (): WorkspaceStoreV1 => ({
+  version: 1,
+  projects: {
+    [demoProjectId]: {
+      id: demoProjectId,
+      title: demoProjectTitle,
+      sceneOrder: demoSceneSeeds.map((sceneSeed) => sceneSeed.id),
+      scenes: createDemoScenes(),
+    },
+  },
+});
+
+export class LocalProjectRepository implements ProjectRepository {
+  public async getScene(input: { projectId: string; sceneId: string }): Promise<Scene | null> {
+    const workspaceStore = this.readWorkspaceStore();
+    const project = this.getProjectOrThrow(workspaceStore, input.projectId);
+    const scene = project.scenes[input.sceneId];
+
+    if (!scene || scene.projectId !== input.projectId) {
+      return null;
+    }
+
+    return sceneSchema.parse(scene);
+  }
+
+  public async listScenes(input: { projectId: string }): Promise<SceneSummary[]> {
+    const workspaceStore = this.readWorkspaceStore();
+    const project = this.getProjectOrThrow(workspaceStore, input.projectId);
+
+    return project.sceneOrder.map((sceneId) => {
+      const scene = project.scenes[sceneId];
+      if (!scene) {
+        throw new Error(sceneNotFoundCode);
+      }
+
+      return sceneSummarySchema.parse(scene);
+    });
+  }
+
+  public async saveScene(input: {
+    projectId: string;
+    sceneId: string;
+    content: string;
+    status: Scene['status'];
+    updatedAt: string;
+  }): Promise<Scene> {
+    const parsedInput = saveSceneInputSchema.parse(input);
+    const workspaceStore = this.readWorkspaceStore();
+    const project = this.getProjectOrThrow(workspaceStore, parsedInput.projectId);
+    const existingScene = project.scenes[parsedInput.sceneId];
+
+    if (!existingScene || existingScene.projectId !== parsedInput.projectId) {
+      throw new Error(sceneNotFoundCode);
+    }
+
+    const updatedScene = sceneSchema.parse({
+      ...existingScene,
+      content: parsedInput.content,
+      status: parsedInput.status,
+      updatedAt: parsedInput.updatedAt,
+    });
+
+    const nextStore: WorkspaceStoreV1 = {
+      ...workspaceStore,
+      projects: {
+        ...workspaceStore.projects,
+        [parsedInput.projectId]: {
+          ...project,
+          scenes: {
+            ...project.scenes,
+            [parsedInput.sceneId]: updatedScene,
+          },
+        },
+      },
+    };
+
+    this.writeWorkspaceStore(nextStore);
+    return updatedScene;
+  }
+
+  private readWorkspaceStore(): WorkspaceStoreV1 {
+    this.assertBrowserContext();
+    const storedWorkspace = window.localStorage.getItem(workspaceStorageKey);
+
+    if (!storedWorkspace) {
+      const seedWorkspace = createSeedWorkspaceStore();
+      this.writeWorkspaceStore(seedWorkspace);
+      return seedWorkspace;
+    }
+
+    try {
+      const parsedWorkspace = JSON.parse(storedWorkspace) as unknown;
+      return workspaceStoreSchema.parse(parsedWorkspace);
+    } catch {
+      const seedWorkspace = createSeedWorkspaceStore();
+      this.writeWorkspaceStore(seedWorkspace);
+      return seedWorkspace;
+    }
+  }
+
+  private writeWorkspaceStore(workspaceStore: WorkspaceStoreV1): void {
+    this.assertBrowserContext();
+    const parsedWorkspace = workspaceStoreSchema.parse(workspaceStore);
+    window.localStorage.setItem(workspaceStorageKey, JSON.stringify(parsedWorkspace));
+  }
+
+  private getProjectOrThrow(
+    workspaceStore: WorkspaceStoreV1,
+    projectId: string,
+  ): WorkspaceStoreV1['projects'][string] {
+    const project = workspaceStore.projects[projectId];
+    if (!project) {
+      throw new Error(projectNotFoundCode);
+    }
+
+    return project;
+  }
+
+  private assertBrowserContext(): void {
+    if (typeof window === 'undefined') {
+      throw new Error(browserOnlyRepositoryMessage);
+    }
+  }
+}

--- a/src/domain/project/repository.ts
+++ b/src/domain/project/repository.ts
@@ -7,6 +7,7 @@ export interface ProjectRepository {
   create(input: CreateProjectInput): Promise<WritingProject>;
   update(id: string, input: UpdateProjectInput): Promise<WritingProject>;
   remove(id: string): Promise<void>;
+  createScene(input: { projectId: string; title: string }): Promise<Scene>;
   getScene(input: { projectId: string; sceneId: string }): Promise<Scene | null>;
   listScenes(input: { projectId: string }): Promise<SceneSummary[]>;
   saveScene(input: {

--- a/src/domain/project/repository.ts
+++ b/src/domain/project/repository.ts
@@ -1,0 +1,13 @@
+import type { Scene, SceneStatus, SceneSummary } from '@/domain/scene/types';
+
+export interface ProjectRepository {
+  getScene(input: { projectId: string; sceneId: string }): Promise<Scene | null>;
+  listScenes(input: { projectId: string }): Promise<SceneSummary[]>;
+  saveScene(input: {
+    projectId: string;
+    sceneId: string;
+    content: string;
+    status: SceneStatus;
+    updatedAt: string;
+  }): Promise<Scene>;
+}

--- a/src/domain/project/schemas.ts
+++ b/src/domain/project/schemas.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { maxSceneContentLength, sceneStatusSchema } from '@/domain/scene/schemas';
+
 const uuidV4Regex =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -21,6 +23,12 @@ const projectLanguageSchema = z
   .trim()
   .min(2, 'Language is required')
   .max(16, 'Language must be 16 characters or fewer');
+
+const sceneTitleSchema = z.string().trim().min(1).max(120);
+const sceneContentSchema = z.string().max(maxSceneContentLength, {
+  message: `Scene content exceeds ${maxSceneContentLength} characters.`,
+});
+const sceneIdSchema = z.string().trim().min(1);
 
 export const projectIdSchema = z
   .string()
@@ -51,7 +59,58 @@ export const updateProjectInputSchema = z.object({
   stats: projectStatsSchema.partial().optional(),
 });
 
-export const writingProjectSchema = z.object({
+export const projectSceneSchema = z.object({
+  id: sceneIdSchema,
+  projectId: projectIdSchema,
+  title: sceneTitleSchema,
+  content: sceneContentSchema,
+  status: sceneStatusSchema,
+  updatedAt: z.string().datetime({ offset: true }),
+});
+
+export const writingProjectSchema = z
+  .object({
+    id: projectIdSchema,
+    title: projectTitleSchema,
+    description: projectDescriptionSchema,
+    createdAt: z.string().datetime({ offset: true }),
+    updatedAt: z.string().datetime({ offset: true }),
+    stats: projectStatsSchema,
+    settings: projectSettingsSchema,
+    sceneOrder: z.array(sceneIdSchema),
+    scenes: z.record(projectSceneSchema),
+  })
+  .superRefine((value, context) => {
+    for (const sceneId of value.sceneOrder) {
+      if (!(sceneId in value.scenes)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Missing scene reference for ${sceneId}.`,
+          path: ['sceneOrder'],
+        });
+      }
+    }
+
+    for (const [sceneId, scene] of Object.entries(value.scenes)) {
+      if (scene.id !== sceneId) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Scene key ${sceneId} does not match scene.id.`,
+          path: ['scenes', sceneId, 'id'],
+        });
+      }
+
+      if (scene.projectId !== value.id) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Scene ${sceneId} belongs to another project.`,
+          path: ['scenes', sceneId, 'projectId'],
+        });
+      }
+    }
+  });
+
+const legacyWritingProjectSchema = z.object({
   id: projectIdSchema,
   title: projectTitleSchema,
   description: projectDescriptionSchema,
@@ -61,9 +120,15 @@ export const writingProjectSchema = z.object({
   settings: projectSettingsSchema,
 });
 
-export const projectStorageSchema = z.object({
+export const legacyProjectStorageSchema = z.object({
   version: z.literal(1),
+  projects: z.array(legacyWritingProjectSchema),
+});
+
+export const projectStorageSchema = z.object({
+  version: z.literal(2),
   projects: z.array(writingProjectSchema),
 });
 
+export type LegacyProjectStorage = z.infer<typeof legacyProjectStorageSchema>;
 export type ProjectStorage = z.infer<typeof projectStorageSchema>;

--- a/src/domain/project/schemas.ts
+++ b/src/domain/project/schemas.ts
@@ -81,7 +81,19 @@ export const writingProjectSchema = z
     scenes: z.record(projectSceneSchema),
   })
   .superRefine((value, context) => {
+    const orderedSceneIdentifiers = new Set<string>();
+
     for (const sceneId of value.sceneOrder) {
+      if (orderedSceneIdentifiers.has(sceneId)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Duplicate scene reference for ${sceneId}.`,
+          path: ['sceneOrder'],
+        });
+        continue;
+      }
+
+      orderedSceneIdentifiers.add(sceneId);
       if (!(sceneId in value.scenes)) {
         context.addIssue({
           code: z.ZodIssueCode.custom,
@@ -92,6 +104,14 @@ export const writingProjectSchema = z
     }
 
     for (const [sceneId, scene] of Object.entries(value.scenes)) {
+      if (!orderedSceneIdentifiers.has(sceneId)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Scene ${sceneId} is missing from sceneOrder.`,
+          path: ['scenes', sceneId],
+        });
+      }
+
       if (scene.id !== sceneId) {
         context.addIssue({
           code: z.ZodIssueCode.custom,

--- a/src/domain/project/types.ts
+++ b/src/domain/project/types.ts
@@ -1,3 +1,5 @@
+import type { SceneStatus } from '@/domain/scene/types';
+
 export type ProjectStats = {
   wordCount: number;
   sceneCount: number;
@@ -9,6 +11,15 @@ export type ProjectSettings = {
   targetWordCount: number | null;
 };
 
+export type ProjectScene = {
+  id: string;
+  projectId: string;
+  title: string;
+  content: string;
+  status: SceneStatus;
+  updatedAt: string;
+};
+
 export type WritingProject = {
   id: string;
   title: string;
@@ -17,6 +28,8 @@ export type WritingProject = {
   updatedAt: string;
   stats: ProjectStats;
   settings: ProjectSettings;
+  sceneOrder: string[];
+  scenes: Record<string, ProjectScene>;
 };
 
 export type CreateProjectInput = {

--- a/src/domain/scene/schemas.ts
+++ b/src/domain/scene/schemas.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod';
+
+export const maxSceneContentLength = 200000;
+
+const sceneIdSchema = z.string().min(1);
+const projectIdSchema = z.string().min(1);
+const sceneContentSchema = z.string().max(maxSceneContentLength, {
+  message: `Scene content exceeds ${maxSceneContentLength} characters.`,
+});
+const updatedAtSchema = z.string().datetime({ offset: true });
+
+export const sceneStatusSchema = z.enum(['draft', 'revise', 'final']);
+
+export const sceneSchema = z.object({
+  id: sceneIdSchema,
+  projectId: projectIdSchema,
+  title: z.string().min(1),
+  content: sceneContentSchema,
+  status: sceneStatusSchema,
+  updatedAt: updatedAtSchema,
+});
+
+export const sceneSummarySchema = sceneSchema.pick({
+  id: true,
+  projectId: true,
+  title: true,
+  status: true,
+  updatedAt: true,
+});
+
+export const saveSceneInputSchema = z.object({
+  projectId: projectIdSchema,
+  sceneId: sceneIdSchema,
+  content: sceneContentSchema,
+  status: sceneStatusSchema,
+  updatedAt: updatedAtSchema,
+});
+
+export const projectStoreSchema = z
+  .object({
+    id: projectIdSchema,
+    title: z.string().min(1),
+    sceneOrder: z.array(sceneIdSchema),
+    scenes: z.record(sceneSchema),
+  })
+  .superRefine((value, context) => {
+    for (const sceneId of value.sceneOrder) {
+      if (!(sceneId in value.scenes)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Missing scene reference for ${sceneId}.`,
+          path: ['sceneOrder'],
+        });
+      }
+    }
+
+    for (const [sceneId, scene] of Object.entries(value.scenes)) {
+      if (scene.id !== sceneId) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Scene key ${sceneId} does not match scene.id.`,
+          path: ['scenes', sceneId, 'id'],
+        });
+      }
+
+      if (scene.projectId !== value.id) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Scene ${sceneId} belongs to another project.`,
+          path: ['scenes', sceneId, 'projectId'],
+        });
+      }
+    }
+  });
+
+export const workspaceStoreSchema = z.object({
+  version: z.literal(1),
+  projects: z.record(projectStoreSchema),
+});
+
+export type WorkspaceStoreV1 = z.infer<typeof workspaceStoreSchema>;

--- a/src/domain/scene/schemas.ts
+++ b/src/domain/scene/schemas.ts
@@ -2,8 +2,12 @@ import { z } from 'zod';
 
 export const maxSceneContentLength = 200000;
 
+const uuidV4Pattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 const sceneIdSchema = z.string().min(1);
-const projectIdSchema = z.string().min(1);
+const projectIdSchema = z.string().trim().regex(uuidV4Pattern, 'Invalid project id');
+const legacyProjectIdSchema = z.string().trim().min(1);
 const sceneContentSchema = z.string().max(maxSceneContentLength, {
   message: `Scene content exceeds ${maxSceneContentLength} characters.`,
 });
@@ -36,15 +40,36 @@ export const saveSceneInputSchema = z.object({
   updatedAt: updatedAtSchema,
 });
 
+const legacySceneSchema = z.object({
+  id: sceneIdSchema,
+  projectId: legacyProjectIdSchema,
+  title: z.string().min(1),
+  content: sceneContentSchema,
+  status: sceneStatusSchema,
+  updatedAt: updatedAtSchema,
+});
+
 export const projectStoreSchema = z
   .object({
-    id: projectIdSchema,
+    id: legacyProjectIdSchema,
     title: z.string().min(1),
     sceneOrder: z.array(sceneIdSchema),
-    scenes: z.record(sceneSchema),
+    scenes: z.record(legacySceneSchema),
   })
   .superRefine((value, context) => {
+    const orderedIds = new Set<string>();
+
     for (const sceneId of value.sceneOrder) {
+      if (orderedIds.has(sceneId)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Duplicate scene reference for ${sceneId}.`,
+          path: ['sceneOrder'],
+        });
+        continue;
+      }
+
+      orderedIds.add(sceneId);
       if (!(sceneId in value.scenes)) {
         context.addIssue({
           code: z.ZodIssueCode.custom,
@@ -55,6 +80,14 @@ export const projectStoreSchema = z
     }
 
     for (const [sceneId, scene] of Object.entries(value.scenes)) {
+      if (!orderedIds.has(sceneId)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Scene ${sceneId} is not present in sceneOrder.`,
+          path: ['scenes', sceneId],
+        });
+      }
+
       if (scene.id !== sceneId) {
         context.addIssue({
           code: z.ZodIssueCode.custom,

--- a/src/domain/scene/types.ts
+++ b/src/domain/scene/types.ts
@@ -1,0 +1,18 @@
+export type SceneStatus = 'draft' | 'revise' | 'final';
+
+export interface Scene {
+  id: string;
+  projectId: string;
+  title: string;
+  content: string;
+  status: SceneStatus;
+  updatedAt: string;
+}
+
+export interface SceneSummary {
+  id: string;
+  projectId: string;
+  title: string;
+  status: SceneStatus;
+  updatedAt: string;
+}

--- a/src/hooks/use-scene-editor-runtime.ts
+++ b/src/hooks/use-scene-editor-runtime.ts
@@ -1,0 +1,211 @@
+import type { MutableRefObject } from 'react';
+
+import type { SceneEditorServicePort } from '@/application/scene/scene-editor-service';
+import type { Scene, SceneStatus } from '@/domain/scene/types';
+
+export type SceneEditorLoadState = 'loading' | 'ready' | 'project-not-found' | 'scene-not-found';
+
+export type SceneViewState = {
+  scene: Scene | null;
+  content: string;
+  status: SceneStatus;
+  isDirty: boolean;
+  isSaving: boolean;
+  saveError: string | null;
+  lastSavedAt: string | null;
+  previousSceneId: string | null;
+  nextSceneId: string | null;
+  loadState: SceneEditorLoadState;
+};
+
+export type SceneRuntimeRefs = {
+  sceneRef: MutableRefObject<Scene | null>;
+  contentRef: MutableRefObject<string>;
+  statusRef: MutableRefObject<SceneStatus>;
+  isDirtyRef: MutableRefObject<boolean>;
+  latestRequestRef: MutableRefObject<number>;
+  latestAppliedRequestRef: MutableRefObject<number>;
+  inFlightRequestCountRef: MutableRefObject<number>;
+  isMountedRef: MutableRefObject<boolean>;
+  autosaveTimeoutRef: MutableRefObject<ReturnType<typeof setTimeout> | null>;
+};
+
+export type ViewStateSetter = (patch: Partial<SceneViewState>) => void;
+export type ViewStateReplacer = (state: SceneViewState) => void;
+
+export type SavePayload = {
+  projectId: string;
+  sceneId: string;
+  content: string;
+  status: SceneStatus;
+  updatedAt: string;
+};
+
+type SaveSuccessInput = {
+  runtimeRefs: SceneRuntimeRefs;
+  patchViewState: ViewStateSetter;
+  requestId: number;
+  payload: SavePayload;
+  savedScene: Scene;
+};
+
+type SaveFailureInput = {
+  runtimeRefs: SceneRuntimeRefs;
+  patchViewState: ViewStateSetter;
+  service: SceneEditorServicePort;
+  requestId: number;
+  error: unknown;
+};
+
+type ApplyLoadedInput = {
+  runtimeRefs: SceneRuntimeRefs;
+  replaceViewState: ViewStateReplacer;
+  scene: Scene;
+  previousSceneId: string | null;
+  nextSceneId: string | null;
+};
+
+export const initialViewState: SceneViewState = {
+  scene: null,
+  content: '',
+  status: 'draft',
+  isDirty: false,
+  isSaving: false,
+  saveError: null,
+  lastSavedAt: null,
+  previousSceneId: null,
+  nextSceneId: null,
+  loadState: 'loading',
+};
+
+export const assignRef = <T>(ref: MutableRefObject<T>, value: T): void => {
+  ref.current = value;
+};
+
+export const incrementRef = (ref: MutableRefObject<number>): number => {
+  ref.current += 1;
+  return ref.current;
+};
+
+export const decrementRef = (ref: MutableRefObject<number>): number => {
+  ref.current = Math.max(ref.current - 1, 0);
+  return ref.current;
+};
+
+export const clearAutosaveTimeout = (
+  autosaveTimeoutRef: MutableRefObject<ReturnType<typeof setTimeout> | null>,
+): void => {
+  if (!autosaveTimeoutRef.current) {
+    return;
+  }
+
+  clearTimeout(autosaveTimeoutRef.current);
+  assignRef(autosaveTimeoutRef, null);
+};
+
+export const resetRuntimeRefs = (runtimeRefs: SceneRuntimeRefs): void => {
+  assignRef(runtimeRefs.sceneRef, null);
+  assignRef(runtimeRefs.contentRef, '');
+  assignRef(runtimeRefs.statusRef, 'draft');
+  assignRef(runtimeRefs.isDirtyRef, false);
+  assignRef(runtimeRefs.latestRequestRef, 0);
+  assignRef(runtimeRefs.latestAppliedRequestRef, 0);
+  assignRef(runtimeRefs.inFlightRequestCountRef, 0);
+};
+
+export const buildUnavailableViewState = (
+  loadState: Extract<SceneEditorLoadState, 'project-not-found' | 'scene-not-found'>,
+): SceneViewState => ({
+  ...initialViewState,
+  loadState,
+});
+
+export const markDirty = (runtimeRefs: SceneRuntimeRefs, patchViewState: ViewStateSetter): void => {
+  assignRef(runtimeRefs.isDirtyRef, true);
+  patchViewState({ isDirty: true });
+};
+
+export const applyUnavailableScene = (
+  runtimeRefs: SceneRuntimeRefs,
+  replaceViewState: ViewStateReplacer,
+  loadState: Extract<SceneEditorLoadState, 'project-not-found' | 'scene-not-found'>,
+): void => {
+  resetRuntimeRefs(runtimeRefs);
+  replaceViewState(buildUnavailableViewState(loadState));
+};
+
+export const applyLoadedScene = (input: ApplyLoadedInput): void => {
+  const { runtimeRefs, replaceViewState, scene, previousSceneId, nextSceneId } = input;
+
+  assignRef(runtimeRefs.sceneRef, scene);
+  assignRef(runtimeRefs.contentRef, scene.content);
+  assignRef(runtimeRefs.statusRef, scene.status);
+  assignRef(runtimeRefs.isDirtyRef, false);
+  assignRef(runtimeRefs.latestRequestRef, 0);
+  assignRef(runtimeRefs.latestAppliedRequestRef, 0);
+  assignRef(runtimeRefs.inFlightRequestCountRef, 0);
+
+  replaceViewState({
+    scene,
+    content: scene.content,
+    status: scene.status,
+    isDirty: false,
+    isSaving: false,
+    saveError: null,
+    lastSavedAt: scene.updatedAt,
+    previousSceneId,
+    nextSceneId,
+    loadState: 'ready',
+  });
+};
+
+export const createSavePayload = (runtimeRefs: SceneRuntimeRefs): SavePayload | null => {
+  if (!runtimeRefs.sceneRef.current) {
+    return null;
+  }
+
+  return {
+    projectId: runtimeRefs.sceneRef.current.projectId,
+    sceneId: runtimeRefs.sceneRef.current.id,
+    content: runtimeRefs.contentRef.current,
+    status: runtimeRefs.statusRef.current,
+    updatedAt: new Date().toISOString(),
+  };
+};
+
+export const applySaveSuccess = (input: SaveSuccessInput): void => {
+  const { runtimeRefs, patchViewState, requestId, payload, savedScene } = input;
+  if (!runtimeRefs.isMountedRef.current || requestId < runtimeRefs.latestAppliedRequestRef.current) {
+    return;
+  }
+
+  assignRef(runtimeRefs.latestAppliedRequestRef, requestId);
+  patchViewState({ saveError: null });
+
+  if (requestId !== runtimeRefs.latestRequestRef.current) {
+    return;
+  }
+
+  assignRef(runtimeRefs.sceneRef, savedScene);
+  patchViewState({ scene: savedScene, lastSavedAt: savedScene.updatedAt });
+
+  const payloadStillCurrent =
+    runtimeRefs.contentRef.current === payload.content && runtimeRefs.statusRef.current === payload.status;
+
+  if (!payloadStillCurrent) {
+    return;
+  }
+
+  assignRef(runtimeRefs.isDirtyRef, false);
+  patchViewState({ isDirty: false });
+};
+
+export const applySaveFailure = (input: SaveFailureInput): void => {
+  const { runtimeRefs, patchViewState, service, requestId, error } = input;
+  if (!runtimeRefs.isMountedRef.current || requestId !== runtimeRefs.latestRequestRef.current) {
+    return;
+  }
+
+  markDirty(runtimeRefs, patchViewState);
+  patchViewState({ saveError: service.toUserErrorMessage(error) });
+};

--- a/src/hooks/use-scene-editor-runtime.ts
+++ b/src/hooks/use-scene-editor-runtime.ts
@@ -3,7 +3,12 @@ import type { MutableRefObject } from 'react';
 import type { SceneEditorServicePort } from '@/application/scene/scene-editor-service';
 import type { Scene, SceneStatus } from '@/domain/scene/types';
 
-export type SceneEditorLoadState = 'loading' | 'ready' | 'project-not-found' | 'scene-not-found';
+export type SceneEditorLoadState =
+  | 'loading'
+  | 'ready'
+  | 'project-not-found'
+  | 'scene-not-found'
+  | 'error';
 
 export type SceneViewState = {
   scene: Scene | null;
@@ -179,13 +184,12 @@ export const applySaveSuccess = (input: SaveSuccessInput): void => {
     return;
   }
 
-  assignRef(runtimeRefs.latestAppliedRequestRef, requestId);
-  patchViewState({ saveError: null });
-
   if (requestId !== runtimeRefs.latestRequestRef.current) {
     return;
   }
 
+  assignRef(runtimeRefs.latestAppliedRequestRef, requestId);
+  patchViewState({ saveError: null });
   assignRef(runtimeRefs.sceneRef, savedScene);
   patchViewState({ scene: savedScene, lastSavedAt: savedScene.updatedAt });
 

--- a/src/hooks/use-scene-editor.ts
+++ b/src/hooks/use-scene-editor.ts
@@ -1,0 +1,283 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import type { SceneEditorServicePort } from '@/application/scene/scene-editor-service';
+import type { Scene, SceneStatus } from '@/domain/scene/types';
+
+type SceneEditorLoadState = 'loading' | 'ready' | 'project-not-found' | 'scene-not-found';
+
+type UseSceneEditorInput = {
+  projectId: string;
+  sceneId: string;
+  service: SceneEditorServicePort;
+};
+
+export type UseSceneEditorResult = {
+  scene: Scene | null;
+  content: string;
+  status: SceneStatus;
+  wordCount: number;
+  isDirty: boolean;
+  isSaving: boolean;
+  saveError: string | null;
+  lastSavedAt: string | null;
+  previousSceneId: string | null;
+  nextSceneId: string | null;
+  loadState: SceneEditorLoadState;
+  setContent: (value: string) => void;
+  setStatus: (value: SceneStatus) => void;
+  retrySave: () => Promise<void>;
+};
+
+const autosaveDelayInMilliseconds = 800;
+
+export function useSceneEditor(input: UseSceneEditorInput): UseSceneEditorResult {
+  const [scene, setScene] = useState<Scene | null>(null);
+  const [content, setContentState] = useState<string>('');
+  const [status, setStatusState] = useState<SceneStatus>('draft');
+  const [isDirty, setIsDirtyState] = useState<boolean>(false);
+  const [isSaving, setIsSavingState] = useState<boolean>(false);
+  const [saveError, setSaveErrorState] = useState<string | null>(null);
+  const [lastSavedAt, setLastSavedAtState] = useState<string | null>(null);
+  const [previousSceneId, setPreviousSceneIdState] = useState<string | null>(null);
+  const [nextSceneId, setNextSceneIdState] = useState<string | null>(null);
+  const [loadState, setLoadState] = useState<SceneEditorLoadState>('loading');
+
+  const sceneRef = useRef<Scene | null>(null);
+  const contentRef = useRef<string>('');
+  const statusRef = useRef<SceneStatus>('draft');
+  const isDirtyRef = useRef<boolean>(false);
+  const latestRequestRef = useRef<number>(0);
+  const latestAppliedRequestRef = useRef<number>(0);
+  const inFlightRequestCountRef = useRef<number>(0);
+  const isMountedRef = useRef<boolean>(false);
+  const autosaveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const resetMutableState = useCallback((): void => {
+    sceneRef.current = null;
+    contentRef.current = '';
+    statusRef.current = 'draft';
+    isDirtyRef.current = false;
+    latestRequestRef.current = 0;
+    latestAppliedRequestRef.current = 0;
+    inFlightRequestCountRef.current = 0;
+  }, []);
+
+  const applyUnavailableSceneState = useCallback(
+    (nextLoadState: Extract<SceneEditorLoadState, 'project-not-found' | 'scene-not-found'>): void => {
+      resetMutableState();
+      setScene(null);
+      setContentState('');
+      setStatusState('draft');
+      setIsDirtyState(false);
+      setIsSavingState(false);
+      setLastSavedAtState(null);
+      setPreviousSceneIdState(null);
+      setNextSceneIdState(null);
+      setLoadState(nextLoadState);
+    },
+    [resetMutableState],
+  );
+
+  const markDirty = useCallback((): void => {
+    isDirtyRef.current = true;
+    setIsDirtyState(true);
+  }, []);
+
+  const clearAutosaveTimeout = useCallback((): void => {
+    if (!autosaveTimeoutRef.current) {
+      return;
+    }
+
+    clearTimeout(autosaveTimeoutRef.current);
+    autosaveTimeoutRef.current = null;
+  }, []);
+
+  const applySaveSuccess = useCallback(
+    (requestId: number, savedScene: Scene, payloadContent: string, payloadStatus: SceneStatus): void => {
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      if (requestId < latestAppliedRequestRef.current) {
+        return;
+      }
+
+      latestAppliedRequestRef.current = requestId;
+      setSaveErrorState(null);
+
+      if (requestId === latestRequestRef.current) {
+        setScene(savedScene);
+        sceneRef.current = savedScene;
+        setLastSavedAtState(savedScene.updatedAt);
+
+        const isCurrentPayload =
+          contentRef.current === payloadContent && statusRef.current === payloadStatus;
+
+        if (isCurrentPayload) {
+          isDirtyRef.current = false;
+          setIsDirtyState(false);
+        }
+      }
+    },
+    [],
+  );
+
+  const applySaveFailure = useCallback(
+    (requestId: number, error: unknown): void => {
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      if (requestId !== latestRequestRef.current) {
+        return;
+      }
+
+      markDirty();
+      setSaveErrorState(input.service.toUserErrorMessage(error));
+    },
+    [input.service, markDirty],
+  );
+
+  const runSaveCycle = useCallback(async (): Promise<void> => {
+    if (!sceneRef.current || !isDirtyRef.current) {
+      return;
+    }
+
+    const payload = {
+      projectId: sceneRef.current.projectId,
+      sceneId: sceneRef.current.id,
+      content: contentRef.current,
+      status: statusRef.current,
+      updatedAt: new Date().toISOString(),
+    };
+
+    const requestId = latestRequestRef.current + 1;
+    latestRequestRef.current = requestId;
+
+    inFlightRequestCountRef.current += 1;
+    setIsSavingState(true);
+
+    try {
+      const savedScene = await input.service.saveScene(payload);
+      applySaveSuccess(requestId, savedScene, payload.content, payload.status);
+    } catch (error) {
+      applySaveFailure(requestId, error);
+    } finally {
+      inFlightRequestCountRef.current = Math.max(inFlightRequestCountRef.current - 1, 0);
+      if (isMountedRef.current && inFlightRequestCountRef.current === 0) {
+        setIsSavingState(false);
+      }
+    }
+  }, [applySaveFailure, applySaveSuccess, input.service]);
+
+  const setContent = useCallback(
+    (value: string): void => {
+      contentRef.current = value;
+      setContentState(value);
+      setSaveErrorState(null);
+      markDirty();
+    },
+    [markDirty],
+  );
+
+  const setStatus = useCallback(
+    (value: SceneStatus): void => {
+      statusRef.current = value;
+      setStatusState(value);
+      setSaveErrorState(null);
+      markDirty();
+    },
+    [markDirty],
+  );
+
+  const retrySave = useCallback(async (): Promise<void> => {
+    setSaveErrorState(null);
+    await runSaveCycle();
+  }, [runSaveCycle]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      clearAutosaveTimeout();
+    };
+  }, [clearAutosaveTimeout]);
+
+  useEffect(() => {
+    const loadScene = async (): Promise<void> => {
+      setLoadState('loading');
+      setSaveErrorState(null);
+
+      const result = await input.service.loadScene({
+        projectId: input.projectId,
+        sceneId: input.sceneId,
+      });
+
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      if (result.state === 'project-not-found') {
+        applyUnavailableSceneState('project-not-found');
+        return;
+      }
+
+      if (result.state === 'scene-not-found') {
+        applyUnavailableSceneState('scene-not-found');
+        return;
+      }
+
+      sceneRef.current = result.scene;
+      contentRef.current = result.scene.content;
+      statusRef.current = result.scene.status;
+      isDirtyRef.current = false;
+      latestRequestRef.current = 0;
+      latestAppliedRequestRef.current = 0;
+      inFlightRequestCountRef.current = 0;
+
+      setScene(result.scene);
+      setContentState(result.scene.content);
+      setStatusState(result.scene.status);
+      setIsDirtyState(false);
+      setIsSavingState(false);
+      setLastSavedAtState(result.scene.updatedAt);
+      setPreviousSceneIdState(result.previousSceneId);
+      setNextSceneIdState(result.nextSceneId);
+      setLoadState('ready');
+    };
+
+    void loadScene();
+  }, [applyUnavailableSceneState, input.projectId, input.sceneId, input.service]);
+
+  useEffect(() => {
+    if (loadState !== 'ready' || !isDirty) {
+      return undefined;
+    }
+
+    clearAutosaveTimeout();
+    autosaveTimeoutRef.current = setTimeout(() => {
+      void runSaveCycle();
+    }, autosaveDelayInMilliseconds);
+
+    return clearAutosaveTimeout;
+  }, [clearAutosaveTimeout, content, isDirty, loadState, runSaveCycle, status]);
+
+  const wordCount = useMemo<number>(() => input.service.countWords(content), [content, input.service]);
+
+  return {
+    scene,
+    content,
+    status,
+    wordCount,
+    isDirty,
+    isSaving,
+    saveError,
+    lastSavedAt,
+    previousSceneId,
+    nextSceneId,
+    loadState,
+    setContent,
+    setStatus,
+    retrySave,
+  };
+}

--- a/src/hooks/use-scene-editor.ts
+++ b/src/hooks/use-scene-editor.ts
@@ -158,32 +158,44 @@ function useLoadScene(
     const loadScene = async (): Promise<void> => {
       patchViewState({ loadState: 'loading', saveError: null });
 
-      const result = await input.service.loadScene({
-        projectId: input.projectId,
-        sceneId: input.sceneId,
-      });
+      try {
+        const result = await input.service.loadScene({
+          projectId: input.projectId,
+          sceneId: input.sceneId,
+        });
 
-      if (!runtimeRefs.isMountedRef.current) {
-        return;
+        if (!runtimeRefs.isMountedRef.current) {
+          return;
+        }
+
+        if (result.state === 'project-not-found') {
+          applyUnavailableScene(runtimeRefs, replaceViewState, 'project-not-found');
+          return;
+        }
+
+        if (result.state === 'scene-not-found') {
+          applyUnavailableScene(runtimeRefs, replaceViewState, 'scene-not-found');
+          return;
+        }
+
+        applyLoadedScene({
+          runtimeRefs,
+          replaceViewState,
+          scene: result.scene,
+          previousSceneId: result.previousSceneId,
+          nextSceneId: result.nextSceneId,
+        });
+      } catch (error) {
+        if (!runtimeRefs.isMountedRef.current) {
+          return;
+        }
+
+        patchViewState({
+          loadState: 'error',
+          isSaving: false,
+          saveError: input.service.toUserErrorMessage(error),
+        });
       }
-
-      if (result.state === 'project-not-found') {
-        applyUnavailableScene(runtimeRefs, replaceViewState, 'project-not-found');
-        return;
-      }
-
-      if (result.state === 'scene-not-found') {
-        applyUnavailableScene(runtimeRefs, replaceViewState, 'scene-not-found');
-        return;
-      }
-
-      applyLoadedScene({
-        runtimeRefs,
-        replaceViewState,
-        scene: result.scene,
-        previousSceneId: result.previousSceneId,
-        nextSceneId: result.nextSceneId,
-      });
     };
 
     void loadScene();

--- a/src/hooks/use-scene-editor.ts
+++ b/src/hooks/use-scene-editor.ts
@@ -1,9 +1,32 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import type { SceneEditorServicePort } from '@/application/scene/scene-editor-service';
 import type { Scene, SceneStatus } from '@/domain/scene/types';
 
-type SceneEditorLoadState = 'loading' | 'ready' | 'project-not-found' | 'scene-not-found';
+import {
+  applyLoadedScene,
+  applySaveFailure,
+  applySaveSuccess,
+  applyUnavailableScene,
+  assignRef,
+  clearAutosaveTimeout,
+  createSavePayload,
+  decrementRef,
+  incrementRef,
+  initialViewState,
+  markDirty,
+  type SceneEditorLoadState,
+  type SceneRuntimeRefs,
+  type SceneViewState,
+  type ViewStateReplacer,
+  type ViewStateSetter,
+} from './use-scene-editor-runtime';
 
 type UseSceneEditorInput = {
   projectId: string;
@@ -30,18 +53,25 @@ export type UseSceneEditorResult = {
 
 const autosaveDelayInMilliseconds = 800;
 
-export function useSceneEditor(input: UseSceneEditorInput): UseSceneEditorResult {
-  const [scene, setScene] = useState<Scene | null>(null);
-  const [content, setContentState] = useState<string>('');
-  const [status, setStatusState] = useState<SceneStatus>('draft');
-  const [isDirty, setIsDirtyState] = useState<boolean>(false);
-  const [isSaving, setIsSavingState] = useState<boolean>(false);
-  const [saveError, setSaveErrorState] = useState<string | null>(null);
-  const [lastSavedAt, setLastSavedAtState] = useState<string | null>(null);
-  const [previousSceneId, setPreviousSceneIdState] = useState<string | null>(null);
-  const [nextSceneId, setNextSceneIdState] = useState<string | null>(null);
-  const [loadState, setLoadState] = useState<SceneEditorLoadState>('loading');
+function useViewState(): {
+  viewState: SceneViewState;
+  patchViewState: ViewStateSetter;
+  replaceViewState: ViewStateReplacer;
+} {
+  const [viewState, setViewState] = useState<SceneViewState>(initialViewState);
 
+  const patchViewState = useCallback((patch: Partial<SceneViewState>): void => {
+    setViewState((previousState) => ({ ...previousState, ...patch }));
+  }, []);
+
+  const replaceViewState = useCallback((nextState: SceneViewState): void => {
+    setViewState(nextState);
+  }, []);
+
+  return { viewState, patchViewState, replaceViewState };
+}
+
+function useRuntimeRefs(): SceneRuntimeRefs {
   const sceneRef = useRef<Scene | null>(null);
   const contentRef = useRef<string>('');
   const statusRef = useRef<SceneStatus>('draft');
@@ -52,230 +82,204 @@ export function useSceneEditor(input: UseSceneEditorInput): UseSceneEditorResult
   const isMountedRef = useRef<boolean>(false);
   const autosaveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const resetMutableState = useCallback((): void => {
-    sceneRef.current = null;
-    contentRef.current = '';
-    statusRef.current = 'draft';
-    isDirtyRef.current = false;
-    latestRequestRef.current = 0;
-    latestAppliedRequestRef.current = 0;
-    inFlightRequestCountRef.current = 0;
-  }, []);
-
-  const applyUnavailableSceneState = useCallback(
-    (nextLoadState: Extract<SceneEditorLoadState, 'project-not-found' | 'scene-not-found'>): void => {
-      resetMutableState();
-      setScene(null);
-      setContentState('');
-      setStatusState('draft');
-      setIsDirtyState(false);
-      setIsSavingState(false);
-      setLastSavedAtState(null);
-      setPreviousSceneIdState(null);
-      setNextSceneIdState(null);
-      setLoadState(nextLoadState);
-    },
-    [resetMutableState],
-  );
-
-  const markDirty = useCallback((): void => {
-    isDirtyRef.current = true;
-    setIsDirtyState(true);
-  }, []);
-
-  const clearAutosaveTimeout = useCallback((): void => {
-    if (!autosaveTimeoutRef.current) {
-      return;
-    }
-
-    clearTimeout(autosaveTimeoutRef.current);
-    autosaveTimeoutRef.current = null;
-  }, []);
-
-  const applySaveSuccess = useCallback(
-    (requestId: number, savedScene: Scene, payloadContent: string, payloadStatus: SceneStatus): void => {
-      if (!isMountedRef.current) {
-        return;
-      }
-
-      if (requestId < latestAppliedRequestRef.current) {
-        return;
-      }
-
-      latestAppliedRequestRef.current = requestId;
-      setSaveErrorState(null);
-
-      if (requestId === latestRequestRef.current) {
-        setScene(savedScene);
-        sceneRef.current = savedScene;
-        setLastSavedAtState(savedScene.updatedAt);
-
-        const isCurrentPayload =
-          contentRef.current === payloadContent && statusRef.current === payloadStatus;
-
-        if (isCurrentPayload) {
-          isDirtyRef.current = false;
-          setIsDirtyState(false);
-        }
-      }
-    },
+  return useMemo(
+    () => ({
+      sceneRef,
+      contentRef,
+      statusRef,
+      isDirtyRef,
+      latestRequestRef,
+      latestAppliedRequestRef,
+      inFlightRequestCountRef,
+      isMountedRef,
+      autosaveTimeoutRef,
+    }),
     [],
   );
+}
 
-  const applySaveFailure = useCallback(
-    (requestId: number, error: unknown): void => {
-      if (!isMountedRef.current) {
-        return;
-      }
-
-      if (requestId !== latestRequestRef.current) {
-        return;
-      }
-
-      markDirty();
-      setSaveErrorState(input.service.toUserErrorMessage(error));
-    },
-    [input.service, markDirty],
-  );
-
-  const runSaveCycle = useCallback(async (): Promise<void> => {
-    if (!sceneRef.current || !isDirtyRef.current) {
+function useRunSaveCycle(
+  input: UseSceneEditorInput,
+  runtimeRefs: SceneRuntimeRefs,
+  patchViewState: ViewStateSetter,
+): () => Promise<void> {
+  return useCallback(async (): Promise<void> => {
+    if (!runtimeRefs.sceneRef.current || !runtimeRefs.isDirtyRef.current) {
       return;
     }
 
-    const payload = {
-      projectId: sceneRef.current.projectId,
-      sceneId: sceneRef.current.id,
-      content: contentRef.current,
-      status: statusRef.current,
-      updatedAt: new Date().toISOString(),
-    };
+    const payload = createSavePayload(runtimeRefs);
+    if (!payload) {
+      return;
+    }
 
-    const requestId = latestRequestRef.current + 1;
-    latestRequestRef.current = requestId;
-
-    inFlightRequestCountRef.current += 1;
-    setIsSavingState(true);
+    const requestId = incrementRef(runtimeRefs.latestRequestRef);
+    incrementRef(runtimeRefs.inFlightRequestCountRef);
+    patchViewState({ isSaving: true });
 
     try {
       const savedScene = await input.service.saveScene(payload);
-      applySaveSuccess(requestId, savedScene, payload.content, payload.status);
+      applySaveSuccess({ runtimeRefs, patchViewState, requestId, payload, savedScene });
     } catch (error) {
-      applySaveFailure(requestId, error);
+      applySaveFailure({
+        runtimeRefs,
+        patchViewState,
+        service: input.service,
+        requestId,
+        error,
+      });
     } finally {
-      inFlightRequestCountRef.current = Math.max(inFlightRequestCountRef.current - 1, 0);
-      if (isMountedRef.current && inFlightRequestCountRef.current === 0) {
-        setIsSavingState(false);
+      const inFlightCount = decrementRef(runtimeRefs.inFlightRequestCountRef);
+      if (runtimeRefs.isMountedRef.current && inFlightCount === 0) {
+        patchViewState({ isSaving: false });
       }
     }
-  }, [applySaveFailure, applySaveSuccess, input.service]);
+  }, [input.service, patchViewState, runtimeRefs]);
+}
 
-  const setContent = useCallback(
-    (value: string): void => {
-      contentRef.current = value;
-      setContentState(value);
-      setSaveErrorState(null);
-      markDirty();
-    },
-    [markDirty],
-  );
-
-  const setStatus = useCallback(
-    (value: SceneStatus): void => {
-      statusRef.current = value;
-      setStatusState(value);
-      setSaveErrorState(null);
-      markDirty();
-    },
-    [markDirty],
-  );
-
-  const retrySave = useCallback(async (): Promise<void> => {
-    setSaveErrorState(null);
-    await runSaveCycle();
-  }, [runSaveCycle]);
-
+function useMountLifecycle(runtimeRefs: SceneRuntimeRefs): void {
   useEffect(() => {
-    isMountedRef.current = true;
-    return () => {
-      isMountedRef.current = false;
-      clearAutosaveTimeout();
-    };
-  }, [clearAutosaveTimeout]);
+    assignRef(runtimeRefs.isMountedRef, true);
 
+    return () => {
+      assignRef(runtimeRefs.isMountedRef, false);
+      clearAutosaveTimeout(runtimeRefs.autosaveTimeoutRef);
+    };
+  }, [runtimeRefs]);
+}
+
+function useLoadScene(
+  input: UseSceneEditorInput,
+  runtimeRefs: SceneRuntimeRefs,
+  patchViewState: ViewStateSetter,
+  replaceViewState: ViewStateReplacer,
+): void {
   useEffect(() => {
     const loadScene = async (): Promise<void> => {
-      setLoadState('loading');
-      setSaveErrorState(null);
+      patchViewState({ loadState: 'loading', saveError: null });
 
       const result = await input.service.loadScene({
         projectId: input.projectId,
         sceneId: input.sceneId,
       });
 
-      if (!isMountedRef.current) {
+      if (!runtimeRefs.isMountedRef.current) {
         return;
       }
 
       if (result.state === 'project-not-found') {
-        applyUnavailableSceneState('project-not-found');
+        applyUnavailableScene(runtimeRefs, replaceViewState, 'project-not-found');
         return;
       }
 
       if (result.state === 'scene-not-found') {
-        applyUnavailableSceneState('scene-not-found');
+        applyUnavailableScene(runtimeRefs, replaceViewState, 'scene-not-found');
         return;
       }
 
-      sceneRef.current = result.scene;
-      contentRef.current = result.scene.content;
-      statusRef.current = result.scene.status;
-      isDirtyRef.current = false;
-      latestRequestRef.current = 0;
-      latestAppliedRequestRef.current = 0;
-      inFlightRequestCountRef.current = 0;
-
-      setScene(result.scene);
-      setContentState(result.scene.content);
-      setStatusState(result.scene.status);
-      setIsDirtyState(false);
-      setIsSavingState(false);
-      setLastSavedAtState(result.scene.updatedAt);
-      setPreviousSceneIdState(result.previousSceneId);
-      setNextSceneIdState(result.nextSceneId);
-      setLoadState('ready');
+      applyLoadedScene({
+        runtimeRefs,
+        replaceViewState,
+        scene: result.scene,
+        previousSceneId: result.previousSceneId,
+        nextSceneId: result.nextSceneId,
+      });
     };
 
     void loadScene();
-  }, [applyUnavailableSceneState, input.projectId, input.sceneId, input.service]);
+  }, [input.projectId, input.sceneId, input.service, patchViewState, replaceViewState, runtimeRefs]);
+}
 
+function useAutosave(
+  runtimeRefs: SceneRuntimeRefs,
+  viewState: SceneViewState,
+  runSaveCycle: () => Promise<void>,
+): void {
   useEffect(() => {
-    if (loadState !== 'ready' || !isDirty) {
+    if (viewState.loadState !== 'ready' || !viewState.isDirty) {
       return undefined;
     }
 
-    clearAutosaveTimeout();
-    autosaveTimeoutRef.current = setTimeout(() => {
+    clearAutosaveTimeout(runtimeRefs.autosaveTimeoutRef);
+    const timeout = setTimeout(() => {
       void runSaveCycle();
     }, autosaveDelayInMilliseconds);
 
-    return clearAutosaveTimeout;
-  }, [clearAutosaveTimeout, content, isDirty, loadState, runSaveCycle, status]);
+    assignRef(runtimeRefs.autosaveTimeoutRef, timeout);
+    return () => clearAutosaveTimeout(runtimeRefs.autosaveTimeoutRef);
+  }, [
+    runSaveCycle,
+    runtimeRefs,
+    viewState.content,
+    viewState.isDirty,
+    viewState.loadState,
+    viewState.status,
+  ]);
+}
 
-  const wordCount = useMemo<number>(() => input.service.countWords(content), [content, input.service]);
+function useEditorMutators(
+  runtimeRefs: SceneRuntimeRefs,
+  patchViewState: ViewStateSetter,
+  runSaveCycle: () => Promise<void>,
+): Pick<UseSceneEditorResult, 'setContent' | 'setStatus' | 'retrySave'> {
+  const setContent = useCallback(
+    (value: string): void => {
+      assignRef(runtimeRefs.contentRef, value);
+      patchViewState({ content: value, saveError: null });
+      markDirty(runtimeRefs, patchViewState);
+    },
+    [patchViewState, runtimeRefs],
+  );
+
+  const setStatus = useCallback(
+    (value: SceneStatus): void => {
+      assignRef(runtimeRefs.statusRef, value);
+      patchViewState({ status: value, saveError: null });
+      markDirty(runtimeRefs, patchViewState);
+    },
+    [patchViewState, runtimeRefs],
+  );
+
+  const retrySave = useCallback(async (): Promise<void> => {
+    patchViewState({ saveError: null });
+    await runSaveCycle();
+  }, [patchViewState, runSaveCycle]);
+
+  return { setContent, setStatus, retrySave };
+}
+
+export function useSceneEditor(input: UseSceneEditorInput): UseSceneEditorResult {
+  const runtimeRefs = useRuntimeRefs();
+  const { viewState, patchViewState, replaceViewState } = useViewState();
+  const runSaveCycle = useRunSaveCycle(input, runtimeRefs, patchViewState);
+
+  useMountLifecycle(runtimeRefs);
+  useLoadScene(input, runtimeRefs, patchViewState, replaceViewState);
+  useAutosave(runtimeRefs, viewState, runSaveCycle);
+
+  const { setContent, setStatus, retrySave } = useEditorMutators(
+    runtimeRefs,
+    patchViewState,
+    runSaveCycle,
+  );
+
+  const wordCount = useMemo<number>(
+    () => input.service.countWords(viewState.content),
+    [input.service, viewState.content],
+  );
 
   return {
-    scene,
-    content,
-    status,
+    scene: viewState.scene,
+    content: viewState.content,
+    status: viewState.status,
     wordCount,
-    isDirty,
-    isSaving,
-    saveError,
-    lastSavedAt,
-    previousSceneId,
-    nextSceneId,
-    loadState,
+    isDirty: viewState.isDirty,
+    isSaving: viewState.isSaving,
+    saveError: viewState.saveError,
+    lastSavedAt: viewState.lastSavedAt,
+    previousSceneId: viewState.previousSceneId,
+    nextSceneId: viewState.nextSceneId,
+    loadState: viewState.loadState,
     setContent,
     setStatus,
     retrySave,

--- a/src/test/project/local-project-repository.test.ts
+++ b/src/test/project/local-project-repository.test.ts
@@ -1,11 +1,33 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { projectIdSchema, projectStorageSchema } from '@/domain/project/schemas';
-import {
-  LocalProjectRepository,
-  PROJECT_STORAGE_KEY,
-} from '@/data/project/local-project-repository';
 
-describe('LocalProjectRepository', () => {
+import { LocalProjectRepository, PROJECT_STORAGE_KEY } from '@/data/project/local-project-repository';
+import { projectIdSchema, projectStorageSchema } from '@/domain/project/schemas';
+
+const legacyProjectId = '11111111-1111-4111-8111-111111111111';
+
+const createLegacyProjectStorage = () => ({
+  version: 1,
+  projects: [
+    {
+      id: legacyProjectId,
+      title: 'Legacy Project',
+      description: 'Migrated from v1',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+      stats: {
+        wordCount: 10,
+        sceneCount: 2,
+        chapterCount: 1,
+      },
+      settings: {
+        language: 'en',
+        targetWordCount: 1000,
+      },
+    },
+  ],
+});
+
+describe('LocalProjectRepository project storage', () => {
   beforeEach(() => {
     window.localStorage.clear();
     vi.restoreAllMocks();
@@ -15,7 +37,7 @@ describe('LocalProjectRepository', () => {
     vi.useRealTimers();
   });
 
-  it('creates and persists a valid project', async () => {
+  it('creates and persists a project with an initial scene in v2 storage', async () => {
     const repository = new LocalProjectRepository();
 
     const createdProject = await repository.create({
@@ -24,21 +46,22 @@ describe('LocalProjectRepository', () => {
     });
 
     expect(projectIdSchema.safeParse(createdProject.id).success).toBe(true);
-    expect(createdProject.title).toBe('Draft project');
-    expect(createdProject.description).toBe('Initial version');
+    expect(createdProject.sceneOrder).toHaveLength(1);
+    expect(createdProject.stats.sceneCount).toBe(1);
 
     const rawStorage = window.localStorage.getItem(PROJECT_STORAGE_KEY);
     expect(rawStorage).toBeTruthy();
 
     const parsedStorage = projectStorageSchema.parse(JSON.parse(rawStorage ?? '{}'));
+    expect(parsedStorage.version).toBe(2);
     expect(parsedStorage.projects).toHaveLength(1);
-    expect(parsedStorage.projects[0]?.id).toBe(createdProject.id);
+    expect(parsedStorage.projects[0]?.sceneOrder).toHaveLength(1);
   });
 
   it('lists projects sorted by updatedAt descending', async () => {
     vi.useFakeTimers();
-
     const repository = new LocalProjectRepository();
+
     vi.setSystemTime(new Date('2025-01-01T00:00:00.000Z'));
     const projectAlpha = await repository.create({ title: 'Alpha', description: '' });
 
@@ -50,13 +73,12 @@ describe('LocalProjectRepository', () => {
 
     const projects = await repository.list();
     expect(projects.map((project) => project.id)).toEqual([projectAlpha.id, projectBeta.id]);
-
   });
 
   it('updates a project and refreshes updatedAt', async () => {
     vi.useFakeTimers();
-
     const repository = new LocalProjectRepository();
+
     vi.setSystemTime(new Date('2025-02-01T00:00:00.000Z'));
     const createdProject = await repository.create({
       title: 'Story',
@@ -74,7 +96,6 @@ describe('LocalProjectRepository', () => {
     expect(new Date(updatedProject.updatedAt).getTime()).toBeGreaterThan(
       new Date(createdProject.updatedAt).getTime(),
     );
-
   });
 
   it('removes project safely and keeps remove idempotent for missing items', async () => {
@@ -89,6 +110,21 @@ describe('LocalProjectRepository', () => {
 
     const projects = await repository.list();
     expect(projects).toHaveLength(0);
+  });
+
+  it('migrates v1 project storage to v2 with default scene data', async () => {
+    window.localStorage.setItem(PROJECT_STORAGE_KEY, JSON.stringify(createLegacyProjectStorage()));
+    const repository = new LocalProjectRepository();
+
+    const projects = await repository.list();
+    expect(projects).toHaveLength(1);
+    expect(projects[0]?.id).toBe(legacyProjectId);
+    expect(projects[0]?.sceneOrder).toHaveLength(1);
+    expect(projects[0]?.stats.sceneCount).toBe(1);
+
+    const rawStorage = window.localStorage.getItem(PROJECT_STORAGE_KEY);
+    const parsedStorage = projectStorageSchema.parse(JSON.parse(rawStorage ?? '{}'));
+    expect(parsedStorage.version).toBe(2);
   });
 
   it('falls back to empty list when storage json is corrupted', async () => {
@@ -109,7 +145,7 @@ describe('LocalProjectRepository', () => {
     window.localStorage.setItem(
       PROJECT_STORAGE_KEY,
       JSON.stringify({
-        version: 2,
+        version: 99,
         projects: [],
       }),
     );

--- a/src/test/project/schemas.test.ts
+++ b/src/test/project/schemas.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { writingProjectSchema } from '@/domain/project/schemas';
+
+const projectId = '11111111-1111-4111-8111-111111111111';
+
+const createProjectScene = (sceneId: string) => ({
+  id: sceneId,
+  projectId,
+  title: `Scene ${sceneId}`,
+  content: 'scene content',
+  status: 'draft' as const,
+  updatedAt: '2026-02-27T00:00:00.000Z',
+});
+
+const createValidProject = () => ({
+  id: projectId,
+  title: 'Valid Project',
+  description: 'Schema checks',
+  createdAt: '2026-02-27T00:00:00.000Z',
+  updatedAt: '2026-02-27T00:00:00.000Z',
+  stats: {
+    wordCount: 2,
+    sceneCount: 1,
+    chapterCount: 0,
+  },
+  settings: {
+    language: 'en',
+    targetWordCount: null,
+  },
+  sceneOrder: ['scene-1'],
+  scenes: {
+    'scene-1': createProjectScene('scene-1'),
+  },
+});
+
+describe('writingProjectSchema graph integrity', () => {
+  it('rejects duplicate scene references in sceneOrder', () => {
+    const project = createValidProject();
+    project.sceneOrder = ['scene-1', 'scene-1'];
+
+    const result = writingProjectSchema.safeParse(project);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects orphan scenes missing from sceneOrder', () => {
+    const project = createValidProject();
+    project.scenes['scene-2'] = createProjectScene('scene-2');
+
+    const result = writingProjectSchema.safeParse(project);
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/test/project/workspace-project-page.test.tsx
+++ b/src/test/project/workspace-project-page.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import WorkspaceProjectPage from '@/app/workspace/[projectId]/page';
+import { LocalProjectRepository } from '@/data/project/local-project-repository';
+
+const mockedUseParams = vi.hoisted(() => vi.fn());
+
+vi.mock('next/navigation', () => ({
+  useParams: mockedUseParams,
+}));
+
+describe('WorkspaceProjectPage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('renders project scenes with open links', async () => {
+    const repository = new LocalProjectRepository();
+    const project = await repository.create({
+      title: 'Project Hub',
+      description: 'Scene overview',
+    });
+
+    mockedUseParams.mockReturnValue({ projectId: project.id });
+
+    render(<WorkspaceProjectPage />);
+
+    expect(await screen.findByText('Project Hub')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Scenes' })).toBeInTheDocument();
+    expect(screen.getByText('Scene 1')).toBeInTheDocument();
+
+    const openLink = screen.getByRole('link', { name: 'Open' });
+    expect(openLink).toHaveAttribute('href', `/workspace/${project.id}/scene/${project.sceneOrder[0]}`);
+  });
+
+  it('creates a scene from the project hub', async () => {
+    const user = userEvent.setup();
+    const repository = new LocalProjectRepository();
+    const project = await repository.create({
+      title: 'Project Create Scene',
+      description: '',
+    });
+
+    mockedUseParams.mockReturnValue({ projectId: project.id });
+
+    render(<WorkspaceProjectPage />);
+    await screen.findByText('Project Create Scene');
+
+    await user.click(screen.getByRole('button', { name: 'Create scene' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Scene 2')).toBeInTheDocument();
+    });
+  });
+
+  it('shows invalid id message when project id is not valid', async () => {
+    mockedUseParams.mockReturnValue({ projectId: 'invalid-id' });
+
+    render(<WorkspaceProjectPage />);
+
+    expect(await screen.findByText('Invalid project id')).toBeInTheDocument();
+  });
+});

--- a/src/test/scene/local-project-repository.test.ts
+++ b/src/test/scene/local-project-repository.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { LocalProjectRepository } from '@/data/project/local-project-repository';
+import { maxSceneContentLength } from '@/domain/scene/schemas';
+
+describe('LocalProjectRepository', () => {
+  it('seeds the demo project when storage is empty', async () => {
+    window.localStorage.clear();
+    const repository = new LocalProjectRepository();
+
+    const scenes = await repository.listScenes({ projectId: 'demo-project' });
+
+    expect(scenes).toHaveLength(3);
+    expect(scenes.map((scene) => scene.id)).toEqual(['scene-1', 'scene-2', 'scene-3']);
+  });
+
+  it('persists scene content and status across repository instances', async () => {
+    window.localStorage.clear();
+    const repository = new LocalProjectRepository();
+    const updatedAt = '2026-02-25T12:00:00.000Z';
+
+    await repository.saveScene({
+      projectId: 'demo-project',
+      sceneId: 'scene-1',
+      content: 'Updated markdown body.',
+      status: 'final',
+      updatedAt,
+    });
+
+    const reloadedRepository = new LocalProjectRepository();
+    const scene = await reloadedRepository.getScene({
+      projectId: 'demo-project',
+      sceneId: 'scene-1',
+    });
+
+    expect(scene).not.toBeNull();
+    expect(scene?.content).toBe('Updated markdown body.');
+    expect(scene?.status).toBe('final');
+    expect(scene?.updatedAt).toBe(updatedAt);
+  });
+
+  it('rejects content larger than the allowed size', async () => {
+    window.localStorage.clear();
+    const repository = new LocalProjectRepository();
+    const oversizedContent = 'a'.repeat(maxSceneContentLength + 1);
+
+    await expect(
+      repository.saveScene({
+        projectId: 'demo-project',
+        sceneId: 'scene-1',
+        content: oversizedContent,
+        status: 'draft',
+        updatedAt: '2026-02-25T12:10:00.000Z',
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/src/test/scene/local-project-repository.test.ts
+++ b/src/test/scene/local-project-repository.test.ts
@@ -1,27 +1,65 @@
 import { describe, expect, it } from 'vitest';
 
-import { LocalProjectRepository } from '@/data/project/local-project-repository';
+import {
+  LocalProjectRepository,
+  workspaceStorageKey,
+} from '@/data/project/local-project-repository';
 import { maxSceneContentLength } from '@/domain/scene/schemas';
 
-describe('LocalProjectRepository', () => {
-  it('seeds the demo project when storage is empty', async () => {
+const buildLegacyWorkspaceStore = (projectId: string) => ({
+  version: 1,
+  projects: {
+    [projectId]: {
+      id: projectId,
+      title: 'Legacy Scene Project',
+      sceneOrder: ['legacy-scene-1'],
+      scenes: {
+        'legacy-scene-1': {
+          id: 'legacy-scene-1',
+          projectId,
+          title: 'Legacy Scene 1',
+          content: 'Legacy imported content',
+          status: 'revise',
+          updatedAt: '2026-02-25T12:00:00.000Z',
+        },
+      },
+    },
+  },
+});
+
+describe('LocalProjectRepository scene storage', () => {
+  it('creates a new scene and appends it to sceneOrder', async () => {
     window.localStorage.clear();
     const repository = new LocalProjectRepository();
+    const project = await repository.create({
+      title: 'Project with scenes',
+      description: '',
+    });
 
-    const scenes = await repository.listScenes({ projectId: 'demo-project' });
+    const createdScene = await repository.createScene({
+      projectId: project.id,
+      title: 'Second Scene',
+    });
 
-    expect(scenes).toHaveLength(3);
-    expect(scenes.map((scene) => scene.id)).toEqual(['scene-1', 'scene-2', 'scene-3']);
+    const updatedProject = await repository.getById(project.id);
+    expect(updatedProject).not.toBeNull();
+    expect(updatedProject?.sceneOrder.includes(createdScene.id)).toBe(true);
+    expect(updatedProject?.stats.sceneCount).toBe(2);
   });
 
   it('persists scene content and status across repository instances', async () => {
     window.localStorage.clear();
     const repository = new LocalProjectRepository();
-    const updatedAt = '2026-02-25T12:00:00.000Z';
+    const project = await repository.create({
+      title: 'Persisted scene project',
+      description: '',
+    });
+    const sceneId = project.sceneOrder[0]!;
+    const updatedAt = '2026-02-25T12:10:00.000Z';
 
     await repository.saveScene({
-      projectId: 'demo-project',
-      sceneId: 'scene-1',
+      projectId: project.id,
+      sceneId,
       content: 'Updated markdown body.',
       status: 'final',
       updatedAt,
@@ -29,8 +67,8 @@ describe('LocalProjectRepository', () => {
 
     const reloadedRepository = new LocalProjectRepository();
     const scene = await reloadedRepository.getScene({
-      projectId: 'demo-project',
-      sceneId: 'scene-1',
+      projectId: project.id,
+      sceneId,
     });
 
     expect(scene).not.toBeNull();
@@ -42,16 +80,66 @@ describe('LocalProjectRepository', () => {
   it('rejects content larger than the allowed size', async () => {
     window.localStorage.clear();
     const repository = new LocalProjectRepository();
+    const project = await repository.create({
+      title: 'Size limited project',
+      description: '',
+    });
+    const sceneId = project.sceneOrder[0]!;
     const oversizedContent = 'a'.repeat(maxSceneContentLength + 1);
 
     await expect(
       repository.saveScene({
-        projectId: 'demo-project',
-        sceneId: 'scene-1',
+        projectId: project.id,
+        sceneId,
         content: oversizedContent,
         status: 'draft',
         updatedAt: '2026-02-25T12:10:00.000Z',
       }),
     ).rejects.toThrow();
+  });
+
+  it('imports legacy workspace scenes into an existing project id', async () => {
+    window.localStorage.clear();
+    const repository = new LocalProjectRepository();
+    const project = await repository.create({
+      title: 'Existing target project',
+      description: '',
+    });
+
+    window.localStorage.setItem(
+      workspaceStorageKey,
+      JSON.stringify(buildLegacyWorkspaceStore(project.id)),
+    );
+
+    const scenes = await repository.listScenes({ projectId: project.id });
+    const sceneTitles = scenes.map((scene) => scene.title);
+
+    expect(sceneTitles).toContain('Legacy Scene 1');
+    expect(scenes.length).toBe(2);
+    expect(window.localStorage.getItem(workspaceStorageKey)).toBeNull();
+  });
+
+  it('creates an imported project when only demo legacy workspace exists', async () => {
+    window.localStorage.clear();
+    const repository = new LocalProjectRepository();
+
+    window.localStorage.setItem(
+      workspaceStorageKey,
+      JSON.stringify(buildLegacyWorkspaceStore('demo-project')),
+    );
+
+    const projects = await repository.list();
+    expect(projects).toHaveLength(1);
+    expect(projects[0]?.title).toBe('Imported Demo Project');
+
+    const importedProjectId = projects[0]?.id;
+    expect(importedProjectId).toBeTruthy();
+    if (!importedProjectId) {
+      throw new Error('Imported project id is required');
+    }
+
+    const scenes = await repository.listScenes({ projectId: importedProjectId });
+    expect(scenes).toHaveLength(1);
+    expect(scenes[0]?.title).toBe('Legacy Scene 1');
   });
 });

--- a/src/test/scene/scene-editor-shell.test.tsx
+++ b/src/test/scene/scene-editor-shell.test.tsx
@@ -138,4 +138,19 @@ describe('SceneEditorShell', () => {
     expect(saveScene).toHaveBeenCalledTimes(2);
     expect(screen.queryByText('Unable to save scene. Retry.')).not.toBeInTheDocument();
   });
+
+  it('shows terminal load error view when loading fails', async () => {
+    const service = createServiceDouble({});
+    vi.mocked(service.loadScene).mockRejectedValueOnce(new Error('LOAD_FAILURE'));
+    vi.mocked(service.toUserErrorMessage).mockReturnValueOnce('Unable to load scene.');
+
+    render(<SceneEditorShell projectId="demo-project" sceneId="scene-1" service={service} />);
+
+    expect(await screen.findByText('Unable to load scene')).toBeInTheDocument();
+    expect(screen.getByText('Unable to load scene.')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to workspace' })).toHaveAttribute(
+      'href',
+      '/workspace/demo-project',
+    );
+  });
 });

--- a/src/test/scene/scene-editor-shell.test.tsx
+++ b/src/test/scene/scene-editor-shell.test.tsx
@@ -1,0 +1,131 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { SceneEditorServicePort } from '@/application/scene/scene-editor-service';
+import { SceneEditorShell } from '@/components/scene/scene-editor-shell';
+import type { Scene } from '@/domain/scene/types';
+
+const createScene = (overrides: Partial<Scene> = {}): Scene => ({
+  id: 'scene-1',
+  projectId: 'demo-project',
+  title: 'Scene 1',
+  content: 'hello world',
+  status: 'draft',
+  updatedAt: '2026-02-25T10:00:00.000Z',
+  ...overrides,
+});
+
+const createServiceDouble = (options: {
+  saveScene?: SceneEditorServicePort['saveScene'];
+  toUserErrorMessage?: SceneEditorServicePort['toUserErrorMessage'];
+}): SceneEditorServicePort => ({
+  loadScene: vi.fn().mockResolvedValue({
+    state: 'ready',
+    scene: createScene(),
+    previousSceneId: null,
+    nextSceneId: 'scene-2',
+  }),
+  listProjectScenes: vi.fn().mockResolvedValue({ state: 'ready', scenes: [] }),
+  saveScene:
+    options.saveScene ??
+    vi.fn().mockImplementation(async (input) =>
+      createScene({
+        content: input.content,
+        status: input.status,
+        updatedAt: input.updatedAt,
+      }),
+    ),
+  countWords: vi.fn().mockImplementation((content: string) => {
+    const trimmedContent = content.trim();
+    return trimmedContent ? trimmedContent.split(/\s+/).length : 0;
+  }),
+  toUserErrorMessage:
+    options.toUserErrorMessage ?? vi.fn().mockReturnValue('Unable to save scene. Retry.'),
+});
+
+describe('SceneEditorShell', () => {
+  const flushAsyncState = async (): Promise<void> => {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  };
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('updates word count when scene content changes', async () => {
+    const service = createServiceDouble({});
+
+    render(<SceneEditorShell projectId="demo-project" sceneId="scene-1" service={service} />);
+
+    await screen.findByText('Scene 1');
+    expect(screen.getByText('2 words')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Markdown content'), {
+      target: { value: 'one two three' },
+    });
+
+    expect(screen.getByText('3 words')).toBeInTheDocument();
+  });
+
+  it('sends updated status in autosave payload', async () => {
+    const saveScene = vi.fn().mockImplementation(async (input) =>
+      createScene({
+        content: input.content,
+        status: input.status,
+        updatedAt: input.updatedAt,
+      }),
+    );
+    const service = createServiceDouble({ saveScene });
+
+    render(<SceneEditorShell projectId="demo-project" sceneId="scene-1" service={service} />);
+    await screen.findByText('Scene 1');
+    vi.useFakeTimers();
+
+    fireEvent.change(screen.getByLabelText('Status'), {
+      target: { value: 'revise' },
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(800);
+    });
+    await flushAsyncState();
+    expect(saveScene).toHaveBeenCalledTimes(1);
+    expect(saveScene.mock.calls[0]?.[0].status).toBe('revise');
+  });
+
+  it('shows save error and retries manually', async () => {
+    const saveScene = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('NETWORK_ERROR'))
+      .mockImplementationOnce(async (input) =>
+        createScene({
+          content: input.content,
+          status: input.status,
+          updatedAt: input.updatedAt,
+        }),
+      );
+    const service = createServiceDouble({ saveScene });
+
+    render(<SceneEditorShell projectId="demo-project" sceneId="scene-1" service={service} />);
+    await screen.findByText('Scene 1');
+    vi.useFakeTimers();
+
+    fireEvent.change(screen.getByLabelText('Markdown content'), {
+      target: { value: 'new markdown value' },
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(800);
+    });
+    await flushAsyncState();
+    expect(screen.getByText('Unable to save scene. Retry.')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    await flushAsyncState();
+    expect(saveScene).toHaveBeenCalledTimes(2);
+    expect(screen.queryByText('Unable to save scene. Retry.')).not.toBeInTheDocument();
+  });
+});

--- a/src/test/scene/scene-editor-shell.test.tsx
+++ b/src/test/scene/scene-editor-shell.test.tsx
@@ -26,6 +26,16 @@ const createServiceDouble = (options: {
     nextSceneId: 'scene-2',
   }),
   listProjectScenes: vi.fn().mockResolvedValue({ state: 'ready', scenes: [] }),
+  createScene: vi.fn().mockImplementation(async (input) =>
+    createScene({
+      id: 'scene-created',
+      projectId: input.projectId,
+      title: input.title,
+      content: '',
+      status: 'draft',
+      updatedAt: '2026-02-25T10:00:00.000Z',
+    }),
+  ),
   saveScene:
     options.saveScene ??
     vi.fn().mockImplementation(async (input) =>

--- a/src/test/scene/schemas.test.ts
+++ b/src/test/scene/schemas.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  projectStoreSchema,
+  saveSceneInputSchema,
+  sceneSchema,
+} from '@/domain/scene/schemas';
+
+const validProjectId = '11111111-1111-4111-8111-111111111111';
+
+const createScene = (projectId: string, sceneId = 'scene-1') => ({
+  id: sceneId,
+  projectId,
+  title: 'Scene 1',
+  content: 'hello world',
+  status: 'draft' as const,
+  updatedAt: '2026-02-27T00:00:00.000Z',
+});
+
+describe('scene schemas', () => {
+  it('accepts valid uuid project ids for scene and save payload', () => {
+    expect(sceneSchema.safeParse(createScene(validProjectId)).success).toBe(true);
+    expect(
+      saveSceneInputSchema.safeParse({
+        projectId: validProjectId,
+        sceneId: 'scene-1',
+        content: 'hello world',
+        status: 'draft',
+        updatedAt: '2026-02-27T00:00:00.000Z',
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects invalid project ids for scene and save payload', () => {
+    expect(sceneSchema.safeParse(createScene('demo-project')).success).toBe(false);
+    expect(
+      saveSceneInputSchema.safeParse({
+        projectId: 'demo-project',
+        sceneId: 'scene-1',
+        content: 'hello world',
+        status: 'draft',
+        updatedAt: '2026-02-27T00:00:00.000Z',
+      }).success,
+    ).toBe(false);
+  });
+
+  it('keeps legacy workspace schema compatible while rejecting duplicate/orphan scene references', () => {
+    const duplicateOrder = projectStoreSchema.safeParse({
+      id: 'demo-project',
+      title: 'Legacy',
+      sceneOrder: ['scene-1', 'scene-1'],
+      scenes: {
+        'scene-1': createScene('demo-project', 'scene-1'),
+      },
+    });
+
+    const orphanScene = projectStoreSchema.safeParse({
+      id: 'demo-project',
+      title: 'Legacy',
+      sceneOrder: ['scene-1'],
+      scenes: {
+        'scene-1': createScene('demo-project', 'scene-1'),
+        'scene-2': createScene('demo-project', 'scene-2'),
+      },
+    });
+
+    expect(duplicateOrder.success).toBe(false);
+    expect(orphanScene.success).toBe(false);
+  });
+});

--- a/src/test/scene/use-scene-editor.test.ts
+++ b/src/test/scene/use-scene-editor.test.ts
@@ -59,6 +59,16 @@ const createServiceDouble = (options: {
     listProjectScenes: vi
       .fn()
       .mockResolvedValue({ state: 'ready', scenes: [] } satisfies ProjectScenesResult),
+    createScene: vi.fn().mockImplementation(async (input) =>
+      createScene({
+        id: 'scene-created',
+        projectId: input.projectId,
+        title: input.title,
+        content: '',
+        status: 'draft',
+        updatedAt: '2026-02-25T10:00:00.000Z',
+      }),
+    ),
     saveScene:
       options.saveScene ??
       vi.fn().mockImplementation(async (input) =>

--- a/src/test/scene/use-scene-editor.test.ts
+++ b/src/test/scene/use-scene-editor.test.ts
@@ -303,3 +303,25 @@ describe('useSceneEditor save recovery', () => {
     expect(result.current.scene?.content).toBe('second version');
   });
 });
+
+describe('useSceneEditor load state', () => {
+  it('sets a terminal error state when scene loading throws', async () => {
+    const service = createServiceDouble({});
+    const loadFailure = new Error('LOAD_FAILURE');
+    vi.mocked(service.loadScene).mockRejectedValueOnce(loadFailure);
+    vi.mocked(service.toUserErrorMessage).mockReturnValueOnce('Unable to load scene.');
+
+    const { result } = renderHook(() =>
+      useSceneEditor({
+        projectId: 'demo-project',
+        sceneId: 'scene-1',
+        service,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loadState).toBe('error');
+    });
+    expect(result.current.saveError).toBe('Unable to load scene.');
+  });
+});

--- a/src/test/scene/use-scene-editor.test.ts
+++ b/src/test/scene/use-scene-editor.test.ts
@@ -1,0 +1,295 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  ProjectScenesResult,
+  SceneEditorServicePort,
+  SceneLoadResult,
+} from '@/application/scene/scene-editor-service';
+import type { Scene } from '@/domain/scene/types';
+import { useSceneEditor } from '@/hooks/use-scene-editor';
+
+type DeferredPromise<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+};
+
+const createDeferredPromise = <T,>(): DeferredPromise<T> => {
+  let resolvePromise!: (value: T) => void;
+  let rejectPromise!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+
+  return {
+    promise,
+    resolve: resolvePromise,
+    reject: rejectPromise,
+  };
+};
+
+const createScene = (overrides: Partial<Scene> = {}): Scene => ({
+  id: 'scene-1',
+  projectId: 'demo-project',
+  title: 'Scene 1',
+  content: 'Initial content',
+  status: 'draft',
+  updatedAt: '2026-02-25T10:00:00.000Z',
+  ...overrides,
+});
+
+const createServiceDouble = (options: {
+  loadSceneResult?: SceneLoadResult;
+  saveScene?: SceneEditorServicePort['saveScene'];
+  toUserErrorMessage?: SceneEditorServicePort['toUserErrorMessage'];
+}): SceneEditorServicePort => {
+  const loadSceneResult =
+    options.loadSceneResult ??
+    ({
+      state: 'ready',
+      scene: createScene(),
+      previousSceneId: null,
+      nextSceneId: 'scene-2',
+    } satisfies SceneLoadResult);
+
+  return {
+    loadScene: vi.fn().mockResolvedValue(loadSceneResult),
+    listProjectScenes: vi
+      .fn()
+      .mockResolvedValue({ state: 'ready', scenes: [] } satisfies ProjectScenesResult),
+    saveScene:
+      options.saveScene ??
+      vi.fn().mockImplementation(async (input) =>
+        createScene({
+          content: input.content,
+          status: input.status,
+          updatedAt: input.updatedAt,
+        }),
+      ),
+    countWords: vi.fn().mockImplementation((content: string) => {
+      const trimmedContent = content.trim();
+      return trimmedContent ? trimmedContent.split(/\s+/).length : 0;
+    }),
+    toUserErrorMessage:
+      options.toUserErrorMessage ?? vi.fn().mockReturnValue('Unable to save scene. Retry.'),
+  };
+};
+
+const flushAsyncState = async (): Promise<void> => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe('useSceneEditor autosave behavior', () => {
+  it('autosaves scene content after 800ms of inactivity', async () => {
+    const saveScene = vi.fn().mockImplementation(async (input) =>
+      createScene({
+        content: input.content,
+        status: input.status,
+        updatedAt: input.updatedAt,
+      }),
+    );
+
+    const service = createServiceDouble({ saveScene });
+    const { result } = renderHook(() =>
+      useSceneEditor({
+        projectId: 'demo-project',
+        sceneId: 'scene-1',
+        service,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loadState).toBe('ready');
+    });
+
+    vi.useFakeTimers();
+
+    act(() => {
+      result.current.setContent('alpha beta');
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(799);
+    });
+    expect(saveScene).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    await flushAsyncState();
+    expect(saveScene).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not save while typing continuously before debounce threshold', async () => {
+    const saveScene = vi.fn().mockImplementation(async (input) =>
+      createScene({
+        content: input.content,
+        status: input.status,
+        updatedAt: input.updatedAt,
+      }),
+    );
+
+    const service = createServiceDouble({ saveScene });
+    const { result } = renderHook(() =>
+      useSceneEditor({
+        projectId: 'demo-project',
+        sceneId: 'scene-1',
+        service,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loadState).toBe('ready');
+    });
+
+    vi.useFakeTimers();
+
+    act(() => {
+      result.current.setContent('first draft');
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    act(() => {
+      result.current.setContent('first draft updated');
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(saveScene).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    await flushAsyncState();
+    expect(saveScene).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useSceneEditor save recovery', () => {
+  it('keeps dirty state after save failure and clears it after manual retry', async () => {
+    const saveScene = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('NETWORK_ERROR'))
+      .mockImplementationOnce(async (input) =>
+        createScene({
+          content: input.content,
+          status: input.status,
+          updatedAt: input.updatedAt,
+        }),
+      );
+
+    const service = createServiceDouble({ saveScene });
+    const { result } = renderHook(() =>
+      useSceneEditor({
+        projectId: 'demo-project',
+        sceneId: 'scene-1',
+        service,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loadState).toBe('ready');
+    });
+
+    vi.useFakeTimers();
+
+    act(() => {
+      result.current.setContent('retry me');
+    });
+    act(() => {
+      vi.advanceTimersByTime(800);
+    });
+    await flushAsyncState();
+
+    expect(result.current.saveError).toBe('Unable to save scene. Retry.');
+    expect(result.current.isDirty).toBe(true);
+
+    await act(async () => {
+      await result.current.retrySave();
+    });
+    await flushAsyncState();
+    expect(result.current.saveError).toBeNull();
+    expect(result.current.isDirty).toBe(false);
+  });
+
+  it('ignores obsolete save responses when requests resolve out of order', async () => {
+    const firstSave = createDeferredPromise<Scene>();
+    const secondSave = createDeferredPromise<Scene>();
+
+    const saveScene = vi.fn().mockImplementation(() => {
+      if (saveScene.mock.calls.length === 1) {
+        return firstSave.promise;
+      }
+
+      return secondSave.promise;
+    });
+
+    const service = createServiceDouble({ saveScene });
+    const { result } = renderHook(() =>
+      useSceneEditor({
+        projectId: 'demo-project',
+        sceneId: 'scene-1',
+        service,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.loadState).toBe('ready');
+    });
+
+    vi.useFakeTimers();
+
+    act(() => {
+      result.current.setContent('first version');
+    });
+    act(() => {
+      vi.advanceTimersByTime(800);
+    });
+
+    act(() => {
+      result.current.setContent('second version');
+    });
+    act(() => {
+      vi.advanceTimersByTime(800);
+    });
+
+    await act(async () => {
+      secondSave.resolve(
+        createScene({
+          content: 'second version',
+          updatedAt: '2026-02-25T10:01:00.000Z',
+        }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.lastSavedAt).toBe('2026-02-25T10:01:00.000Z');
+
+    await act(async () => {
+      firstSave.resolve(
+        createScene({
+          content: 'first version',
+          updatedAt: '2026-02-25T10:00:30.000Z',
+        }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.lastSavedAt).toBe('2026-02-25T10:01:00.000Z');
+    expect(result.current.scene?.content).toBe('second version');
+  });
+});


### PR DESCRIPTION
## Summary
- upgrade project storage schema to v2 so each project owns its scenes, including scene-order tracking
- refactor the local project repository to route all project/scene operations through the unified store with automatic migrations from legacy keys
- refresh the workspace and editor UI/pages so the project hub lists scenes, supports creation, and keeps navigation in sync with the new model

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes: Unify Workspace Projects and Scenes Storage

### ✨ Key Features
- **Scene Editor**: New local-first scene editor with Markdown support, featuring autosave (800ms debounce), word count tracking, and save state indicators
- **Project Hub**: Workspace upgraded to display projects with ordered scene lists, supporting scene creation and navigation
- **Scene Management**: Full CRUD operations for scenes (create, read, list, update) with status tracking (Draft, Revise, Final)
- **Automatic Migration**: Seamless v1-to-v2 storage upgrade for existing projects with legacy workspace data import

### 🔄 Storage Schema Upgrade
- **v2 Storage**: Projects now own scenes with explicit `sceneOrder` and `scenes` map, replacing flat workspace structure
- **Backward Compatible**: Automatic migration from v1 storage on first load; legacy workspace data imported into new project structure
- **Enhanced Validation**: Cross-reference checks ensure scene IDs in `sceneOrder` exist and maintain consistency

### 🎨 UI/Frontend Improvements
- Added local fallback fonts (removed problematic remote `next/font` for hydration stability)
- New scene editor shell with toolbar (title, status selector, word count, save state)
- Scene status badge component for visual feedback
- Workspace scene list with scene cards and open links
- Create scene button with loading and error states
- Consistent error handling with retry prompts

### 📦 Data & Domain Layer
- New scene domain types: `Scene`, `SceneSummary`, `ProjectScene` with validation schemas
- Refactored `LocalProjectRepository` with new public methods: `createScene()`, `getScene()`, `listScenes()`, `saveScene()`
- Centralized storage helpers for creation, parsing, migration, and recalculation workflows
- Project stats automatically recalculated after mutations

### ⚙️ Autosave & Reliability
- 800ms debounce on content changes to minimize saves
- Request tracking prevents stale save responses from overwriting newer data
- Manual retry mechanism for failed saves with user-visible error messages
- Dirty flag tracking to distinguish unsaved changes from in-flight saves

### ✅ Test Coverage
- Local repository persistence and v1→v2 migration tests
- Scene editor autosave, error recovery, and out-of-order response handling tests
- Workspace project page render and scene creation tests
- Comprehensive `useSceneEditor` hook tests with deterministic timers

### ⚠️ Breaking Changes
- Project storage schema upgraded to v2; v1 storage automatically migrated on access
- Scene page route structure: `/workspace/[projectId]/scene/[sceneId]`

### 📍 Affected Areas
- **Frontend**: Components, routing, state management hooks
- **Storage**: localStorage schema, key structure, migration logic
- **Domain**: Types, schemas, validation
- **Testing**: New test suites for repositories, components, hooks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->