### PR TITLE
Finish integrating story bible workflow with workspace pages

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,8 +25,9 @@ export default function RootLayout({
   children: ReactNode;
 }>): ReactElement {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
+        suppressHydrationWarning
         className={`${inter.variable} ${spaceGrotesk.variable} ${merriweather.variable} font-body antialiased`}
       >
         {children}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import type { ReactElement } from 'react';
 
 export default function HomePage(): ReactElement {
@@ -11,6 +12,13 @@ export default function HomePage(): ReactElement {
             Start development with <code className="rounded bg-muted px-2 py-1">npm run dev</code>.
           </p>
           <p>Next step: build the local-first writing workspace and data model.</p>
+          <p>
+            Open the Story Bible at{' '}
+            <Link className="font-semibold text-primary hover:underline" href="/workspace/demo-project">
+              /workspace/demo-project
+            </Link>
+            .
+          </p>
         </div>
       </div>
     </main>

--- a/src/app/workspace/[projectId]/bible/page.tsx
+++ b/src/app/workspace/[projectId]/bible/page.tsx
@@ -1,0 +1,13 @@
+import type { ReactElement } from 'react';
+import { BiblePageClient } from '@/components/bible/bible-page-client';
+
+interface BiblePageProps {
+  params: Promise<{
+    projectId: string;
+  }>;
+}
+
+export default async function BiblePage({ params }: BiblePageProps): Promise<ReactElement> {
+  const { projectId } = await params;
+  return <BiblePageClient key={projectId} projectId={projectId} />;
+}

--- a/src/app/workspace/[projectId]/page.tsx
+++ b/src/app/workspace/[projectId]/page.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link';
+import type { ReactElement } from 'react';
+
+interface WorkspacePageProps {
+  params: Promise<{
+    projectId: string;
+  }>;
+}
+
+export default async function WorkspacePage({ params }: WorkspacePageProps): Promise<ReactElement> {
+  const { projectId } = await params;
+
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-4xl flex-col gap-6 px-4 py-10">
+      <header className="space-y-2">
+        <p className="text-sm text-muted-foreground">Project</p>
+        <h1 className="text-3xl font-headline font-bold">{projectId}</h1>
+      </header>
+      <section className="rounded-lg border bg-card p-6 text-card-foreground">
+        <h2 className="text-xl font-headline font-semibold">Workspace</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Manage your narrative references and keep continuity aligned with the Story Bible.
+        </p>
+        <div className="mt-4">
+          <Link
+            href={`/workspace/${projectId}/bible`}
+            className="inline-flex rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground"
+          >
+            Open Story Bible
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/workspace/[projectId]/page.tsx
+++ b/src/app/workspace/[projectId]/page.tsx
@@ -165,14 +165,7 @@ function ProjectDetailContent({ project }: { project: WritingProject }): ReactEl
   );
 }
 
-export default function WorkspaceProjectPage(): ReactElement {
-  const params = useParams<{ projectId: string }>();
-  const service = useMemo(() => createProjectService(new LocalProjectRepository()), []);
-  const projectIdParam = getProjectIdParam(params.projectId);
-  const parsedProjectId = projectIdSchema.safeParse(projectIdParam);
-  const projectId = parsedProjectId.success ? parsedProjectId.data : null;
-  const { state, errorMessage, project } = useProjectDetail(projectId, service);
-
+function renderWorkspaceProjectState(result: ProjectDetailResult, projectId: string | null): ReactElement {
   if (!projectId) {
     return (
       <CenteredMessage
@@ -182,7 +175,7 @@ export default function WorkspaceProjectPage(): ReactElement {
     );
   }
 
-  if (state === 'loading') {
+  if (result.state === 'loading') {
     return (
       <main className="mx-auto flex min-h-screen w-full max-w-4xl items-center justify-center px-4">
         <p>Loading project...</p>
@@ -190,23 +183,23 @@ export default function WorkspaceProjectPage(): ReactElement {
     );
   }
 
-  if (state === 'not-found') {
+  if (result.state === 'not-found') {
     return (
       <CenteredMessage description="This project does not exist in local storage." title="Project not found" />
     );
   }
 
-  if (state === 'error') {
+  if (result.state === 'error') {
     return (
       <CenteredMessage
-        description={errorMessage ?? 'Unable to open project.'}
+        description={result.errorMessage ?? 'Unable to open project.'}
         title="Unable to open project"
         tone="destructive"
       />
     );
   }
 
-  if (!project) {
+  if (!result.project) {
     return (
       <main className="mx-auto flex min-h-screen w-full max-w-4xl items-center justify-center px-4">
         <p>Unable to load project.</p>
@@ -214,5 +207,15 @@ export default function WorkspaceProjectPage(): ReactElement {
     );
   }
 
-  return <ProjectDetailContent project={project} />;
+  return <ProjectDetailContent project={result.project} />;
+}
+
+export default function WorkspaceProjectPage(): ReactElement {
+  const params = useParams<{ projectId: string }>();
+  const service = useMemo(() => createProjectService(new LocalProjectRepository()), []);
+  const projectIdParam = getProjectIdParam(params.projectId);
+  const parsedProjectId = projectIdSchema.safeParse(projectIdParam);
+  const projectId = parsedProjectId.success ? parsedProjectId.data : null;
+  const projectDetail = useProjectDetail(projectId, service);
+  return renderWorkspaceProjectState(projectDetail, projectId);
 }

--- a/src/application/bible/bible-service.ts
+++ b/src/application/bible/bible-service.ts
@@ -1,5 +1,6 @@
 import type { BibleRepository } from '@/domain/bible/repository';
 import { bibleEntitySchema, bibleRelationshipSchema, bibleSceneLinkSchema, projectSceneSchema } from '@/domain/bible/schemas';
+import { projectIdSchema } from '@/domain/project/schemas';
 import type {
   BibleEntity,
   BibleEntityFilters,
@@ -136,11 +137,12 @@ export class BibleService {
   }
 
   private normalizeProjectId(projectId: string): string {
-    const normalizedProjectId = projectId.trim();
-    if (!normalizedProjectId) {
+    const parsedProjectId = projectIdSchema.safeParse(projectId);
+    if (!parsedProjectId.success) {
       throw new BibleValidationError('A valid projectId is required');
     }
-    return normalizedProjectId;
+
+    return parsedProjectId.data;
   }
 
   private sanitizeTags(tags: string[]): string[] {

--- a/src/application/bible/bible-service.ts
+++ b/src/application/bible/bible-service.ts
@@ -1,0 +1,277 @@
+import type { BibleRepository } from '@/domain/bible/repository';
+import { bibleEntitySchema, bibleRelationshipSchema, bibleSceneLinkSchema, projectSceneSchema } from '@/domain/bible/schemas';
+import type {
+  BibleEntity,
+  BibleEntityFilters,
+  BibleRelationship,
+  BibleRelationshipFilters,
+  BibleSceneLink,
+  BibleSceneLinkFilters,
+  ProjectScene,
+  SaveBibleEntityInput,
+  SaveBibleRelationshipInput,
+  SaveBibleSceneLinkInput,
+} from '@/domain/bible/types';
+
+export class BibleValidationError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = 'BibleValidationError';
+  }
+}
+
+const DEFAULT_SCENES = ['Scene 1', 'Scene 2', 'Scene 3'] as const;
+
+export class BibleService {
+  private readonly repository: BibleRepository;
+
+  private readonly now: () => string;
+
+  public constructor(repository: BibleRepository, nowProvider: () => string = () => new Date().toISOString()) {
+    this.repository = repository;
+    this.now = nowProvider;
+  }
+
+  public seedScenes(projectId: string): ProjectScene[] {
+    const normalizedProjectId = this.normalizeProjectId(projectId);
+    const defaultScenes = DEFAULT_SCENES.map((title, index) =>
+      projectSceneSchema.parse({
+        id: `${normalizedProjectId}-scene-${index + 1}`,
+        projectId: normalizedProjectId,
+        title,
+        order: index,
+      }),
+    );
+
+    return this.repository.bulkSeedScenes(normalizedProjectId, defaultScenes);
+  }
+
+  public listScenes(projectId: string): ProjectScene[] {
+    return this.repository.listScenes(this.normalizeProjectId(projectId));
+  }
+
+  public listEntities(projectId: string, filters?: BibleEntityFilters): BibleEntity[] {
+    return this.repository.listEntities(this.normalizeProjectId(projectId), filters);
+  }
+
+  public getEntity(projectId: string, entityId: string): BibleEntity | null {
+    return this.repository.getEntity(this.normalizeProjectId(projectId), entityId);
+  }
+
+  public saveEntity(input: SaveBibleEntityInput): BibleEntity {
+    const normalizedProjectId = this.normalizeProjectId(input.projectId);
+    const normalizedEntityId = input.entityId?.trim();
+    const existingEntity = normalizedEntityId
+      ? this.repository.getEntity(normalizedProjectId, normalizedEntityId)
+      : null;
+    const now = this.now();
+    const entity = bibleEntitySchema.parse({
+      id: existingEntity?.id ?? this.generateId(),
+      projectId: normalizedProjectId,
+      category: input.category,
+      name: input.name.trim(),
+      summary: (input.summary ?? '').trim(),
+      details: (input.details ?? '').trim(),
+      tags: this.sanitizeTags(input.tags ?? []),
+      createdAt: existingEntity?.createdAt ?? now,
+      updatedAt: now,
+    });
+
+    return this.repository.upsertEntity(entity);
+  }
+
+  public deleteEntity(projectId: string, entityId: string): void {
+    this.repository.deleteEntity(this.normalizeProjectId(projectId), entityId.trim());
+  }
+
+  public listRelationships(projectId: string, filters?: BibleRelationshipFilters): BibleRelationship[] {
+    return this.repository.listRelationships(this.normalizeProjectId(projectId), filters);
+  }
+
+  public saveRelationship(input: SaveBibleRelationshipInput): BibleRelationship {
+    const normalizedProjectId = this.normalizeProjectId(input.projectId);
+    this.ensureDistinctRelationshipEndpoints(input.fromEntityId, input.toEntityId);
+    this.ensureRelationshipProjectScope(normalizedProjectId, input.fromEntityId, input.toEntityId);
+    const relationship = this.buildRelationship(normalizedProjectId, input);
+    this.ensureNoRelationshipCycle(normalizedProjectId, relationship);
+    return this.repository.upsertRelationship(relationship);
+  }
+
+  public deleteRelationship(projectId: string, relationshipId: string): void {
+    this.repository.deleteRelationship(this.normalizeProjectId(projectId), relationshipId.trim());
+  }
+
+  public listSceneLinks(projectId: string, filters?: BibleSceneLinkFilters): BibleSceneLink[] {
+    return this.repository.listSceneLinks(this.normalizeProjectId(projectId), filters);
+  }
+
+  public saveSceneLink(input: SaveBibleSceneLinkInput): BibleSceneLink {
+    const normalizedProjectId = this.normalizeProjectId(input.projectId);
+    const entity = this.requireEntity(normalizedProjectId, input.entityId);
+    const scene = this.requireScene(normalizedProjectId, input.sceneId);
+    if (entity.projectId !== normalizedProjectId || scene.projectId !== normalizedProjectId) {
+      throw new BibleValidationError('Scene links cannot cross project boundaries');
+    }
+
+    const sceneLinkId = input.sceneLinkId?.trim();
+    const existingSceneLink = sceneLinkId
+      ? this.repository.listSceneLinks(normalizedProjectId).find((sceneLink) => sceneLink.id === sceneLinkId)
+      : null;
+    const now = this.now();
+    const sceneLink = bibleSceneLinkSchema.parse({
+      id: existingSceneLink?.id ?? this.generateId(),
+      projectId: normalizedProjectId,
+      sceneId: input.sceneId,
+      entityId: input.entityId,
+      notes: (input.notes ?? '').trim(),
+      createdAt: existingSceneLink?.createdAt ?? now,
+      updatedAt: now,
+    });
+
+    return this.repository.upsertSceneLink(sceneLink);
+  }
+
+  public deleteSceneLink(projectId: string, sceneLinkId: string): void {
+    this.repository.deleteSceneLink(this.normalizeProjectId(projectId), sceneLinkId.trim());
+  }
+
+  private normalizeProjectId(projectId: string): string {
+    const normalizedProjectId = projectId.trim();
+    if (!normalizedProjectId) {
+      throw new BibleValidationError('A valid projectId is required');
+    }
+    return normalizedProjectId;
+  }
+
+  private sanitizeTags(tags: string[]): string[] {
+    const uniqueTags = Array.from(new Set(tags.map((tag) => tag.trim()).filter(Boolean)));
+    if (uniqueTags.length > 12) {
+      throw new BibleValidationError('A maximum of 12 tags is allowed');
+    }
+    return uniqueTags;
+  }
+
+  private requireEntity(projectId: string, entityId: string): BibleEntity {
+    const entity = this.repository.getEntity(projectId, entityId.trim());
+    if (!entity) {
+      throw new BibleValidationError(`Entity not found: ${entityId}`);
+    }
+    return entity;
+  }
+
+  private requireScene(projectId: string, sceneId: string): ProjectScene {
+    const scene = this.repository.listScenes(projectId).find((projectScene) => projectScene.id === sceneId);
+    if (!scene) {
+      throw new BibleValidationError(`Scene not found: ${sceneId}`);
+    }
+    return scene;
+  }
+
+  private wouldCreateCycle(candidate: BibleRelationship, relationships: BibleRelationship[]): boolean {
+    const otherRelationships = relationships.filter((relationship) => relationship.id !== candidate.id);
+    const adjacencyMap = new Map<string, Set<string>>();
+
+    for (const relationship of otherRelationships) {
+      const neighbors = adjacencyMap.get(relationship.fromEntityId) ?? new Set<string>();
+      neighbors.add(relationship.toEntityId);
+      adjacencyMap.set(relationship.fromEntityId, neighbors);
+    }
+
+    const candidateNeighbors = adjacencyMap.get(candidate.fromEntityId) ?? new Set<string>();
+    candidateNeighbors.add(candidate.toEntityId);
+    adjacencyMap.set(candidate.fromEntityId, candidateNeighbors);
+    return this.hasPath(adjacencyMap, candidate.toEntityId, candidate.fromEntityId);
+  }
+
+  private hasPath(adjacencyMap: Map<string, Set<string>>, sourceId: string, targetId: string): boolean {
+    const visited = new Set<string>();
+    const stack = [sourceId];
+
+    while (stack.length > 0) {
+      const currentEntityId = stack.pop();
+      if (!currentEntityId || visited.has(currentEntityId)) {
+        continue;
+      }
+      if (currentEntityId === targetId) {
+        return true;
+      }
+
+      visited.add(currentEntityId);
+      const neighbors = adjacencyMap.get(currentEntityId);
+      if (!neighbors) {
+        continue;
+      }
+
+      for (const neighbor of neighbors) {
+        if (!visited.has(neighbor)) {
+          stack.push(neighbor);
+        }
+      }
+    }
+
+    return false;
+  }
+
+  private ensureDistinctRelationshipEndpoints(fromEntityId: string, toEntityId: string): void {
+    if (fromEntityId === toEntityId) {
+      throw new BibleValidationError('Self references are not allowed');
+    }
+  }
+
+  private ensureRelationshipProjectScope(projectId: string, fromEntityId: string, toEntityId: string): void {
+    const fromEntity = this.requireEntity(projectId, fromEntityId);
+    const toEntity = this.requireEntity(projectId, toEntityId);
+    if (fromEntity.projectId !== projectId || toEntity.projectId !== projectId) {
+      throw new BibleValidationError('Relationships cannot cross project boundaries');
+    }
+  }
+
+  private buildRelationship(
+    projectId: string,
+    input: SaveBibleRelationshipInput,
+  ): BibleRelationship {
+    const existingRelationship = this.findRelationship(projectId, input.relationshipId);
+    const now = this.now();
+
+    return bibleRelationshipSchema.parse({
+      id: existingRelationship?.id ?? this.generateId(),
+      projectId,
+      type: input.type,
+      fromEntityId: input.fromEntityId,
+      toEntityId: input.toEntityId,
+      notes: (input.notes ?? '').trim(),
+      createdAt: existingRelationship?.createdAt ?? now,
+      updatedAt: now,
+    });
+  }
+
+  private findRelationship(projectId: string, relationshipId?: string): BibleRelationship | null {
+    const normalizedRelationshipId = relationshipId?.trim();
+    if (!normalizedRelationshipId) {
+      return null;
+    }
+
+    return (
+      this.repository
+        .listRelationships(projectId)
+        .find((relationship) => relationship.id === normalizedRelationshipId) ?? null
+    );
+  }
+
+  private ensureNoRelationshipCycle(projectId: string, relationship: BibleRelationship): void {
+    const allRelationships = this.repository.listRelationships(projectId);
+    if (this.wouldCreateCycle(relationship, allRelationships)) {
+      throw new BibleValidationError('The relationship introduces a directional cycle');
+    }
+  }
+
+  private generateId(): string {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+
+    const randomPart = Math.random().toString(36).slice(2, 10);
+    const timePart = Date.now().toString(36);
+    return `${timePart}-${randomPart}`;
+  }
+}

--- a/src/components/bible/bible-editor.tsx
+++ b/src/components/bible/bible-editor.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { type FormEvent, type ReactElement, useState } from 'react';
-import type { BibleEntity, BibleEntityCategory, SaveBibleEntityInput } from '@/domain/bible/types';
 import { BIBLE_ENTITY_CATEGORIES } from '@/domain/bible/types';
+import type { BibleEntity, BibleEntityCategory, SaveBibleEntityInput } from '@/domain/bible/types';
 
 interface BibleEditorProps {
   projectId: string;
@@ -10,6 +10,28 @@ interface BibleEditorProps {
   errorMessage: string | null;
   onSave: (input: SaveBibleEntityInput) => void | Promise<void>;
   onDelete: (entityId: string) => void | Promise<void>;
+}
+
+interface EntityFormState {
+  category: BibleEntityCategory;
+  name: string;
+  summary: string;
+  details: string;
+  tagsInputValue: string;
+}
+
+interface EntityFormProps {
+  state: EntityFormState;
+  onCategoryChange: (value: BibleEntityCategory) => void;
+  onNameChange: (value: string) => void;
+  onSummaryChange: (value: string) => void;
+  onDetailsChange: (value: string) => void;
+  onTagsInputValueChange: (value: string) => void;
+}
+
+interface EditorActionsHandlers {
+  handleSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  handleDelete: () => void;
 }
 
 function toTagInputValue(tags: string[]): string {
@@ -22,14 +44,6 @@ function parseTagInputValue(value: string): string[] {
     .map((tag) => tag.trim())
     .filter(Boolean);
   return Array.from(new Set(tags));
-}
-
-interface EntityFormState {
-  category: BibleEntityCategory;
-  name: string;
-  summary: string;
-  details: string;
-  tagsInputValue: string;
 }
 
 function getInitialFormState(selectedEntity: BibleEntity | null): EntityFormState {
@@ -52,13 +66,14 @@ function getInitialFormState(selectedEntity: BibleEntity | null): EntityFormStat
   };
 }
 
-export function BibleEditor({
-  projectId,
-  selectedEntity,
-  errorMessage,
-  onSave,
-  onDelete,
-}: BibleEditorProps): ReactElement {
+function useEntityFormState(selectedEntity: BibleEntity | null): {
+  state: EntityFormState;
+  setCategory: (value: BibleEntityCategory) => void;
+  setName: (value: string) => void;
+  setSummary: (value: string) => void;
+  setDetails: (value: string) => void;
+  setTagsInputValue: (value: string) => void;
+} {
   const initialFormState = getInitialFormState(selectedEntity);
   const [category, setCategory] = useState<BibleEntityCategory>(initialFormState.category);
   const [name, setName] = useState(initialFormState.name);
@@ -66,16 +81,192 @@ export function BibleEditor({
   const [details, setDetails] = useState(initialFormState.details);
   const [tagsInputValue, setTagsInputValue] = useState(initialFormState.tagsInputValue);
 
+  return {
+    state: { category, name, summary, details, tagsInputValue },
+    setCategory,
+    setName,
+    setSummary,
+    setDetails,
+    setTagsInputValue,
+  };
+}
+
+function EditorHeader({ hasSelectedEntity }: { hasSelectedEntity: boolean }): ReactElement {
+  return <h2 className="text-lg font-bold">{hasSelectedEntity ? 'Edit entity' : 'New entity'}</h2>;
+}
+
+function EditorError({ message }: { message: string | null }): ReactElement | null {
+  if (!message) {
+    return null;
+  }
+
+  return <p className="rounded-md bg-destructive/10 p-2 text-sm text-destructive">{message}</p>;
+}
+
+function EntityFormFields({
+  state,
+  onCategoryChange,
+  onNameChange,
+  onSummaryChange,
+  onDetailsChange,
+  onTagsInputValueChange,
+}: EntityFormProps): ReactElement {
+  return (
+    <>
+      <NameField value={state.name} onChange={onNameChange} />
+      <CategoryField value={state.category} onChange={onCategoryChange} />
+      <SummaryField value={state.summary} onChange={onSummaryChange} />
+      <DetailsField value={state.details} onChange={onDetailsChange} />
+      <TagsField value={state.tagsInputValue} onChange={onTagsInputValueChange} />
+    </>
+  );
+}
+
+function NameField({ value, onChange }: { value: string; onChange: (value: string) => void }): ReactElement {
+  return (
+    <div className="space-y-2">
+      <label className="text-sm font-semibold" htmlFor="entity-name">
+        Name
+      </label>
+      <input
+        id="entity-name"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+        required
+        maxLength={120}
+      />
+    </div>
+  );
+}
+
+function CategoryField({
+  value,
+  onChange,
+}: {
+  value: BibleEntityCategory;
+  onChange: (value: BibleEntityCategory) => void;
+}): ReactElement {
+  return (
+    <div className="space-y-2">
+      <label className="text-sm font-semibold" htmlFor="entity-category">
+        Category
+      </label>
+      <select
+        id="entity-category"
+        value={value}
+        onChange={(event) => onChange(event.target.value as BibleEntityCategory)}
+        className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+      >
+        {BIBLE_ENTITY_CATEGORIES.map((categoryOption) => (
+          <option value={categoryOption} key={categoryOption}>
+            {categoryOption}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function SummaryField({ value, onChange }: { value: string; onChange: (value: string) => void }): ReactElement {
+  return (
+    <div className="space-y-2">
+      <label className="text-sm font-semibold" htmlFor="entity-summary">
+        Summary
+      </label>
+      <textarea
+        id="entity-summary"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="min-h-20 w-full rounded-md border bg-background px-3 py-2 text-sm"
+        maxLength={280}
+      />
+    </div>
+  );
+}
+
+function DetailsField({ value, onChange }: { value: string; onChange: (value: string) => void }): ReactElement {
+  return (
+    <div className="space-y-2">
+      <label className="text-sm font-semibold" htmlFor="entity-details">
+        Details
+      </label>
+      <textarea
+        id="entity-details"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="min-h-28 w-full rounded-md border bg-background px-3 py-2 text-sm"
+        maxLength={5000}
+      />
+    </div>
+  );
+}
+
+function TagsField({ value, onChange }: { value: string; onChange: (value: string) => void }): ReactElement {
+  return (
+    <div className="space-y-2">
+      <label className="text-sm font-semibold" htmlFor="entity-tags">
+        Tags
+      </label>
+      <input
+        id="entity-tags"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+        placeholder="comma, separated, tags"
+      />
+    </div>
+  );
+}
+
+function EditorActions({
+  selectedEntity,
+  onDelete,
+}: {
+  selectedEntity: BibleEntity | null;
+  onDelete: () => void;
+}): ReactElement {
+  return (
+    <div className="flex gap-2">
+      <button type="submit" className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground">
+        Save entity
+      </button>
+      {selectedEntity ? (
+        <button
+          type="button"
+          onClick={onDelete}
+          className="rounded-md border border-destructive px-4 py-2 text-sm font-semibold text-destructive"
+        >
+          Delete entity
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function useEditorActions({
+  projectId,
+  selectedEntity,
+  state,
+  onSave,
+  onDelete,
+}: {
+  projectId: string;
+  selectedEntity: BibleEntity | null;
+  state: EntityFormState;
+  onSave: (input: SaveBibleEntityInput) => void | Promise<void>;
+  onDelete: (entityId: string) => void | Promise<void>;
+}): EditorActionsHandlers {
   const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
     event.preventDefault();
     void onSave({
       projectId,
       entityId: selectedEntity?.id,
-      category,
-      name,
-      summary,
-      details,
-      tags: parseTagInputValue(tagsInputValue),
+      category: state.category,
+      name: state.name,
+      summary: state.summary,
+      details: state.details,
+      tags: parseTagInputValue(state.tagsInputValue),
     });
   };
 
@@ -86,91 +277,40 @@ export function BibleEditor({
     void onDelete(selectedEntity.id);
   };
 
+  return { handleSubmit, handleDelete };
+}
+
+export function BibleEditor({
+  projectId,
+  selectedEntity,
+  errorMessage,
+  onSave,
+  onDelete,
+}: BibleEditorProps): ReactElement {
+  const { state, setCategory, setName, setSummary, setDetails, setTagsInputValue } =
+    useEntityFormState(selectedEntity);
+  const { handleSubmit, handleDelete } = useEditorActions({
+    projectId,
+    selectedEntity,
+    state,
+    onSave,
+    onDelete,
+  });
+
   return (
     <section className="space-y-4 rounded-lg border bg-card p-4 text-card-foreground">
-      <h2 className="text-lg font-bold">{selectedEntity ? 'Edit entity' : 'New entity'}</h2>
-      {errorMessage ? <p className="rounded-md bg-destructive/10 p-2 text-sm text-destructive">{errorMessage}</p> : null}
+      <EditorHeader hasSelectedEntity={Boolean(selectedEntity)} />
+      <EditorError message={errorMessage} />
       <form className="space-y-3" onSubmit={handleSubmit}>
-        <div className="space-y-2">
-          <label className="text-sm font-semibold" htmlFor="entity-name">
-            Name
-          </label>
-          <input
-            id="entity-name"
-            value={name}
-            onChange={(event) => setName(event.target.value)}
-            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
-            required
-            maxLength={120}
-          />
-        </div>
-        <div className="space-y-2">
-          <label className="text-sm font-semibold" htmlFor="entity-category">
-            Category
-          </label>
-          <select
-            id="entity-category"
-            value={category}
-            onChange={(event) => setCategory(event.target.value as BibleEntityCategory)}
-            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
-          >
-            {BIBLE_ENTITY_CATEGORIES.map((categoryOption) => (
-              <option value={categoryOption} key={categoryOption}>
-                {categoryOption}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div className="space-y-2">
-          <label className="text-sm font-semibold" htmlFor="entity-summary">
-            Summary
-          </label>
-          <textarea
-            id="entity-summary"
-            value={summary}
-            onChange={(event) => setSummary(event.target.value)}
-            className="min-h-20 w-full rounded-md border bg-background px-3 py-2 text-sm"
-            maxLength={280}
-          />
-        </div>
-        <div className="space-y-2">
-          <label className="text-sm font-semibold" htmlFor="entity-details">
-            Details
-          </label>
-          <textarea
-            id="entity-details"
-            value={details}
-            onChange={(event) => setDetails(event.target.value)}
-            className="min-h-28 w-full rounded-md border bg-background px-3 py-2 text-sm"
-            maxLength={5000}
-          />
-        </div>
-        <div className="space-y-2">
-          <label className="text-sm font-semibold" htmlFor="entity-tags">
-            Tags
-          </label>
-          <input
-            id="entity-tags"
-            value={tagsInputValue}
-            onChange={(event) => setTagsInputValue(event.target.value)}
-            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
-            placeholder="comma, separated, tags"
-          />
-        </div>
-        <div className="flex gap-2">
-          <button type="submit" className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground">
-            Save entity
-          </button>
-          {selectedEntity ? (
-            <button
-              type="button"
-              onClick={handleDelete}
-              className="rounded-md border border-destructive px-4 py-2 text-sm font-semibold text-destructive"
-            >
-              Delete entity
-            </button>
-          ) : null}
-        </div>
+        <EntityFormFields
+          state={state}
+          onCategoryChange={setCategory}
+          onNameChange={setName}
+          onSummaryChange={setSummary}
+          onDetailsChange={setDetails}
+          onTagsInputValueChange={setTagsInputValue}
+        />
+        <EditorActions selectedEntity={selectedEntity} onDelete={handleDelete} />
       </form>
     </section>
   );

--- a/src/components/bible/bible-editor.tsx
+++ b/src/components/bible/bible-editor.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { type FormEvent, type ReactElement, useState } from 'react';
+import type { BibleEntity, BibleEntityCategory, SaveBibleEntityInput } from '@/domain/bible/types';
+import { BIBLE_ENTITY_CATEGORIES } from '@/domain/bible/types';
+
+interface BibleEditorProps {
+  projectId: string;
+  selectedEntity: BibleEntity | null;
+  errorMessage: string | null;
+  onSave: (input: SaveBibleEntityInput) => void | Promise<void>;
+  onDelete: (entityId: string) => void | Promise<void>;
+}
+
+function toTagInputValue(tags: string[]): string {
+  return tags.join(', ');
+}
+
+function parseTagInputValue(value: string): string[] {
+  const tags = value
+    .split(',')
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+  return Array.from(new Set(tags));
+}
+
+interface EntityFormState {
+  category: BibleEntityCategory;
+  name: string;
+  summary: string;
+  details: string;
+  tagsInputValue: string;
+}
+
+function getInitialFormState(selectedEntity: BibleEntity | null): EntityFormState {
+  if (!selectedEntity) {
+    return {
+      category: 'character',
+      name: '',
+      summary: '',
+      details: '',
+      tagsInputValue: '',
+    };
+  }
+
+  return {
+    category: selectedEntity.category,
+    name: selectedEntity.name,
+    summary: selectedEntity.summary,
+    details: selectedEntity.details,
+    tagsInputValue: toTagInputValue(selectedEntity.tags),
+  };
+}
+
+export function BibleEditor({
+  projectId,
+  selectedEntity,
+  errorMessage,
+  onSave,
+  onDelete,
+}: BibleEditorProps): ReactElement {
+  const initialFormState = getInitialFormState(selectedEntity);
+  const [category, setCategory] = useState<BibleEntityCategory>(initialFormState.category);
+  const [name, setName] = useState(initialFormState.name);
+  const [summary, setSummary] = useState(initialFormState.summary);
+  const [details, setDetails] = useState(initialFormState.details);
+  const [tagsInputValue, setTagsInputValue] = useState(initialFormState.tagsInputValue);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    void onSave({
+      projectId,
+      entityId: selectedEntity?.id,
+      category,
+      name,
+      summary,
+      details,
+      tags: parseTagInputValue(tagsInputValue),
+    });
+  };
+
+  const handleDelete = (): void => {
+    if (!selectedEntity) {
+      return;
+    }
+    void onDelete(selectedEntity.id);
+  };
+
+  return (
+    <section className="space-y-4 rounded-lg border bg-card p-4 text-card-foreground">
+      <h2 className="text-lg font-bold">{selectedEntity ? 'Edit entity' : 'New entity'}</h2>
+      {errorMessage ? <p className="rounded-md bg-destructive/10 p-2 text-sm text-destructive">{errorMessage}</p> : null}
+      <form className="space-y-3" onSubmit={handleSubmit}>
+        <div className="space-y-2">
+          <label className="text-sm font-semibold" htmlFor="entity-name">
+            Name
+          </label>
+          <input
+            id="entity-name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+            required
+            maxLength={120}
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm font-semibold" htmlFor="entity-category">
+            Category
+          </label>
+          <select
+            id="entity-category"
+            value={category}
+            onChange={(event) => setCategory(event.target.value as BibleEntityCategory)}
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+          >
+            {BIBLE_ENTITY_CATEGORIES.map((categoryOption) => (
+              <option value={categoryOption} key={categoryOption}>
+                {categoryOption}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm font-semibold" htmlFor="entity-summary">
+            Summary
+          </label>
+          <textarea
+            id="entity-summary"
+            value={summary}
+            onChange={(event) => setSummary(event.target.value)}
+            className="min-h-20 w-full rounded-md border bg-background px-3 py-2 text-sm"
+            maxLength={280}
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm font-semibold" htmlFor="entity-details">
+            Details
+          </label>
+          <textarea
+            id="entity-details"
+            value={details}
+            onChange={(event) => setDetails(event.target.value)}
+            className="min-h-28 w-full rounded-md border bg-background px-3 py-2 text-sm"
+            maxLength={5000}
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm font-semibold" htmlFor="entity-tags">
+            Tags
+          </label>
+          <input
+            id="entity-tags"
+            value={tagsInputValue}
+            onChange={(event) => setTagsInputValue(event.target.value)}
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+            placeholder="comma, separated, tags"
+          />
+        </div>
+        <div className="flex gap-2">
+          <button type="submit" className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground">
+            Save entity
+          </button>
+          {selectedEntity ? (
+            <button
+              type="button"
+              onClick={handleDelete}
+              className="rounded-md border border-destructive px-4 py-2 text-sm font-semibold text-destructive"
+            >
+              Delete entity
+            </button>
+          ) : null}
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/src/components/bible/bible-list.tsx
+++ b/src/components/bible/bible-list.tsx
@@ -1,0 +1,102 @@
+import type { ChangeEvent, ReactElement } from 'react';
+import type { BibleEntity, BibleEntityCategory } from '@/domain/bible/types';
+import { BIBLE_ENTITY_CATEGORIES } from '@/domain/bible/types';
+
+interface BibleListProps {
+  entities: BibleEntity[];
+  selectedEntityId: string | null;
+  searchValue: string;
+  categoryFilter: BibleEntityCategory | 'all';
+  onSearchChange: (value: string) => void;
+  onCategoryFilterChange: (value: BibleEntityCategory | 'all') => void;
+  onSelectEntity: (entityId: string) => void;
+  onCreateEntity: () => void;
+}
+
+function handleCategoryValue(value: string): BibleEntityCategory | 'all' {
+  if (value === 'all') {
+    return 'all';
+  }
+  if (BIBLE_ENTITY_CATEGORIES.includes(value as BibleEntityCategory)) {
+    return value as BibleEntityCategory;
+  }
+  return 'all';
+}
+
+export function BibleList({
+  entities,
+  selectedEntityId,
+  searchValue,
+  categoryFilter,
+  onSearchChange,
+  onCategoryFilterChange,
+  onSelectEntity,
+  onCreateEntity,
+}: BibleListProps): ReactElement {
+  const onSearchInputChange = (event: ChangeEvent<HTMLInputElement>): void => {
+    onSearchChange(event.target.value);
+  };
+
+  const onCategoryChange = (event: ChangeEvent<HTMLSelectElement>): void => {
+    onCategoryFilterChange(handleCategoryValue(event.target.value));
+  };
+
+  return (
+    <section className="space-y-4 rounded-lg border bg-card p-4 text-card-foreground">
+      <div className="space-y-2">
+        <label className="text-sm font-semibold" htmlFor="bible-search">
+          Search
+        </label>
+        <input
+          id="bible-search"
+          value={searchValue}
+          onChange={onSearchInputChange}
+          placeholder="Search entities"
+          className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+        />
+      </div>
+      <div className="space-y-2">
+        <label className="text-sm font-semibold" htmlFor="bible-category-filter">
+          Category
+        </label>
+        <select
+          id="bible-category-filter"
+          value={categoryFilter}
+          onChange={onCategoryChange}
+          className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+        >
+          <option value="all">All</option>
+          {BIBLE_ENTITY_CATEGORIES.map((category) => (
+            <option value={category} key={category}>
+              {category}
+            </option>
+          ))}
+        </select>
+      </div>
+      <button
+        type="button"
+        className="w-full rounded-md bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground"
+        onClick={onCreateEntity}
+      >
+        New entity
+      </button>
+      <ul className="space-y-2">
+        {entities.map((entity) => (
+          <li key={entity.id}>
+            <button
+              type="button"
+              onClick={() => onSelectEntity(entity.id)}
+              className={`w-full rounded-md border px-3 py-2 text-left ${
+                selectedEntityId === entity.id ? 'border-primary' : 'border-border'
+              }`}
+            >
+              <p className="font-semibold">{entity.name}</p>
+              <p className="text-xs text-muted-foreground">{entity.category}</p>
+            </button>
+          </li>
+        ))}
+      </ul>
+      {entities.length === 0 ? <p className="text-sm text-muted-foreground">No entities found.</p> : null}
+    </section>
+  );
+}

--- a/src/components/bible/bible-list.tsx
+++ b/src/components/bible/bible-list.tsx
@@ -23,63 +23,84 @@ function handleCategoryValue(value: string): BibleEntityCategory | 'all' {
   return 'all';
 }
 
-export function BibleList({
-  entities,
-  selectedEntityId,
+function BibleSearchField({
   searchValue,
-  categoryFilter,
   onSearchChange,
-  onCategoryFilterChange,
-  onSelectEntity,
-  onCreateEntity,
-}: BibleListProps): ReactElement {
+}: Pick<BibleListProps, 'searchValue' | 'onSearchChange'>): ReactElement {
   const onSearchInputChange = (event: ChangeEvent<HTMLInputElement>): void => {
     onSearchChange(event.target.value);
   };
 
+  return (
+    <div className="space-y-2">
+      <label className="text-sm font-semibold" htmlFor="bible-search">
+        Search
+      </label>
+      <input
+        id="bible-search"
+        value={searchValue}
+        onChange={onSearchInputChange}
+        placeholder="Search entities"
+        className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+      />
+    </div>
+  );
+}
+
+function BibleCategoryField({
+  categoryFilter,
+  onCategoryFilterChange,
+}: Pick<BibleListProps, 'categoryFilter' | 'onCategoryFilterChange'>): ReactElement {
   const onCategoryChange = (event: ChangeEvent<HTMLSelectElement>): void => {
     onCategoryFilterChange(handleCategoryValue(event.target.value));
   };
 
   return (
-    <section className="space-y-4 rounded-lg border bg-card p-4 text-card-foreground">
-      <div className="space-y-2">
-        <label className="text-sm font-semibold" htmlFor="bible-search">
-          Search
-        </label>
-        <input
-          id="bible-search"
-          value={searchValue}
-          onChange={onSearchInputChange}
-          placeholder="Search entities"
-          className="w-full rounded-md border bg-background px-3 py-2 text-sm"
-        />
-      </div>
-      <div className="space-y-2">
-        <label className="text-sm font-semibold" htmlFor="bible-category-filter">
-          Category
-        </label>
-        <select
-          id="bible-category-filter"
-          value={categoryFilter}
-          onChange={onCategoryChange}
-          className="w-full rounded-md border bg-background px-3 py-2 text-sm"
-        >
-          <option value="all">All</option>
-          {BIBLE_ENTITY_CATEGORIES.map((category) => (
-            <option value={category} key={category}>
-              {category}
-            </option>
-          ))}
-        </select>
-      </div>
-      <button
-        type="button"
-        className="w-full rounded-md bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground"
-        onClick={onCreateEntity}
+    <div className="space-y-2">
+      <label className="text-sm font-semibold" htmlFor="bible-category-filter">
+        Category
+      </label>
+      <select
+        id="bible-category-filter"
+        value={categoryFilter}
+        onChange={onCategoryChange}
+        className="w-full rounded-md border bg-background px-3 py-2 text-sm"
       >
-        New entity
-      </button>
+        <option value="all">All</option>
+        {BIBLE_ENTITY_CATEGORIES.map((category) => (
+          <option value={category} key={category}>
+            {category}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function BibleListFilters({
+  searchValue,
+  categoryFilter,
+  onSearchChange,
+  onCategoryFilterChange,
+}: Pick<BibleListProps, 'searchValue' | 'categoryFilter' | 'onSearchChange' | 'onCategoryFilterChange'>): ReactElement {
+  return (
+    <>
+      <BibleSearchField searchValue={searchValue} onSearchChange={onSearchChange} />
+      <BibleCategoryField
+        categoryFilter={categoryFilter}
+        onCategoryFilterChange={onCategoryFilterChange}
+      />
+    </>
+  );
+}
+
+function BibleEntityItems({
+  entities,
+  selectedEntityId,
+  onSelectEntity,
+}: Pick<BibleListProps, 'entities' | 'selectedEntityId' | 'onSelectEntity'>): ReactElement {
+  return (
+    <>
       <ul className="space-y-2">
         {entities.map((entity) => (
           <li key={entity.id}>
@@ -97,6 +118,31 @@ export function BibleList({
         ))}
       </ul>
       {entities.length === 0 ? <p className="text-sm text-muted-foreground">No entities found.</p> : null}
+    </>
+  );
+}
+
+export function BibleList(props: BibleListProps): ReactElement {
+  return (
+    <section className="space-y-4 rounded-lg border bg-card p-4 text-card-foreground">
+      <BibleListFilters
+        searchValue={props.searchValue}
+        categoryFilter={props.categoryFilter}
+        onSearchChange={props.onSearchChange}
+        onCategoryFilterChange={props.onCategoryFilterChange}
+      />
+      <button
+        type="button"
+        className="w-full rounded-md bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground"
+        onClick={props.onCreateEntity}
+      >
+        New entity
+      </button>
+      <BibleEntityItems
+        entities={props.entities}
+        selectedEntityId={props.selectedEntityId}
+        onSelectEntity={props.onSelectEntity}
+      />
     </section>
   );
 }

--- a/src/components/bible/bible-page-client.tsx
+++ b/src/components/bible/bible-page-client.tsx
@@ -105,6 +105,7 @@ function CenteredMessage({
 }
 
 function useProjectAccess(projectId: string): ProjectAccess {
+  const parsedProjectId = useMemo(() => projectIdSchema.safeParse(projectId), [projectId]);
   const projectService = useMemo(
     () => createProjectService(new LocalProjectRepository()),
     [],
@@ -114,11 +115,7 @@ function useProjectAccess(projectId: string): ProjectAccess {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   useEffect(() => {
-    const parsedProjectId = projectIdSchema.safeParse(projectId);
     if (!parsedProjectId.success) {
-      setProject(null);
-      setErrorMessage(null);
-      setState('invalid');
       return undefined;
     }
 
@@ -158,17 +155,23 @@ function useProjectAccess(projectId: string): ProjectAccess {
     return () => {
       isActive = false;
     };
-  }, [projectId, projectService]);
+  }, [parsedProjectId, projectService]);
+
+  if (!parsedProjectId.success) {
+    return { state: 'invalid', errorMessage: null, project: null };
+  }
 
   return { state, errorMessage, project };
 }
 
-function createBibleService(): BibleService | null {
+function createBibleService(projectId: string): BibleService | null {
   if (typeof window === 'undefined') {
     return null;
   }
 
-  return new BibleService(new LocalBibleRepository(window.localStorage));
+  const service = new BibleService(new LocalBibleRepository(window.localStorage));
+  service.seedScenes(projectId);
+  return service;
 }
 
 export function BiblePageClient({ projectId }: BiblePageClientProps): ReactElement {
@@ -180,8 +183,11 @@ export function BiblePageClient({ projectId }: BiblePageClientProps): ReactEleme
   const [errors, setErrors] = useState<ErrorState>(EMPTY_ERRORS);
   const [, setDataRevision] = useState(0);
   const bibleService = useMemo(
-    () => (projectAccess.state === 'ready' ? createBibleService() : null),
-    [projectAccess.state],
+    () =>
+      projectAccess.state === 'ready' && projectAccess.project
+        ? createBibleService(projectAccess.project.id)
+        : null,
+    [projectAccess.project, projectAccess.state],
   );
   const entityFilters = useMemo(
     () => ({
@@ -190,15 +196,6 @@ export function BiblePageClient({ projectId }: BiblePageClientProps): ReactEleme
     }),
     [searchValue, categoryFilter],
   );
-
-  useEffect(() => {
-    if (!bibleService || !projectAccess.project) {
-      return;
-    }
-
-    bibleService.seedScenes(projectAccess.project.id);
-    setDataRevision((currentRevision) => currentRevision + 1);
-  }, [bibleService, projectAccess.project]);
 
   const data: BibleDataSnapshot =
     bibleService && projectAccess.project

--- a/src/components/bible/bible-page-client.tsx
+++ b/src/components/bible/bible-page-client.tsx
@@ -1,85 +1,19 @@
 'use client';
 
 import Link from 'next/link';
-import { type ReactElement, useEffect, useMemo, useState } from 'react';
-import { createProjectService } from '@/application/project/project-service';
-import { BibleService, BibleValidationError } from '@/application/bible/bible-service';
+import type { ReactElement } from 'react';
 import { BibleEditor } from '@/components/bible/bible-editor';
+import {
+  type BiblePageController,
+  useBiblePageController,
+} from '@/components/bible/bible-page-controller';
 import { BibleList } from '@/components/bible/bible-list';
 import { RelationshipEditor } from '@/components/bible/relationship-editor';
 import { SceneLinks } from '@/components/bible/scene-links';
-import { LocalBibleRepository } from '@/data/bible/local-bible-repository';
-import { LocalProjectRepository } from '@/data/project/local-project-repository';
-import { projectIdSchema } from '@/domain/project/schemas';
 import type { WritingProject } from '@/domain/project/types';
-import type {
-  BibleEntityCategory,
-  SaveBibleEntityInput,
-  SaveBibleRelationshipInput,
-  SaveBibleSceneLinkInput,
-} from '@/domain/bible/types';
 
 interface BiblePageClientProps {
   projectId: string;
-}
-
-type ProjectAccessState = 'loading' | 'invalid' | 'not-found' | 'error' | 'ready';
-
-interface ProjectAccess {
-  state: ProjectAccessState;
-  errorMessage: string | null;
-  project: WritingProject | null;
-}
-
-interface BibleDataSnapshot {
-  entities: ReturnType<BibleService['listEntities']>;
-  relationships: ReturnType<BibleService['listRelationships']>;
-  sceneLinks: ReturnType<BibleService['listSceneLinks']>;
-  scenes: ReturnType<BibleService['listScenes']>;
-}
-
-interface ErrorState {
-  entity: string | null;
-  relationship: string | null;
-  sceneLink: string | null;
-}
-
-const EMPTY_BIBLE_DATA: BibleDataSnapshot = {
-  entities: [],
-  relationships: [],
-  sceneLinks: [],
-  scenes: [],
-};
-
-const EMPTY_ERRORS: ErrorState = {
-  entity: null,
-  relationship: null,
-  sceneLink: null,
-};
-
-function readErrorMessage(error: unknown, fallbackMessage: string): string {
-  if (error instanceof Error && error.message.trim().length > 0) {
-    return error.message;
-  }
-
-  return fallbackMessage;
-}
-
-function toBibleErrorMessage(error: unknown): string {
-  if (error instanceof BibleValidationError) {
-    return error.message;
-  }
-  return readErrorMessage(error, 'Unexpected error while updating the Story Bible');
-}
-
-function getSelectedEntity(entities: BibleDataSnapshot['entities'], selectedEntityId: string | null) {
-  if (selectedEntityId) {
-    const selectedEntity = entities.find((entity) => entity.id === selectedEntityId);
-    if (selectedEntity) {
-      return selectedEntity;
-    }
-  }
-  return entities[0] ?? null;
 }
 
 function CenteredMessage({
@@ -104,203 +38,92 @@ function CenteredMessage({
   );
 }
 
-function useProjectAccess(projectId: string): ProjectAccess {
-  const parsedProjectId = useMemo(() => projectIdSchema.safeParse(projectId), [projectId]);
-  const projectService = useMemo(
-    () => createProjectService(new LocalProjectRepository()),
-    [],
+function BiblePageHeader({ project }: { project: WritingProject }): ReactElement {
+  return (
+    <header className="space-y-2">
+      <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+        <Link href="/workspace" className="hover:underline">
+          Workspace
+        </Link>
+        <span>/</span>
+        <Link href={`/workspace/${project.id}`} className="hover:underline">
+          {project.title}
+        </Link>
+        <span>/</span>
+        <span>Story Bible</span>
+      </div>
+      <h1 className="text-3xl font-headline font-bold">Story Bible</h1>
+      <p className="text-sm text-muted-foreground">Project: {project.title}</p>
+    </header>
   );
-  const [state, setState] = useState<ProjectAccessState>('loading');
-  const [project, setProject] = useState<WritingProject | null>(null);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!parsedProjectId.success) {
-      return undefined;
-    }
-
-    let isActive = true;
-
-    const loadProject = async (): Promise<void> => {
-      setState('loading');
-      setErrorMessage(null);
-
-      try {
-        const loadedProject = await projectService.getProjectById(parsedProjectId.data);
-        if (!isActive) {
-          return;
-        }
-
-        if (!loadedProject) {
-          setProject(null);
-          setState('not-found');
-          return;
-        }
-
-        setProject(loadedProject);
-        setState('ready');
-      } catch (error) {
-        if (!isActive) {
-          return;
-        }
-
-        setProject(null);
-        setErrorMessage(readErrorMessage(error, 'Unable to open project.'));
-        setState('error');
-      }
-    };
-
-    void loadProject();
-
-    return () => {
-      isActive = false;
-    };
-  }, [parsedProjectId, projectService]);
-
-  if (!parsedProjectId.success) {
-    return { state: 'invalid', errorMessage: null, project: null };
-  }
-
-  return { state, errorMessage, project };
 }
 
-function createBibleService(projectId: string): BibleService | null {
-  if (typeof window === 'undefined') {
-    return null;
-  }
-
-  const service = new BibleService(new LocalBibleRepository(window.localStorage));
-  service.seedScenes(projectId);
-  return service;
+function BiblePanels({
+  controller,
+  project,
+}: {
+  controller: BiblePageController;
+  project: WritingProject;
+}): ReactElement {
+  return (
+    <div className="grid gap-4 lg:grid-cols-[320px_1fr]">
+      <BibleList
+        entities={controller.data.entities}
+        selectedEntityId={controller.activeSelectedEntityId}
+        searchValue={controller.searchValue}
+        categoryFilter={controller.categoryFilter}
+        onSearchChange={controller.setSearchValue}
+        onCategoryFilterChange={controller.setCategoryFilter}
+        onSelectEntity={controller.onSelectEntity}
+        onCreateEntity={controller.onCreateEntity}
+      />
+      <BibleEditorsColumn controller={controller} project={project} />
+    </div>
+  );
 }
 
-export function BiblePageClient({ projectId }: BiblePageClientProps): ReactElement {
-  const projectAccess = useProjectAccess(projectId);
-  const [selectedEntityId, setSelectedEntityId] = useState<string | null>(null);
-  const [isCreatingEntity, setIsCreatingEntity] = useState(false);
-  const [searchValue, setSearchValue] = useState('');
-  const [categoryFilter, setCategoryFilter] = useState<BibleEntityCategory | 'all'>('all');
-  const [errors, setErrors] = useState<ErrorState>(EMPTY_ERRORS);
-  const [, setDataRevision] = useState(0);
-  const bibleService = useMemo(
-    () =>
-      projectAccess.state === 'ready' && projectAccess.project
-        ? createBibleService(projectAccess.project.id)
-        : null,
-    [projectAccess.project, projectAccess.state],
+function BibleEditorsColumn({
+  controller,
+  project,
+}: {
+  controller: BiblePageController;
+  project: WritingProject;
+}): ReactElement {
+  return (
+    <div className="space-y-4">
+      <BibleEditor
+        key={controller.activeSelectedEntityId ?? 'new-entity'}
+        projectId={project.id}
+        selectedEntity={controller.selectedEntity}
+        errorMessage={controller.entityError}
+        onSave={controller.onSaveEntity}
+        onDelete={controller.onDeleteEntity}
+      />
+      <RelationshipEditor
+        projectId={project.id}
+        entities={controller.data.entities}
+        relationships={controller.data.relationships}
+        selectedEntityId={controller.activeSelectedEntityId}
+        errorMessage={controller.relationshipError}
+        onSave={controller.onSaveRelationship}
+        onDelete={controller.onDeleteRelationship}
+      />
+      <SceneLinks
+        projectId={project.id}
+        entities={controller.data.entities}
+        scenes={controller.data.scenes}
+        sceneLinks={controller.data.sceneLinks}
+        selectedEntityId={controller.activeSelectedEntityId}
+        errorMessage={controller.sceneLinkError}
+        onSave={controller.onSaveSceneLink}
+        onDelete={controller.onDeleteSceneLink}
+      />
+    </div>
   );
-  const entityFilters = useMemo(
-    () => ({
-      search: searchValue,
-      category: categoryFilter === 'all' ? undefined : categoryFilter,
-    }),
-    [searchValue, categoryFilter],
-  );
+}
 
-  const data: BibleDataSnapshot =
-    bibleService && projectAccess.project
-      ? {
-          entities: bibleService.listEntities(projectAccess.project.id, entityFilters),
-          relationships: bibleService.listRelationships(projectAccess.project.id),
-          sceneLinks: bibleService.listSceneLinks(projectAccess.project.id),
-          scenes: bibleService.listScenes(projectAccess.project.id),
-        }
-      : EMPTY_BIBLE_DATA;
-
-  const selectedEntity = useMemo(() => {
-    if (isCreatingEntity) {
-      return null;
-    }
-    return getSelectedEntity(data.entities, selectedEntityId);
-  }, [data.entities, isCreatingEntity, selectedEntityId]);
-  const activeSelectedEntityId = selectedEntity?.id ?? null;
-
-  const triggerRefresh = (): void => {
-    setDataRevision((currentRevision) => currentRevision + 1);
-  };
-
-  const clearError = (key: keyof ErrorState): void => {
-    setErrors((currentErrors) => ({ ...currentErrors, [key]: null }));
-  };
-
-  const setError = (key: keyof ErrorState, error: unknown): void => {
-    setErrors((currentErrors) => ({ ...currentErrors, [key]: toBibleErrorMessage(error) }));
-  };
-
-  const withBibleService = (callback: (service: BibleService, validProjectId: string) => void): void => {
-    if (!bibleService || !projectAccess.project) {
-      return;
-    }
-
-    callback(bibleService, projectAccess.project.id);
-    triggerRefresh();
-  };
-
-  const handleSaveEntity = async (input: SaveBibleEntityInput): Promise<void> => {
-    try {
-      withBibleService((service, validProjectId) => {
-        clearError('entity');
-        const savedEntity = service.saveEntity({ ...input, projectId: validProjectId });
-        setSelectedEntityId(savedEntity.id);
-        setIsCreatingEntity(false);
-      });
-    } catch (error) {
-      setError('entity', error);
-    }
-  };
-
-  const handleDeleteEntity = async (entityId: string): Promise<void> => {
-    try {
-      withBibleService((service, validProjectId) => {
-        clearError('entity');
-        service.deleteEntity(validProjectId, entityId);
-        if (activeSelectedEntityId === entityId) {
-          setSelectedEntityId(null);
-          setIsCreatingEntity(false);
-        }
-      });
-    } catch (error) {
-      setError('entity', error);
-    }
-  };
-
-  const handleSaveRelationship = async (input: SaveBibleRelationshipInput): Promise<void> => {
-    try {
-      withBibleService((service, validProjectId) => {
-        clearError('relationship');
-        service.saveRelationship({ ...input, projectId: validProjectId });
-      });
-    } catch (error) {
-      setError('relationship', error);
-    }
-  };
-
-  const handleDeleteRelationship = async (relationshipId: string): Promise<void> => {
-    withBibleService((service, validProjectId) => {
-      clearError('relationship');
-      service.deleteRelationship(validProjectId, relationshipId);
-    });
-  };
-
-  const handleSaveSceneLink = async (input: SaveBibleSceneLinkInput): Promise<void> => {
-    try {
-      withBibleService((service, validProjectId) => {
-        clearError('sceneLink');
-        service.saveSceneLink({ ...input, projectId: validProjectId });
-      });
-    } catch (error) {
-      setError('sceneLink', error);
-    }
-  };
-
-  const handleDeleteSceneLink = async (sceneLinkId: string): Promise<void> => {
-    withBibleService((service, validProjectId) => {
-      clearError('sceneLink');
-      service.deleteSceneLink(validProjectId, sceneLinkId);
-    });
-  };
-
-  if (projectAccess.state === 'invalid') {
+function renderProjectAccessState(controller: BiblePageController): ReactElement | null {
+  if (controller.projectAccess.state === 'invalid') {
     return (
       <CenteredMessage
         title="Invalid project id"
@@ -309,7 +132,7 @@ export function BiblePageClient({ projectId }: BiblePageClientProps): ReactEleme
     );
   }
 
-  if (projectAccess.state === 'loading') {
+  if (controller.projectAccess.state === 'loading') {
     return (
       <main className="mx-auto flex min-h-screen w-full max-w-4xl items-center justify-center px-4">
         <p>Loading project...</p>
@@ -317,26 +140,21 @@ export function BiblePageClient({ projectId }: BiblePageClientProps): ReactEleme
     );
   }
 
-  if (projectAccess.state === 'not-found') {
-    return (
-      <CenteredMessage
-        title="Project not found"
-        description="This project does not exist in local storage."
-      />
-    );
+  if (controller.projectAccess.state === 'not-found') {
+    return <CenteredMessage title="Project not found" description="This project does not exist in local storage." />;
   }
 
-  if (projectAccess.state === 'error') {
+  if (controller.projectAccess.state === 'error') {
     return (
       <CenteredMessage
         title="Unable to open Story Bible"
-        description={projectAccess.errorMessage ?? 'Unable to open this project Story Bible.'}
+        description={controller.projectAccess.errorMessage ?? 'Unable to open this project Story Bible.'}
         tone="destructive"
       />
     );
   }
 
-  if (!projectAccess.project || !bibleService) {
+  if (!controller.project || !controller.bibleService) {
     return (
       <main className="mx-auto flex min-h-screen w-full max-w-4xl items-center justify-center px-4">
         <p>Loading Story Bible...</p>
@@ -344,70 +162,43 @@ export function BiblePageClient({ projectId }: BiblePageClientProps): ReactEleme
     );
   }
 
+  return null;
+}
+
+function BiblePageContent({
+  controller,
+  project,
+}: {
+  controller: BiblePageController;
+  project: WritingProject;
+}): ReactElement {
   return (
     <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-6 px-4 py-10">
-      <header className="space-y-2">
-        <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
-          <Link href="/workspace" className="hover:underline">
-            Workspace
-          </Link>
-          <span>/</span>
-          <Link href={`/workspace/${projectAccess.project.id}`} className="hover:underline">
-            {projectAccess.project.title}
-          </Link>
-          <span>/</span>
-          <span>Story Bible</span>
-        </div>
-        <h1 className="text-3xl font-headline font-bold">Story Bible</h1>
-        <p className="text-sm text-muted-foreground">Project: {projectAccess.project.title}</p>
-      </header>
-      <div className="grid gap-4 lg:grid-cols-[320px_1fr]">
-        <BibleList
-          entities={data.entities}
-          selectedEntityId={activeSelectedEntityId}
-          searchValue={searchValue}
-          categoryFilter={categoryFilter}
-          onSearchChange={setSearchValue}
-          onCategoryFilterChange={setCategoryFilter}
-          onSelectEntity={(entityId) => {
-            setSelectedEntityId(entityId);
-            setIsCreatingEntity(false);
-          }}
-          onCreateEntity={() => {
-            setSelectedEntityId(null);
-            setIsCreatingEntity(true);
-          }}
-        />
-        <div className="space-y-4">
-          <BibleEditor
-            key={activeSelectedEntityId ?? 'new-entity'}
-            projectId={projectAccess.project.id}
-            selectedEntity={selectedEntity}
-            errorMessage={errors.entity}
-            onSave={handleSaveEntity}
-            onDelete={handleDeleteEntity}
-          />
-          <RelationshipEditor
-            projectId={projectAccess.project.id}
-            entities={data.entities}
-            relationships={data.relationships}
-            selectedEntityId={activeSelectedEntityId}
-            errorMessage={errors.relationship}
-            onSave={handleSaveRelationship}
-            onDelete={handleDeleteRelationship}
-          />
-          <SceneLinks
-            projectId={projectAccess.project.id}
-            entities={data.entities}
-            scenes={data.scenes}
-            sceneLinks={data.sceneLinks}
-            selectedEntityId={activeSelectedEntityId}
-            errorMessage={errors.sceneLink}
-            onSave={handleSaveSceneLink}
-            onDelete={handleDeleteSceneLink}
-          />
-        </div>
-      </div>
+      <BiblePageHeader project={project} />
+      <BiblePanels controller={controller} project={project} />
     </main>
   );
+}
+
+function LoadingStoryBibleMessage(): ReactElement {
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-4xl items-center justify-center px-4">
+      <p>Loading Story Bible...</p>
+    </main>
+  );
+}
+
+export function BiblePageClient({ projectId }: BiblePageClientProps): ReactElement {
+  const controller = useBiblePageController(projectId);
+  const accessState = renderProjectAccessState(controller);
+
+  if (accessState) {
+    return accessState;
+  }
+
+  if (!controller.project) {
+    return <LoadingStoryBibleMessage />;
+  }
+
+  return <BiblePageContent controller={controller} project={controller.project} />;
 }

--- a/src/components/bible/bible-page-client.tsx
+++ b/src/components/bible/bible-page-client.tsx
@@ -1,0 +1,267 @@
+'use client';
+
+import Link from 'next/link';
+import { type ReactElement, useMemo, useState } from 'react';
+import { BibleEditor } from '@/components/bible/bible-editor';
+import { BibleList } from '@/components/bible/bible-list';
+import { RelationshipEditor } from '@/components/bible/relationship-editor';
+import { SceneLinks } from '@/components/bible/scene-links';
+import { BibleService, BibleValidationError } from '@/application/bible/bible-service';
+import { LocalBibleRepository } from '@/data/bible/local-bible-repository';
+import type {
+  BibleEntityCategory,
+  SaveBibleEntityInput,
+  SaveBibleRelationshipInput,
+  SaveBibleSceneLinkInput,
+} from '@/domain/bible/types';
+
+interface BiblePageClientProps {
+  projectId: string;
+}
+
+interface BibleDataSnapshot {
+  entities: ReturnType<BibleService['listEntities']>;
+  relationships: ReturnType<BibleService['listRelationships']>;
+  sceneLinks: ReturnType<BibleService['listSceneLinks']>;
+  scenes: ReturnType<BibleService['listScenes']>;
+}
+
+interface ErrorState {
+  entity: string | null;
+  relationship: string | null;
+  sceneLink: string | null;
+}
+
+const EMPTY_BIBLE_DATA: BibleDataSnapshot = {
+  entities: [],
+  relationships: [],
+  sceneLinks: [],
+  scenes: [],
+};
+
+const EMPTY_ERRORS: ErrorState = {
+  entity: null,
+  relationship: null,
+  sceneLink: null,
+};
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof BibleValidationError) {
+    return error.message;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return 'Unexpected error while updating the Story Bible';
+}
+
+function createService(projectId: string): BibleService | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  const repository = new LocalBibleRepository(window.localStorage);
+  const service = new BibleService(repository);
+  service.seedScenes(projectId);
+  return service;
+}
+
+function getSelectedEntity(entities: BibleDataSnapshot['entities'], selectedEntityId: string | null) {
+  if (selectedEntityId) {
+    const selectedEntity = entities.find((entity) => entity.id === selectedEntityId);
+    if (selectedEntity) {
+      return selectedEntity;
+    }
+  }
+  return entities[0] ?? null;
+}
+
+export function BiblePageClient({ projectId }: BiblePageClientProps): ReactElement {
+  const [selectedEntityId, setSelectedEntityId] = useState<string | null>(null);
+  const [isCreatingEntity, setIsCreatingEntity] = useState(false);
+  const [searchValue, setSearchValue] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState<BibleEntityCategory | 'all'>('all');
+  const [errors, setErrors] = useState<ErrorState>(EMPTY_ERRORS);
+  const [, setDataRevision] = useState(0);
+  const service = useMemo(() => createService(projectId), [projectId]);
+  const entityFilters = useMemo(
+    () => ({
+      search: searchValue,
+      category: categoryFilter === 'all' ? undefined : categoryFilter,
+    }),
+    [searchValue, categoryFilter],
+  );
+
+  const data: BibleDataSnapshot = service
+    ? {
+        entities: service.listEntities(projectId, entityFilters),
+        relationships: service.listRelationships(projectId),
+        sceneLinks: service.listSceneLinks(projectId),
+        scenes: service.listScenes(projectId),
+      }
+    : EMPTY_BIBLE_DATA;
+
+  const selectedEntity = useMemo(() => {
+    if (isCreatingEntity) {
+      return null;
+    }
+    return getSelectedEntity(data.entities, selectedEntityId);
+  }, [data.entities, isCreatingEntity, selectedEntityId]);
+  const activeSelectedEntityId = selectedEntity?.id ?? null;
+
+  const triggerRefresh = (): void => {
+    setDataRevision((currentRevision) => currentRevision + 1);
+  };
+
+  const clearError = (key: keyof ErrorState): void => {
+    setErrors((currentErrors) => ({ ...currentErrors, [key]: null }));
+  };
+
+  const setError = (key: keyof ErrorState, error: unknown): void => {
+    setErrors((currentErrors) => ({ ...currentErrors, [key]: toErrorMessage(error) }));
+  };
+
+  const withService = (callback: (nextService: BibleService) => void): void => {
+    if (!service) {
+      return;
+    }
+    callback(service);
+    triggerRefresh();
+  };
+
+  const handleSaveEntity = async (input: SaveBibleEntityInput): Promise<void> => {
+    try {
+      withService((nextService) => {
+        clearError('entity');
+        const savedEntity = nextService.saveEntity(input);
+        setSelectedEntityId(savedEntity.id);
+        setIsCreatingEntity(false);
+      });
+    } catch (error) {
+      setError('entity', error);
+    }
+  };
+
+  const handleDeleteEntity = async (entityId: string): Promise<void> => {
+    try {
+      withService((nextService) => {
+        clearError('entity');
+        nextService.deleteEntity(projectId, entityId);
+        if (activeSelectedEntityId === entityId) {
+          setSelectedEntityId(null);
+          setIsCreatingEntity(false);
+        }
+      });
+    } catch (error) {
+      setError('entity', error);
+    }
+  };
+
+  const handleSaveRelationship = async (input: SaveBibleRelationshipInput): Promise<void> => {
+    try {
+      withService((nextService) => {
+        clearError('relationship');
+        nextService.saveRelationship(input);
+      });
+    } catch (error) {
+      setError('relationship', error);
+    }
+  };
+
+  const handleDeleteRelationship = async (relationshipId: string): Promise<void> => {
+    withService((nextService) => {
+      clearError('relationship');
+      nextService.deleteRelationship(projectId, relationshipId);
+    });
+  };
+
+  const handleSaveSceneLink = async (input: SaveBibleSceneLinkInput): Promise<void> => {
+    try {
+      withService((nextService) => {
+        clearError('sceneLink');
+        nextService.saveSceneLink(input);
+      });
+    } catch (error) {
+      setError('sceneLink', error);
+    }
+  };
+
+  const handleDeleteSceneLink = async (sceneLinkId: string): Promise<void> => {
+    withService((nextService) => {
+      clearError('sceneLink');
+      nextService.deleteSceneLink(projectId, sceneLinkId);
+    });
+  };
+
+  if (!service) {
+    return (
+      <main className="mx-auto flex min-h-screen w-full max-w-6xl items-center justify-center px-4 py-10">
+        <p className="text-muted-foreground">Loading Story Bible...</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-6 px-4 py-10">
+      <header className="space-y-2">
+        <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+          <Link href="/" className="hover:underline">
+            Home
+          </Link>
+          <span>/</span>
+          <Link href={`/workspace/${projectId}`} className="hover:underline">
+            Workspace
+          </Link>
+        </div>
+        <h1 className="text-3xl font-headline font-bold">Story Bible</h1>
+        <p className="text-sm text-muted-foreground">Project: {projectId}</p>
+      </header>
+      <div className="grid gap-4 lg:grid-cols-[320px_1fr]">
+        <BibleList
+          entities={data.entities}
+          selectedEntityId={activeSelectedEntityId}
+          searchValue={searchValue}
+          categoryFilter={categoryFilter}
+          onSearchChange={setSearchValue}
+          onCategoryFilterChange={setCategoryFilter}
+          onSelectEntity={(entityId) => {
+            setSelectedEntityId(entityId);
+            setIsCreatingEntity(false);
+          }}
+          onCreateEntity={() => {
+            setSelectedEntityId(null);
+            setIsCreatingEntity(true);
+          }}
+        />
+        <div className="space-y-4">
+          <BibleEditor
+            key={activeSelectedEntityId ?? 'new-entity'}
+            projectId={projectId}
+            selectedEntity={selectedEntity}
+            errorMessage={errors.entity}
+            onSave={handleSaveEntity}
+            onDelete={handleDeleteEntity}
+          />
+          <RelationshipEditor
+            projectId={projectId}
+            entities={data.entities}
+            relationships={data.relationships}
+            selectedEntityId={activeSelectedEntityId}
+            errorMessage={errors.relationship}
+            onSave={handleSaveRelationship}
+            onDelete={handleDeleteRelationship}
+          />
+          <SceneLinks
+            projectId={projectId}
+            entities={data.entities}
+            scenes={data.scenes}
+            sceneLinks={data.sceneLinks}
+            selectedEntityId={activeSelectedEntityId}
+            errorMessage={errors.sceneLink}
+            onSave={handleSaveSceneLink}
+            onDelete={handleDeleteSceneLink}
+          />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/bible/bible-page-controller.ts
+++ b/src/components/bible/bible-page-controller.ts
@@ -66,6 +66,11 @@ interface EntityActions {
   deleteEntity: (entityId: string) => Promise<void>;
 }
 
+interface ProjectAccessSnapshot {
+  projectId: string | null;
+  access: ProjectAccess;
+}
+
 const EMPTY_BIBLE_DATA: BibleDataSnapshot = {
   entities: [],
   relationships: [],
@@ -143,17 +148,24 @@ async function fetchProjectAccess(projectId: string): Promise<ProjectAccess> {
 
 function useProjectAccess(projectId: string): ProjectAccess {
   const parsedProjectId = useMemo(() => projectIdSchema.safeParse(projectId), [projectId]);
-  const [projectAccess, setProjectAccess] = useState<ProjectAccess>(LOADING_PROJECT_ACCESS);
+  const [snapshot, setSnapshot] = useState<ProjectAccessSnapshot>({
+    projectId: null,
+    access: LOADING_PROJECT_ACCESS,
+  });
 
   useEffect(() => {
     if (!parsedProjectId.success) {
       return undefined;
     }
 
+    const nextProjectId = parsedProjectId.data;
     let isActive = true;
-    void fetchProjectAccess(parsedProjectId.data).then((nextProjectAccess) => {
+    void fetchProjectAccess(nextProjectId).then((nextProjectAccess) => {
       if (isActive) {
-        setProjectAccess(nextProjectAccess);
+        setSnapshot({
+          projectId: nextProjectId,
+          access: nextProjectAccess,
+        });
       }
     });
 
@@ -166,7 +178,11 @@ function useProjectAccess(projectId: string): ProjectAccess {
     return INVALID_PROJECT_ACCESS;
   }
 
-  return projectAccess;
+  if (snapshot.projectId !== parsedProjectId.data) {
+    return LOADING_PROJECT_ACCESS;
+  }
+
+  return snapshot.access;
 }
 
 function useBibleService(projectAccess: ProjectAccess): BibleService | null {
@@ -261,7 +277,7 @@ function useRunBibleOperation(
 ): (operation: (service: BibleService, validProjectId: string) => void) => void {
   return (operation: (service: BibleService, validProjectId: string) => void): void => {
     if (!bibleService || !projectId) {
-      return;
+      throw new BibleValidationError('Story Bible is not ready for this project');
     }
 
     operation(bibleService, projectId);
@@ -325,14 +341,19 @@ function useRelationshipActions(
       });
     } catch (nextError) {
       setError(toBibleErrorMessage(nextError));
+      throw nextError;
     }
   };
 
   const deleteRelationship = async (relationshipId: string): Promise<void> => {
-    runOperation((service, validProjectId) => {
-      setError(null);
-      service.deleteRelationship(validProjectId, relationshipId);
-    });
+    try {
+      runOperation((service, validProjectId) => {
+        setError(null);
+        service.deleteRelationship(validProjectId, relationshipId);
+      });
+    } catch (nextError) {
+      setError(toBibleErrorMessage(nextError));
+    }
   };
 
   return { error, saveRelationship, deleteRelationship };
@@ -355,14 +376,19 @@ function useSceneLinkActions(
       });
     } catch (nextError) {
       setError(toBibleErrorMessage(nextError));
+      throw nextError;
     }
   };
 
   const deleteSceneLink = async (sceneLinkId: string): Promise<void> => {
-    runOperation((service, validProjectId) => {
-      setError(null);
-      service.deleteSceneLink(validProjectId, sceneLinkId);
-    });
+    try {
+      runOperation((service, validProjectId) => {
+        setError(null);
+        service.deleteSceneLink(validProjectId, sceneLinkId);
+      });
+    } catch (nextError) {
+      setError(toBibleErrorMessage(nextError));
+    }
   };
 
   return { error, saveSceneLink, deleteSceneLink };

--- a/src/components/bible/bible-page-controller.ts
+++ b/src/components/bible/bible-page-controller.ts
@@ -1,0 +1,414 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { BibleService, BibleValidationError } from '@/application/bible/bible-service';
+import { createProjectService } from '@/application/project/project-service';
+import { LocalBibleRepository } from '@/data/bible/local-bible-repository';
+import { LocalProjectRepository } from '@/data/project/local-project-repository';
+import { projectIdSchema } from '@/domain/project/schemas';
+import type { WritingProject } from '@/domain/project/types';
+import type {
+  BibleEntityCategory,
+  SaveBibleEntityInput,
+  SaveBibleRelationshipInput,
+  SaveBibleSceneLinkInput,
+} from '@/domain/bible/types';
+
+export type ProjectAccessState = 'loading' | 'invalid' | 'not-found' | 'error' | 'ready';
+
+export interface ProjectAccess {
+  state: ProjectAccessState;
+  errorMessage: string | null;
+  project: WritingProject | null;
+}
+
+export interface BibleDataSnapshot {
+  entities: ReturnType<BibleService['listEntities']>;
+  relationships: ReturnType<BibleService['listRelationships']>;
+  sceneLinks: ReturnType<BibleService['listSceneLinks']>;
+  scenes: ReturnType<BibleService['listScenes']>;
+}
+
+export interface BiblePageController {
+  projectAccess: ProjectAccess;
+  project: WritingProject | null;
+  bibleService: BibleService | null;
+  data: BibleDataSnapshot;
+  searchValue: string;
+  categoryFilter: BibleEntityCategory | 'all';
+  selectedEntity: BibleDataSnapshot['entities'][number] | null;
+  activeSelectedEntityId: string | null;
+  entityError: string | null;
+  relationshipError: string | null;
+  sceneLinkError: string | null;
+  setSearchValue: (value: string) => void;
+  setCategoryFilter: (value: BibleEntityCategory | 'all') => void;
+  onSelectEntity: (entityId: string) => void;
+  onCreateEntity: () => void;
+  onSaveEntity: (input: SaveBibleEntityInput) => Promise<void>;
+  onDeleteEntity: (entityId: string) => Promise<void>;
+  onSaveRelationship: (input: SaveBibleRelationshipInput) => Promise<void>;
+  onDeleteRelationship: (relationshipId: string) => Promise<void>;
+  onSaveSceneLink: (input: SaveBibleSceneLinkInput) => Promise<void>;
+  onDeleteSceneLink: (sceneLinkId: string) => Promise<void>;
+}
+
+interface EntityActionParams {
+  runOperation: (operation: (service: BibleService, validProjectId: string) => void) => void;
+  activeSelectedEntityId: string | null;
+  setSelectedEntityId: (entityId: string | null) => void;
+  setIsCreatingEntity: (value: boolean) => void;
+}
+
+interface EntityActions {
+  error: string | null;
+  saveEntity: (input: SaveBibleEntityInput) => Promise<void>;
+  deleteEntity: (entityId: string) => Promise<void>;
+}
+
+const EMPTY_BIBLE_DATA: BibleDataSnapshot = {
+  entities: [],
+  relationships: [],
+  sceneLinks: [],
+  scenes: [],
+};
+
+const LOADING_PROJECT_ACCESS: ProjectAccess = {
+  state: 'loading',
+  errorMessage: null,
+  project: null,
+};
+
+const INVALID_PROJECT_ACCESS: ProjectAccess = {
+  state: 'invalid',
+  errorMessage: null,
+  project: null,
+};
+
+function readErrorMessage(error: unknown, fallbackMessage: string): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+
+  return fallbackMessage;
+}
+
+function toBibleErrorMessage(error: unknown): string {
+  if (error instanceof BibleValidationError) {
+    return error.message;
+  }
+
+  return readErrorMessage(error, 'Unexpected error while updating the Story Bible');
+}
+
+function getSelectedEntity(entities: BibleDataSnapshot['entities'], selectedEntityId: string | null) {
+  if (selectedEntityId) {
+    const selectedEntity = entities.find((entity) => entity.id === selectedEntityId);
+    if (selectedEntity) {
+      return selectedEntity;
+    }
+  }
+
+  return entities[0] ?? null;
+}
+
+function createBibleService(projectId: string): BibleService | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const service = new BibleService(new LocalBibleRepository(window.localStorage));
+  service.seedScenes(projectId);
+  return service;
+}
+
+async function fetchProjectAccess(projectId: string): Promise<ProjectAccess> {
+  const projectService = createProjectService(new LocalProjectRepository());
+
+  try {
+    const loadedProject = await projectService.getProjectById(projectId);
+    if (!loadedProject) {
+      return { state: 'not-found', errorMessage: null, project: null };
+    }
+
+    return { state: 'ready', errorMessage: null, project: loadedProject };
+  } catch (error) {
+    return {
+      state: 'error',
+      errorMessage: readErrorMessage(error, 'Unable to open project.'),
+      project: null,
+    };
+  }
+}
+
+function useProjectAccess(projectId: string): ProjectAccess {
+  const parsedProjectId = useMemo(() => projectIdSchema.safeParse(projectId), [projectId]);
+  const [projectAccess, setProjectAccess] = useState<ProjectAccess>(LOADING_PROJECT_ACCESS);
+
+  useEffect(() => {
+    if (!parsedProjectId.success) {
+      return undefined;
+    }
+
+    let isActive = true;
+    void fetchProjectAccess(parsedProjectId.data).then((nextProjectAccess) => {
+      if (isActive) {
+        setProjectAccess(nextProjectAccess);
+      }
+    });
+
+    return () => {
+      isActive = false;
+    };
+  }, [parsedProjectId]);
+
+  if (!parsedProjectId.success) {
+    return INVALID_PROJECT_ACCESS;
+  }
+
+  return projectAccess;
+}
+
+function useBibleService(projectAccess: ProjectAccess): BibleService | null {
+  return useMemo(() => {
+    if (projectAccess.state !== 'ready' || !projectAccess.project) {
+      return null;
+    }
+
+    return createBibleService(projectAccess.project.id);
+  }, [projectAccess.project, projectAccess.state]);
+}
+
+function useEntityFilters(): {
+  searchValue: string;
+  categoryFilter: BibleEntityCategory | 'all';
+  entityFilters: { search: string; category?: BibleEntityCategory };
+  setSearchValue: (value: string) => void;
+  setCategoryFilter: (value: BibleEntityCategory | 'all') => void;
+} {
+  const [searchValue, setSearchValue] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState<BibleEntityCategory | 'all'>('all');
+  const entityFilters = useMemo(
+    () => ({ search: searchValue, category: categoryFilter === 'all' ? undefined : categoryFilter }),
+    [categoryFilter, searchValue],
+  );
+
+  return { searchValue, categoryFilter, entityFilters, setSearchValue, setCategoryFilter };
+}
+
+function useBibleDataSnapshot(
+  bibleService: BibleService | null,
+  projectId: string | null,
+  entityFilters: { search: string; category?: BibleEntityCategory },
+): BibleDataSnapshot {
+  if (!bibleService || !projectId) {
+    return EMPTY_BIBLE_DATA;
+  }
+
+  return {
+    entities: bibleService.listEntities(projectId, entityFilters),
+    relationships: bibleService.listRelationships(projectId),
+    sceneLinks: bibleService.listSceneLinks(projectId),
+    scenes: bibleService.listScenes(projectId),
+  };
+}
+
+function useEntitySelection(entities: BibleDataSnapshot['entities']): {
+  selectedEntity: BibleDataSnapshot['entities'][number] | null;
+  activeSelectedEntityId: string | null;
+  setSelectedEntityId: (entityId: string | null) => void;
+  setIsCreatingEntity: (value: boolean) => void;
+  onSelectEntity: (entityId: string) => void;
+  onCreateEntity: () => void;
+} {
+  const [selectedEntityId, setSelectedEntityId] = useState<string | null>(null);
+  const [isCreatingEntity, setIsCreatingEntity] = useState(false);
+  const selectedEntity = useMemo(() => {
+    if (isCreatingEntity) {
+      return null;
+    }
+
+    return getSelectedEntity(entities, selectedEntityId);
+  }, [entities, isCreatingEntity, selectedEntityId]);
+
+  return {
+    selectedEntity,
+    activeSelectedEntityId: selectedEntity?.id ?? null,
+    setSelectedEntityId,
+    setIsCreatingEntity,
+    onSelectEntity: (entityId: string) => {
+      setSelectedEntityId(entityId);
+      setIsCreatingEntity(false);
+    },
+    onCreateEntity: () => {
+      setSelectedEntityId(null);
+      setIsCreatingEntity(true);
+    },
+  };
+}
+
+function useRefreshTrigger(): () => void {
+  const [, setDataRevision] = useState(0);
+  return () => {
+    setDataRevision((currentRevision) => currentRevision + 1);
+  };
+}
+
+function useRunBibleOperation(
+  bibleService: BibleService | null,
+  projectId: string | null,
+  triggerRefresh: () => void,
+): (operation: (service: BibleService, validProjectId: string) => void) => void {
+  return (operation: (service: BibleService, validProjectId: string) => void): void => {
+    if (!bibleService || !projectId) {
+      return;
+    }
+
+    operation(bibleService, projectId);
+    triggerRefresh();
+  };
+}
+
+function useEntityActions({
+  runOperation,
+  activeSelectedEntityId,
+  setSelectedEntityId,
+  setIsCreatingEntity,
+}: EntityActionParams): EntityActions {
+  const [error, setError] = useState<string | null>(null);
+
+  const saveEntity = async (input: SaveBibleEntityInput): Promise<void> => {
+    try {
+      runOperation((service, validProjectId) => {
+        setError(null);
+        const savedEntity = service.saveEntity({ ...input, projectId: validProjectId });
+        setSelectedEntityId(savedEntity.id);
+        setIsCreatingEntity(false);
+      });
+    } catch (nextError) {
+      setError(toBibleErrorMessage(nextError));
+    }
+  };
+
+  const deleteEntity = async (entityId: string): Promise<void> => {
+    try {
+      runOperation((service, validProjectId) => {
+        setError(null);
+        service.deleteEntity(validProjectId, entityId);
+        if (activeSelectedEntityId === entityId) {
+          setSelectedEntityId(null);
+          setIsCreatingEntity(false);
+        }
+      });
+    } catch (nextError) {
+      setError(toBibleErrorMessage(nextError));
+    }
+  };
+
+  return { error, saveEntity, deleteEntity };
+}
+
+function useRelationshipActions(
+  runOperation: (operation: (service: BibleService, validProjectId: string) => void) => void,
+): {
+  error: string | null;
+  saveRelationship: (input: SaveBibleRelationshipInput) => Promise<void>;
+  deleteRelationship: (relationshipId: string) => Promise<void>;
+} {
+  const [error, setError] = useState<string | null>(null);
+
+  const saveRelationship = async (input: SaveBibleRelationshipInput): Promise<void> => {
+    try {
+      runOperation((service, validProjectId) => {
+        setError(null);
+        service.saveRelationship({ ...input, projectId: validProjectId });
+      });
+    } catch (nextError) {
+      setError(toBibleErrorMessage(nextError));
+    }
+  };
+
+  const deleteRelationship = async (relationshipId: string): Promise<void> => {
+    runOperation((service, validProjectId) => {
+      setError(null);
+      service.deleteRelationship(validProjectId, relationshipId);
+    });
+  };
+
+  return { error, saveRelationship, deleteRelationship };
+}
+
+function useSceneLinkActions(
+  runOperation: (operation: (service: BibleService, validProjectId: string) => void) => void,
+): {
+  error: string | null;
+  saveSceneLink: (input: SaveBibleSceneLinkInput) => Promise<void>;
+  deleteSceneLink: (sceneLinkId: string) => Promise<void>;
+} {
+  const [error, setError] = useState<string | null>(null);
+
+  const saveSceneLink = async (input: SaveBibleSceneLinkInput): Promise<void> => {
+    try {
+      runOperation((service, validProjectId) => {
+        setError(null);
+        service.saveSceneLink({ ...input, projectId: validProjectId });
+      });
+    } catch (nextError) {
+      setError(toBibleErrorMessage(nextError));
+    }
+  };
+
+  const deleteSceneLink = async (sceneLinkId: string): Promise<void> => {
+    runOperation((service, validProjectId) => {
+      setError(null);
+      service.deleteSceneLink(validProjectId, sceneLinkId);
+    });
+  };
+
+  return { error, saveSceneLink, deleteSceneLink };
+}
+
+export function useBiblePageController(projectId: string): BiblePageController {
+  const projectAccess = useProjectAccess(projectId);
+  const { project } = projectAccess;
+  const bibleService = useBibleService(projectAccess);
+  const { searchValue, categoryFilter, entityFilters, setSearchValue, setCategoryFilter } = useEntityFilters();
+  const data = useBibleDataSnapshot(bibleService, project?.id ?? null, entityFilters);
+  const selection = useEntitySelection(data.entities);
+  const runOperation = useRunBibleOperation(bibleService, project?.id ?? null, useRefreshTrigger());
+  const entityActions = useEntityActions({
+    runOperation,
+    activeSelectedEntityId: selection.activeSelectedEntityId,
+    setSelectedEntityId: selection.setSelectedEntityId,
+    setIsCreatingEntity: selection.setIsCreatingEntity,
+  });
+  const relationshipActions = useRelationshipActions(runOperation);
+  const sceneLinkActions = useSceneLinkActions(runOperation);
+  return createControllerState({
+    projectAccess,
+    project,
+    bibleService,
+    data,
+    searchValue,
+    categoryFilter,
+    selectedEntity: selection.selectedEntity,
+    activeSelectedEntityId: selection.activeSelectedEntityId,
+    entityError: entityActions.error,
+    relationshipError: relationshipActions.error,
+    sceneLinkError: sceneLinkActions.error,
+    setSearchValue,
+    setCategoryFilter,
+    onSelectEntity: selection.onSelectEntity,
+    onCreateEntity: selection.onCreateEntity,
+    onSaveEntity: entityActions.saveEntity,
+    onDeleteEntity: entityActions.deleteEntity,
+    onSaveRelationship: relationshipActions.saveRelationship,
+    onDeleteRelationship: relationshipActions.deleteRelationship,
+    onSaveSceneLink: sceneLinkActions.saveSceneLink,
+    onDeleteSceneLink: sceneLinkActions.deleteSceneLink,
+  });
+}
+
+function createControllerState(controller: BiblePageController): BiblePageController {
+  return controller;
+}

--- a/src/components/bible/relationship-editor-state.ts
+++ b/src/components/bible/relationship-editor-state.ts
@@ -1,0 +1,171 @@
+'use client';
+
+import { type FormEvent, useMemo, useState } from 'react';
+import type {
+  BibleEntity,
+  BibleRelationship,
+  RelationshipType,
+  SaveBibleRelationshipInput,
+} from '@/domain/bible/types';
+
+interface RelationshipFormState {
+  fromEntityId: string;
+  toEntityId: string;
+  relationshipType: RelationshipType;
+  notes: string;
+}
+
+interface RelationshipFormStateActions {
+  state: RelationshipFormState;
+  setFromEntityId: (value: string) => void;
+  setToEntityId: (value: string) => void;
+  setRelationshipType: (value: RelationshipType) => void;
+  setNotes: (value: string) => void;
+  resetNotes: () => void;
+}
+
+interface RelationshipEditorStateInput {
+  projectId: string;
+  entities: BibleEntity[];
+  relationships: BibleRelationship[];
+  selectedEntityId: string | null;
+  onSave: (input: SaveBibleRelationshipInput) => void | Promise<void>;
+}
+
+export interface RelationshipEditorState {
+  state: RelationshipFormState;
+  visibleRelationships: BibleRelationship[];
+  resolvedFromEntityId: string;
+  resolvedToEntityId: string;
+  setFromEntityId: (value: string) => void;
+  setToEntityId: (value: string) => void;
+  setRelationshipType: (value: RelationshipType) => void;
+  setNotes: (value: string) => void;
+  handleSubmit: (event: FormEvent<HTMLFormElement>) => void;
+}
+
+function useRelationshipFormState(): RelationshipFormStateActions {
+  const [fromEntityId, setFromEntityId] = useState('');
+  const [toEntityId, setToEntityId] = useState('');
+  const [relationshipType, setRelationshipType] = useState<RelationshipType>('ally_of');
+  const [notes, setNotes] = useState('');
+
+  return {
+    state: { fromEntityId, toEntityId, relationshipType, notes },
+    setFromEntityId,
+    setToEntityId,
+    setRelationshipType,
+    setNotes,
+    resetNotes: () => setNotes(''),
+  };
+}
+
+function getVisibleRelationships(
+  relationships: BibleRelationship[],
+  selectedEntityId: string | null,
+): BibleRelationship[] {
+  if (!selectedEntityId) {
+    return relationships;
+  }
+
+  return relationships.filter(
+    (relationship) =>
+      relationship.fromEntityId === selectedEntityId || relationship.toEntityId === selectedEntityId,
+  );
+}
+
+function resolveFromEntityId(
+  candidateFromEntityId: string,
+  selectedEntityId: string | null,
+  entities: BibleEntity[],
+): string {
+  const entityIds = new Set(entities.map((entity) => entity.id));
+  if (entityIds.has(candidateFromEntityId)) {
+    return candidateFromEntityId;
+  }
+
+  return selectedEntityId ?? entities[0]?.id ?? '';
+}
+
+function resolveToEntityId(
+  candidateToEntityId: string,
+  fromEntityId: string,
+  entities: BibleEntity[],
+): string {
+  const entityIds = new Set(entities.map((entity) => entity.id));
+  if (entityIds.has(candidateToEntityId) && candidateToEntityId !== fromEntityId) {
+    return candidateToEntityId;
+  }
+
+  return entities.find((entity) => entity.id !== fromEntityId)?.id ?? fromEntityId;
+}
+
+function createSubmitHandler({
+  projectId,
+  state,
+  resolvedFromEntityId,
+  resolvedToEntityId,
+  onSave,
+  resetNotes,
+}: {
+  projectId: string;
+  state: RelationshipFormState;
+  resolvedFromEntityId: string;
+  resolvedToEntityId: string;
+  onSave: (input: SaveBibleRelationshipInput) => void | Promise<void>;
+  resetNotes: () => void;
+}): (event: FormEvent<HTMLFormElement>) => void {
+  return (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    void onSave({
+      projectId,
+      type: state.relationshipType,
+      fromEntityId: resolvedFromEntityId,
+      toEntityId: resolvedToEntityId,
+      notes: state.notes,
+    });
+    resetNotes();
+  };
+}
+
+export function useRelationshipEditorState({
+  projectId,
+  entities,
+  relationships,
+  selectedEntityId,
+  onSave,
+}: RelationshipEditorStateInput): RelationshipEditorState {
+  const formState = useRelationshipFormState();
+  const visibleRelationships = useMemo(
+    () => getVisibleRelationships(relationships, selectedEntityId),
+    [relationships, selectedEntityId],
+  );
+  const resolvedFromEntityId = useMemo(
+    () => resolveFromEntityId(formState.state.fromEntityId, selectedEntityId, entities),
+    [entities, formState.state.fromEntityId, selectedEntityId],
+  );
+  const resolvedToEntityId = useMemo(
+    () => resolveToEntityId(formState.state.toEntityId, resolvedFromEntityId, entities),
+    [entities, formState.state.toEntityId, resolvedFromEntityId],
+  );
+  const handleSubmit = createSubmitHandler({
+    projectId,
+    state: formState.state,
+    resolvedFromEntityId,
+    resolvedToEntityId,
+    onSave,
+    resetNotes: formState.resetNotes,
+  });
+
+  return {
+    state: formState.state,
+    visibleRelationships,
+    resolvedFromEntityId,
+    resolvedToEntityId,
+    setFromEntityId: formState.setFromEntityId,
+    setToEntityId: formState.setToEntityId,
+    setRelationshipType: formState.setRelationshipType,
+    setNotes: formState.setNotes,
+    handleSubmit,
+  };
+}

--- a/src/components/bible/relationship-editor-state.ts
+++ b/src/components/bible/relationship-editor-state.ts
@@ -41,7 +41,7 @@ export interface RelationshipEditorState {
   setToEntityId: (value: string) => void;
   setRelationshipType: (value: RelationshipType) => void;
   setNotes: (value: string) => void;
-  handleSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  handleSubmit: (event: FormEvent<HTMLFormElement>) => Promise<void>;
 }
 
 function useRelationshipFormState(): RelationshipFormStateActions {
@@ -114,17 +114,25 @@ function createSubmitHandler({
   resolvedToEntityId: string;
   onSave: (input: SaveBibleRelationshipInput) => void | Promise<void>;
   resetNotes: () => void;
-}): (event: FormEvent<HTMLFormElement>) => void {
-  return (event: FormEvent<HTMLFormElement>): void => {
+}): (event: FormEvent<HTMLFormElement>) => Promise<void> {
+  return async (event: FormEvent<HTMLFormElement>): Promise<void> => {
     event.preventDefault();
-    void onSave({
-      projectId,
-      type: state.relationshipType,
-      fromEntityId: resolvedFromEntityId,
-      toEntityId: resolvedToEntityId,
-      notes: state.notes,
-    });
-    resetNotes();
+    if (!resolvedFromEntityId || !resolvedToEntityId || resolvedFromEntityId === resolvedToEntityId) {
+      return;
+    }
+
+    try {
+      await onSave({
+        projectId,
+        type: state.relationshipType,
+        fromEntityId: resolvedFromEntityId,
+        toEntityId: resolvedToEntityId,
+        notes: state.notes,
+      });
+      resetNotes();
+    } catch {
+      // Keep notes so users can retry after a failed save.
+    }
   };
 }
 

--- a/src/components/bible/relationship-editor.tsx
+++ b/src/components/bible/relationship-editor.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { type FormEvent, type ReactElement, useMemo, useState } from 'react';
+import { type FormEvent, type ReactElement, useMemo } from 'react';
+import { useRelationshipEditorState } from '@/components/bible/relationship-editor-state';
+import { RELATIONSHIP_TYPES } from '@/domain/bible/types';
 import type {
   BibleEntity,
   BibleRelationship,
   RelationshipType,
   SaveBibleRelationshipInput,
 } from '@/domain/bible/types';
-import { RELATIONSHIP_TYPES } from '@/domain/bible/types';
 
 interface RelationshipEditorProps {
   projectId: string;
@@ -19,6 +20,277 @@ interface RelationshipEditorProps {
   onDelete: (relationshipId: string) => void | Promise<void>;
 }
 
+interface RelationshipFormProps {
+  entities: BibleEntity[];
+  resolvedFromEntityId: string;
+  resolvedToEntityId: string;
+  relationshipType: RelationshipType;
+  notes: string;
+  onFromEntityChange: (value: string) => void;
+  onToEntityChange: (value: string) => void;
+  onRelationshipTypeChange: (value: RelationshipType) => void;
+  onNotesChange: (value: string) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+}
+
+interface RelationshipEditorSectionProps {
+  entities: BibleEntity[];
+  visibleRelationships: BibleRelationship[];
+  resolvedFromEntityId: string;
+  resolvedToEntityId: string;
+  relationshipType: RelationshipType;
+  notes: string;
+  errorMessage: string | null;
+  onFromEntityChange: (value: string) => void;
+  onToEntityChange: (value: string) => void;
+  onRelationshipTypeChange: (value: RelationshipType) => void;
+  onNotesChange: (value: string) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onDelete: (relationshipId: string) => void | Promise<void>;
+}
+
+function SectionError({ message }: { message: string | null }): ReactElement | null {
+  if (!message) {
+    return null;
+  }
+
+  return <p className="rounded-md bg-destructive/10 p-2 text-sm text-destructive">{message}</p>;
+}
+
+function EntitySelectField({
+  id,
+  label,
+  value,
+  entities,
+  disabled,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  entities: BibleEntity[];
+  disabled: boolean;
+  onChange: (value: string) => void;
+}): ReactElement {
+  return (
+    <div className="space-y-2">
+      <label className="text-sm font-semibold" htmlFor={id}>
+        {label}
+      </label>
+      <select
+        id={id}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+        disabled={disabled}
+      >
+        {entities.map((entity) => (
+          <option value={entity.id} key={entity.id}>
+            {entity.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function RelationshipTypeField({
+  value,
+  onChange,
+}: {
+  value: RelationshipType;
+  onChange: (value: RelationshipType) => void;
+}): ReactElement {
+  return (
+    <div className="space-y-2">
+      <label className="text-sm font-semibold" htmlFor="relationship-type">
+        Type
+      </label>
+      <select
+        id="relationship-type"
+        value={value}
+        onChange={(event) => onChange(event.target.value as RelationshipType)}
+        className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+      >
+        {RELATIONSHIP_TYPES.map((typeOption) => (
+          <option value={typeOption} key={typeOption}>
+            {typeOption}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function RelationshipNotesField({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+}): ReactElement {
+  return (
+    <div className="space-y-2">
+      <label className="text-sm font-semibold" htmlFor="relationship-notes">
+        Notes
+      </label>
+      <input
+        id="relationship-notes"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+        maxLength={500}
+      />
+    </div>
+  );
+}
+
+function RelationshipForm({
+  entities,
+  resolvedFromEntityId,
+  resolvedToEntityId,
+  relationshipType,
+  notes,
+  onFromEntityChange,
+  onToEntityChange,
+  onRelationshipTypeChange,
+  onNotesChange,
+  onSubmit,
+}: RelationshipFormProps): ReactElement {
+  return (
+    <form className="grid gap-3 md:grid-cols-2" onSubmit={onSubmit}>
+      <EntitySelectField
+        id="relationship-from-entity"
+        label="From entity"
+        value={resolvedFromEntityId}
+        entities={entities}
+        disabled={entities.length === 0}
+        onChange={onFromEntityChange}
+      />
+      <EntitySelectField
+        id="relationship-to-entity"
+        label="To entity"
+        value={resolvedToEntityId}
+        entities={entities}
+        disabled={entities.length === 0}
+        onChange={onToEntityChange}
+      />
+      <RelationshipTypeField value={relationshipType} onChange={onRelationshipTypeChange} />
+      <RelationshipNotesField value={notes} onChange={onNotesChange} />
+      <RelationshipSubmitButton disabled={entities.length < 2} />
+    </form>
+  );
+}
+
+function RelationshipSubmitButton({ disabled }: { disabled: boolean }): ReactElement {
+  return (
+    <div className="md:col-span-2">
+      <button
+        type="submit"
+        className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground"
+        disabled={disabled}
+      >
+        Save relationship
+      </button>
+    </div>
+  );
+}
+
+function RelationshipEditorSection({
+  entities,
+  visibleRelationships,
+  resolvedFromEntityId,
+  resolvedToEntityId,
+  relationshipType,
+  notes,
+  errorMessage,
+  onFromEntityChange,
+  onToEntityChange,
+  onRelationshipTypeChange,
+  onNotesChange,
+  onSubmit,
+  onDelete,
+}: RelationshipEditorSectionProps): ReactElement {
+  return (
+    <section className="space-y-4 rounded-lg border bg-card p-4 text-card-foreground">
+      <h3 className="text-base font-bold">Relationships</h3>
+      <SectionError message={errorMessage} />
+      <RelationshipForm
+        entities={entities}
+        resolvedFromEntityId={resolvedFromEntityId}
+        resolvedToEntityId={resolvedToEntityId}
+        relationshipType={relationshipType}
+        notes={notes}
+        onFromEntityChange={onFromEntityChange}
+        onToEntityChange={onToEntityChange}
+        onRelationshipTypeChange={onRelationshipTypeChange}
+        onNotesChange={onNotesChange}
+        onSubmit={onSubmit}
+      />
+      <RelationshipList visibleRelationships={visibleRelationships} entities={entities} onDelete={onDelete} />
+    </section>
+  );
+}
+
+function RelationshipList({
+  visibleRelationships,
+  entities,
+  onDelete,
+}: {
+  visibleRelationships: BibleRelationship[];
+  entities: BibleEntity[];
+  onDelete: (relationshipId: string) => void | Promise<void>;
+}): ReactElement {
+  const entitiesById = useMemo(() => new Map(entities.map((entity) => [entity.id, entity])), [entities]);
+
+  if (visibleRelationships.length === 0) {
+    return <p className="text-sm text-muted-foreground">No relationships found.</p>;
+  }
+
+  return (
+    <ul className="space-y-2">
+      {visibleRelationships.map((relationship) => (
+        <RelationshipListItem
+          key={relationship.id}
+          relationship={relationship}
+          fromEntityName={entitiesById.get(relationship.fromEntityId)?.name ?? relationship.fromEntityId}
+          toEntityName={entitiesById.get(relationship.toEntityId)?.name ?? relationship.toEntityId}
+          onDelete={onDelete}
+        />
+      ))}
+    </ul>
+  );
+}
+
+function RelationshipListItem({
+  relationship,
+  fromEntityName,
+  toEntityName,
+  onDelete,
+}: {
+  relationship: BibleRelationship;
+  fromEntityName: string;
+  toEntityName: string;
+  onDelete: (relationshipId: string) => void | Promise<void>;
+}): ReactElement {
+  return (
+    <li className="rounded-md border px-3 py-2">
+      <p className="text-sm">
+        <span className="font-semibold">{fromEntityName}</span> {relationship.type}{' '}
+        <span className="font-semibold">{toEntityName}</span>
+      </p>
+      {relationship.notes ? <p className="text-xs text-muted-foreground">{relationship.notes}</p> : null}
+      <button
+        type="button"
+        onClick={() => void onDelete(relationship.id)}
+        className="mt-2 text-xs font-semibold text-destructive"
+      >
+        Remove
+      </button>
+    </li>
+  );
+}
+
 export function RelationshipEditor({
   projectId,
   entities,
@@ -28,151 +300,29 @@ export function RelationshipEditor({
   onSave,
   onDelete,
 }: RelationshipEditorProps): ReactElement {
-  const [fromEntityId, setFromEntityId] = useState('');
-  const [toEntityId, setToEntityId] = useState('');
-  const [relationshipType, setRelationshipType] = useState<RelationshipType>('ally_of');
-  const [notes, setNotes] = useState('');
-  const entitiesById = useMemo(
-    () => new Map(entities.map((entity) => [entity.id, entity])),
-    [entities],
-  );
-  const entityIds = useMemo(() => new Set(entities.map((entity) => entity.id)), [entities]);
-  const visibleRelationships = selectedEntityId
-    ? relationships.filter(
-        (relationship) =>
-          relationship.fromEntityId === selectedEntityId || relationship.toEntityId === selectedEntityId,
-      )
-    : relationships;
-  const resolvedFromEntityId = useMemo(() => {
-    if (entityIds.has(fromEntityId)) {
-      return fromEntityId;
-    }
-    return selectedEntityId ?? entities[0]?.id ?? '';
-  }, [entities, entityIds, fromEntityId, selectedEntityId]);
-  const resolvedToEntityId = useMemo(() => {
-    if (entityIds.has(toEntityId) && toEntityId !== resolvedFromEntityId) {
-      return toEntityId;
-    }
-    return entities.find((entity) => entity.id !== resolvedFromEntityId)?.id ?? resolvedFromEntityId;
-  }, [entities, entityIds, resolvedFromEntityId, toEntityId]);
-
-  const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
-    event.preventDefault();
-    void onSave({
-      projectId,
-      type: relationshipType,
-      fromEntityId: resolvedFromEntityId,
-      toEntityId: resolvedToEntityId,
-      notes,
-    });
-    setNotes('');
-  };
+  const editorState = useRelationshipEditorState({
+    projectId,
+    entities,
+    relationships,
+    selectedEntityId,
+    onSave,
+  });
 
   return (
-    <section className="space-y-4 rounded-lg border bg-card p-4 text-card-foreground">
-      <h3 className="text-base font-bold">Relationships</h3>
-      {errorMessage ? <p className="rounded-md bg-destructive/10 p-2 text-sm text-destructive">{errorMessage}</p> : null}
-      <form className="grid gap-3 md:grid-cols-2" onSubmit={handleSubmit}>
-        <div className="space-y-2">
-          <label className="text-sm font-semibold" htmlFor="relationship-from-entity">
-            From entity
-          </label>
-          <select
-            id="relationship-from-entity"
-            value={resolvedFromEntityId}
-            onChange={(event) => setFromEntityId(event.target.value)}
-            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
-            disabled={entities.length === 0}
-          >
-            {entities.map((entity) => (
-              <option value={entity.id} key={entity.id}>
-                {entity.name}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div className="space-y-2">
-          <label className="text-sm font-semibold" htmlFor="relationship-to-entity">
-            To entity
-          </label>
-          <select
-            id="relationship-to-entity"
-            value={resolvedToEntityId}
-            onChange={(event) => setToEntityId(event.target.value)}
-            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
-            disabled={entities.length === 0}
-          >
-            {entities.map((entity) => (
-              <option value={entity.id} key={entity.id}>
-                {entity.name}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div className="space-y-2">
-          <label className="text-sm font-semibold" htmlFor="relationship-type">
-            Type
-          </label>
-          <select
-            id="relationship-type"
-            value={relationshipType}
-            onChange={(event) => setRelationshipType(event.target.value as RelationshipType)}
-            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
-          >
-            {RELATIONSHIP_TYPES.map((typeOption) => (
-              <option value={typeOption} key={typeOption}>
-                {typeOption}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div className="space-y-2">
-          <label className="text-sm font-semibold" htmlFor="relationship-notes">
-            Notes
-          </label>
-          <input
-            id="relationship-notes"
-            value={notes}
-            onChange={(event) => setNotes(event.target.value)}
-            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
-            maxLength={500}
-          />
-        </div>
-        <div className="md:col-span-2">
-          <button
-            type="submit"
-            className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground"
-            disabled={entities.length < 2}
-          >
-            Save relationship
-          </button>
-        </div>
-      </form>
-      <ul className="space-y-2">
-        {visibleRelationships.map((relationship) => {
-          const fromEntity = entitiesById.get(relationship.fromEntityId);
-          const toEntity = entitiesById.get(relationship.toEntityId);
-          return (
-            <li key={relationship.id} className="rounded-md border px-3 py-2">
-              <p className="text-sm">
-                <span className="font-semibold">{fromEntity?.name ?? relationship.fromEntityId}</span> {relationship.type}{' '}
-                <span className="font-semibold">{toEntity?.name ?? relationship.toEntityId}</span>
-              </p>
-              {relationship.notes ? <p className="text-xs text-muted-foreground">{relationship.notes}</p> : null}
-              <button
-                type="button"
-                onClick={() => void onDelete(relationship.id)}
-                className="mt-2 text-xs font-semibold text-destructive"
-              >
-                Remove
-              </button>
-            </li>
-          );
-        })}
-      </ul>
-      {visibleRelationships.length === 0 ? (
-        <p className="text-sm text-muted-foreground">No relationships found.</p>
-      ) : null}
-    </section>
+    <RelationshipEditorSection
+      entities={entities}
+      visibleRelationships={editorState.visibleRelationships}
+      resolvedFromEntityId={editorState.resolvedFromEntityId}
+      resolvedToEntityId={editorState.resolvedToEntityId}
+      relationshipType={editorState.state.relationshipType}
+      notes={editorState.state.notes}
+      errorMessage={errorMessage}
+      onFromEntityChange={editorState.setFromEntityId}
+      onToEntityChange={editorState.setToEntityId}
+      onRelationshipTypeChange={editorState.setRelationshipType}
+      onNotesChange={editorState.setNotes}
+      onSubmit={editorState.handleSubmit}
+      onDelete={onDelete}
+    />
   );
 }

--- a/src/components/bible/relationship-editor.tsx
+++ b/src/components/bible/relationship-editor.tsx
@@ -30,7 +30,7 @@ interface RelationshipFormProps {
   onToEntityChange: (value: string) => void;
   onRelationshipTypeChange: (value: RelationshipType) => void;
   onNotesChange: (value: string) => void;
-  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void | Promise<void>;
 }
 
 interface RelationshipEditorSectionProps {
@@ -45,7 +45,7 @@ interface RelationshipEditorSectionProps {
   onToEntityChange: (value: string) => void;
   onRelationshipTypeChange: (value: RelationshipType) => void;
   onNotesChange: (value: string) => void;
-  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void | Promise<void>;
   onDelete: (relationshipId: string) => void | Promise<void>;
 }
 

--- a/src/components/bible/relationship-editor.tsx
+++ b/src/components/bible/relationship-editor.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import { type FormEvent, type ReactElement, useMemo, useState } from 'react';
+import type {
+  BibleEntity,
+  BibleRelationship,
+  RelationshipType,
+  SaveBibleRelationshipInput,
+} from '@/domain/bible/types';
+import { RELATIONSHIP_TYPES } from '@/domain/bible/types';
+
+interface RelationshipEditorProps {
+  projectId: string;
+  entities: BibleEntity[];
+  relationships: BibleRelationship[];
+  selectedEntityId: string | null;
+  errorMessage: string | null;
+  onSave: (input: SaveBibleRelationshipInput) => void | Promise<void>;
+  onDelete: (relationshipId: string) => void | Promise<void>;
+}
+
+export function RelationshipEditor({
+  projectId,
+  entities,
+  relationships,
+  selectedEntityId,
+  errorMessage,
+  onSave,
+  onDelete,
+}: RelationshipEditorProps): ReactElement {
+  const [fromEntityId, setFromEntityId] = useState('');
+  const [toEntityId, setToEntityId] = useState('');
+  const [relationshipType, setRelationshipType] = useState<RelationshipType>('ally_of');
+  const [notes, setNotes] = useState('');
+  const entitiesById = useMemo(
+    () => new Map(entities.map((entity) => [entity.id, entity])),
+    [entities],
+  );
+  const entityIds = useMemo(() => new Set(entities.map((entity) => entity.id)), [entities]);
+  const visibleRelationships = selectedEntityId
+    ? relationships.filter(
+        (relationship) =>
+          relationship.fromEntityId === selectedEntityId || relationship.toEntityId === selectedEntityId,
+      )
+    : relationships;
+  const resolvedFromEntityId = useMemo(() => {
+    if (entityIds.has(fromEntityId)) {
+      return fromEntityId;
+    }
+    return selectedEntityId ?? entities[0]?.id ?? '';
+  }, [entities, entityIds, fromEntityId, selectedEntityId]);
+  const resolvedToEntityId = useMemo(() => {
+    if (entityIds.has(toEntityId) && toEntityId !== resolvedFromEntityId) {
+      return toEntityId;
+    }
+    return entities.find((entity) => entity.id !== resolvedFromEntityId)?.id ?? resolvedFromEntityId;
+  }, [entities, entityIds, resolvedFromEntityId, toEntityId]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    void onSave({
+      projectId,
+      type: relationshipType,
+      fromEntityId: resolvedFromEntityId,
+      toEntityId: resolvedToEntityId,
+      notes,
+    });
+    setNotes('');
+  };
+
+  return (
+    <section className="space-y-4 rounded-lg border bg-card p-4 text-card-foreground">
+      <h3 className="text-base font-bold">Relationships</h3>
+      {errorMessage ? <p className="rounded-md bg-destructive/10 p-2 text-sm text-destructive">{errorMessage}</p> : null}
+      <form className="grid gap-3 md:grid-cols-2" onSubmit={handleSubmit}>
+        <div className="space-y-2">
+          <label className="text-sm font-semibold" htmlFor="relationship-from-entity">
+            From entity
+          </label>
+          <select
+            id="relationship-from-entity"
+            value={resolvedFromEntityId}
+            onChange={(event) => setFromEntityId(event.target.value)}
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+            disabled={entities.length === 0}
+          >
+            {entities.map((entity) => (
+              <option value={entity.id} key={entity.id}>
+                {entity.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm font-semibold" htmlFor="relationship-to-entity">
+            To entity
+          </label>
+          <select
+            id="relationship-to-entity"
+            value={resolvedToEntityId}
+            onChange={(event) => setToEntityId(event.target.value)}
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+            disabled={entities.length === 0}
+          >
+            {entities.map((entity) => (
+              <option value={entity.id} key={entity.id}>
+                {entity.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm font-semibold" htmlFor="relationship-type">
+            Type
+          </label>
+          <select
+            id="relationship-type"
+            value={relationshipType}
+            onChange={(event) => setRelationshipType(event.target.value as RelationshipType)}
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+          >
+            {RELATIONSHIP_TYPES.map((typeOption) => (
+              <option value={typeOption} key={typeOption}>
+                {typeOption}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm font-semibold" htmlFor="relationship-notes">
+            Notes
+          </label>
+          <input
+            id="relationship-notes"
+            value={notes}
+            onChange={(event) => setNotes(event.target.value)}
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+            maxLength={500}
+          />
+        </div>
+        <div className="md:col-span-2">
+          <button
+            type="submit"
+            className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground"
+            disabled={entities.length < 2}
+          >
+            Save relationship
+          </button>
+        </div>
+      </form>
+      <ul className="space-y-2">
+        {visibleRelationships.map((relationship) => {
+          const fromEntity = entitiesById.get(relationship.fromEntityId);
+          const toEntity = entitiesById.get(relationship.toEntityId);
+          return (
+            <li key={relationship.id} className="rounded-md border px-3 py-2">
+              <p className="text-sm">
+                <span className="font-semibold">{fromEntity?.name ?? relationship.fromEntityId}</span> {relationship.type}{' '}
+                <span className="font-semibold">{toEntity?.name ?? relationship.toEntityId}</span>
+              </p>
+              {relationship.notes ? <p className="text-xs text-muted-foreground">{relationship.notes}</p> : null}
+              <button
+                type="button"
+                onClick={() => void onDelete(relationship.id)}
+                className="mt-2 text-xs font-semibold text-destructive"
+              >
+                Remove
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+      {visibleRelationships.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No relationships found.</p>
+      ) : null}
+    </section>
+  );
+}

--- a/src/components/bible/scene-links-state.ts
+++ b/src/components/bible/scene-links-state.ts
@@ -1,0 +1,149 @@
+'use client';
+
+import { type FormEvent, useMemo, useState } from 'react';
+import type {
+  BibleEntity,
+  BibleSceneLink,
+  ProjectScene,
+  SaveBibleSceneLinkInput,
+} from '@/domain/bible/types';
+
+interface SceneLinkFormState {
+  entityId: string;
+  sceneId: string;
+  notes: string;
+}
+
+interface SceneLinkFormStateActions {
+  state: SceneLinkFormState;
+  setEntityId: (value: string) => void;
+  setSceneId: (value: string) => void;
+  setNotes: (value: string) => void;
+  resetNotes: () => void;
+}
+
+interface SceneLinksEditorStateInput {
+  projectId: string;
+  entities: BibleEntity[];
+  scenes: ProjectScene[];
+  sceneLinks: BibleSceneLink[];
+  selectedEntityId: string | null;
+  onSave: (input: SaveBibleSceneLinkInput) => void | Promise<void>;
+}
+
+export interface SceneLinksEditorState {
+  state: SceneLinkFormState;
+  entitiesById: Map<string, BibleEntity>;
+  scenesById: Map<string, ProjectScene>;
+  visibleSceneLinks: BibleSceneLink[];
+  resolvedEntityId: string;
+  resolvedSceneId: string;
+  setEntityId: (value: string) => void;
+  setSceneId: (value: string) => void;
+  setNotes: (value: string) => void;
+  handleSubmit: (event: FormEvent<HTMLFormElement>) => void;
+}
+
+function useSceneLinkFormState(): SceneLinkFormStateActions {
+  const [entityId, setEntityId] = useState('');
+  const [sceneId, setSceneId] = useState('');
+  const [notes, setNotes] = useState('');
+
+  return {
+    state: { entityId, sceneId, notes },
+    setEntityId,
+    setSceneId,
+    setNotes,
+    resetNotes: () => setNotes(''),
+  };
+}
+
+function getVisibleSceneLinks(sceneLinks: BibleSceneLink[], selectedEntityId: string | null): BibleSceneLink[] {
+  if (!selectedEntityId) {
+    return sceneLinks;
+  }
+
+  return sceneLinks.filter((sceneLink) => sceneLink.entityId === selectedEntityId);
+}
+
+function resolveEntityId(candidateEntityId: string, selectedEntityId: string | null, entities: BibleEntity[]): string {
+  const entityIds = new Set(entities.map((entity) => entity.id));
+  if (entityIds.has(candidateEntityId)) {
+    return candidateEntityId;
+  }
+
+  return selectedEntityId ?? entities[0]?.id ?? '';
+}
+
+function resolveSceneId(candidateSceneId: string, scenes: ProjectScene[]): string {
+  const sceneIds = new Set(scenes.map((scene) => scene.id));
+  if (sceneIds.has(candidateSceneId)) {
+    return candidateSceneId;
+  }
+
+  return scenes[0]?.id ?? '';
+}
+
+function createSubmitHandler({
+  projectId,
+  state,
+  resolvedEntityId,
+  resolvedSceneId,
+  onSave,
+  resetNotes,
+}: {
+  projectId: string;
+  state: SceneLinkFormState;
+  resolvedEntityId: string;
+  resolvedSceneId: string;
+  onSave: (input: SaveBibleSceneLinkInput) => void | Promise<void>;
+  resetNotes: () => void;
+}): (event: FormEvent<HTMLFormElement>) => void {
+  return (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    void onSave({
+      projectId,
+      entityId: resolvedEntityId,
+      sceneId: resolvedSceneId,
+      notes: state.notes,
+    });
+    resetNotes();
+  };
+}
+
+export function useSceneLinksEditorState(input: SceneLinksEditorStateInput): SceneLinksEditorState {
+  const { projectId, entities, scenes, sceneLinks, selectedEntityId, onSave } = input;
+  const formState = useSceneLinkFormState();
+  const { entityId, sceneId } = formState.state;
+  const entitiesById = useMemo(() => new Map(entities.map((entity) => [entity.id, entity])), [entities]);
+  const scenesById = useMemo(() => new Map(scenes.map((scene) => [scene.id, scene])), [scenes]);
+  const visibleSceneLinks = useMemo(
+    () => getVisibleSceneLinks(sceneLinks, selectedEntityId),
+    [sceneLinks, selectedEntityId],
+  );
+  const resolvedEntityId = useMemo(
+    () => resolveEntityId(entityId, selectedEntityId, entities),
+    [entities, entityId, selectedEntityId],
+  );
+  const resolvedSceneId = useMemo(() => resolveSceneId(sceneId, scenes), [sceneId, scenes]);
+  const handleSubmit = createSubmitHandler({
+    projectId,
+    state: formState.state,
+    resolvedEntityId,
+    resolvedSceneId,
+    onSave,
+    resetNotes: formState.resetNotes,
+  });
+  return {
+    state: formState.state,
+    entitiesById,
+    scenesById,
+    visibleSceneLinks,
+    resolvedEntityId,
+    resolvedSceneId,
+    setEntityId: formState.setEntityId,
+    setSceneId: formState.setSceneId,
+    setNotes: formState.setNotes,
+    handleSubmit,
+  };
+}

--- a/src/components/bible/scene-links-state.ts
+++ b/src/components/bible/scene-links-state.ts
@@ -41,7 +41,7 @@ export interface SceneLinksEditorState {
   setEntityId: (value: string) => void;
   setSceneId: (value: string) => void;
   setNotes: (value: string) => void;
-  handleSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  handleSubmit: (event: FormEvent<HTMLFormElement>) => Promise<void>;
 }
 
 function useSceneLinkFormState(): SceneLinkFormStateActions {
@@ -98,16 +98,24 @@ function createSubmitHandler({
   resolvedSceneId: string;
   onSave: (input: SaveBibleSceneLinkInput) => void | Promise<void>;
   resetNotes: () => void;
-}): (event: FormEvent<HTMLFormElement>) => void {
-  return (event: FormEvent<HTMLFormElement>): void => {
+}): (event: FormEvent<HTMLFormElement>) => Promise<void> {
+  return async (event: FormEvent<HTMLFormElement>): Promise<void> => {
     event.preventDefault();
-    void onSave({
-      projectId,
-      entityId: resolvedEntityId,
-      sceneId: resolvedSceneId,
-      notes: state.notes,
-    });
-    resetNotes();
+    if (!resolvedEntityId || !resolvedSceneId) {
+      return;
+    }
+
+    try {
+      await onSave({
+        projectId,
+        entityId: resolvedEntityId,
+        sceneId: resolvedSceneId,
+        notes: state.notes,
+      });
+      resetNotes();
+    } catch {
+      // Keep notes so users can retry after a failed save.
+    }
   };
 }
 

--- a/src/components/bible/scene-links.tsx
+++ b/src/components/bible/scene-links.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { type FormEvent, type ReactElement, useMemo, useState } from 'react';
+import type {
+  BibleEntity,
+  BibleSceneLink,
+  ProjectScene,
+  SaveBibleSceneLinkInput,
+} from '@/domain/bible/types';
+
+interface SceneLinksProps {
+  projectId: string;
+  entities: BibleEntity[];
+  scenes: ProjectScene[];
+  sceneLinks: BibleSceneLink[];
+  selectedEntityId: string | null;
+  errorMessage: string | null;
+  onSave: (input: SaveBibleSceneLinkInput) => void | Promise<void>;
+  onDelete: (sceneLinkId: string) => void | Promise<void>;
+}
+
+export function SceneLinks({
+  projectId,
+  entities,
+  scenes,
+  sceneLinks,
+  selectedEntityId,
+  errorMessage,
+  onSave,
+  onDelete,
+}: SceneLinksProps): ReactElement {
+  const [entityId, setEntityId] = useState('');
+  const [sceneId, setSceneId] = useState('');
+  const [notes, setNotes] = useState('');
+  const entitiesById = useMemo(
+    () => new Map(entities.map((entity) => [entity.id, entity])),
+    [entities],
+  );
+  const entityIds = useMemo(() => new Set(entities.map((entity) => entity.id)), [entities]);
+  const scenesById = useMemo(
+    () => new Map(scenes.map((scene) => [scene.id, scene])),
+    [scenes],
+  );
+  const sceneIds = useMemo(() => new Set(scenes.map((scene) => scene.id)), [scenes]);
+  const visibleSceneLinks = selectedEntityId
+    ? sceneLinks.filter((sceneLink) => sceneLink.entityId === selectedEntityId)
+    : sceneLinks;
+  const resolvedEntityId = useMemo(() => {
+    if (entityIds.has(entityId)) {
+      return entityId;
+    }
+    return selectedEntityId ?? entities[0]?.id ?? '';
+  }, [entities, entityId, entityIds, selectedEntityId]);
+  const resolvedSceneId = useMemo(() => {
+    if (sceneIds.has(sceneId)) {
+      return sceneId;
+    }
+    return scenes[0]?.id ?? '';
+  }, [sceneId, sceneIds, scenes]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    void onSave({
+      projectId,
+      entityId: resolvedEntityId,
+      sceneId: resolvedSceneId,
+      notes,
+    });
+    setNotes('');
+  };
+
+  return (
+    <section className="space-y-4 rounded-lg border bg-card p-4 text-card-foreground">
+      <h3 className="text-base font-bold">Scene links</h3>
+      {errorMessage ? <p className="rounded-md bg-destructive/10 p-2 text-sm text-destructive">{errorMessage}</p> : null}
+      <form className="grid gap-3 md:grid-cols-2" onSubmit={handleSubmit}>
+        <div className="space-y-2">
+          <label className="text-sm font-semibold" htmlFor="scene-link-entity">
+            Entity
+          </label>
+          <select
+            id="scene-link-entity"
+            value={resolvedEntityId}
+            onChange={(event) => setEntityId(event.target.value)}
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+            disabled={entities.length === 0}
+          >
+            {entities.map((entity) => (
+              <option value={entity.id} key={entity.id}>
+                {entity.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm font-semibold" htmlFor="scene-link-scene">
+            Scene
+          </label>
+          <select
+            id="scene-link-scene"
+            value={resolvedSceneId}
+            onChange={(event) => setSceneId(event.target.value)}
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+            disabled={scenes.length === 0}
+          >
+            {scenes.map((scene) => (
+              <option value={scene.id} key={scene.id}>
+                {scene.title}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2 md:col-span-2">
+          <label className="text-sm font-semibold" htmlFor="scene-link-notes">
+            Notes
+          </label>
+          <input
+            id="scene-link-notes"
+            value={notes}
+            onChange={(event) => setNotes(event.target.value)}
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+            maxLength={500}
+          />
+        </div>
+        <div className="md:col-span-2">
+          <button
+            type="submit"
+            className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground"
+            disabled={entities.length === 0 || scenes.length === 0}
+          >
+            Save scene link
+          </button>
+        </div>
+      </form>
+      <ul className="space-y-2">
+        {visibleSceneLinks.map((sceneLink) => (
+          <li key={sceneLink.id} className="rounded-md border px-3 py-2">
+            <p className="text-sm">
+              <span className="font-semibold">{entitiesById.get(sceneLink.entityId)?.name ?? sceneLink.entityId}</span> in{' '}
+              <span className="font-semibold">{scenesById.get(sceneLink.sceneId)?.title ?? sceneLink.sceneId}</span>
+            </p>
+            {sceneLink.notes ? <p className="text-xs text-muted-foreground">{sceneLink.notes}</p> : null}
+            <button
+              type="button"
+              onClick={() => void onDelete(sceneLink.id)}
+              className="mt-2 text-xs font-semibold text-destructive"
+            >
+              Remove
+            </button>
+          </li>
+        ))}
+      </ul>
+      {visibleSceneLinks.length === 0 ? <p className="text-sm text-muted-foreground">No scene links found.</p> : null}
+    </section>
+  );
+}

--- a/src/components/bible/scene-links.tsx
+++ b/src/components/bible/scene-links.tsx
@@ -29,7 +29,7 @@ interface SceneLinkFormProps {
   onEntityChange: (value: string) => void;
   onSceneChange: (value: string) => void;
   onNotesChange: (value: string) => void;
-  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void | Promise<void>;
 }
 
 interface SceneLinksSectionProps {
@@ -45,7 +45,7 @@ interface SceneLinksSectionProps {
   onEntityChange: (value: string) => void;
   onSceneChange: (value: string) => void;
   onNotesChange: (value: string) => void;
-  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void | Promise<void>;
   onDelete: (sceneLinkId: string) => void | Promise<void>;
 }
 

--- a/src/components/bible/scene-links.tsx
+++ b/src/components/bible/scene-links.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { type FormEvent, type ReactElement, useMemo, useState } from 'react';
+import { type FormEvent, type ReactElement } from 'react';
+import { useSceneLinksEditorState } from '@/components/bible/scene-links-state';
 import type {
   BibleEntity,
   BibleSceneLink,
@@ -19,6 +20,248 @@ interface SceneLinksProps {
   onDelete: (sceneLinkId: string) => void | Promise<void>;
 }
 
+interface SceneLinkFormProps {
+  entities: BibleEntity[];
+  scenes: ProjectScene[];
+  resolvedEntityId: string;
+  resolvedSceneId: string;
+  notes: string;
+  onEntityChange: (value: string) => void;
+  onSceneChange: (value: string) => void;
+  onNotesChange: (value: string) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+}
+
+interface SceneLinksSectionProps {
+  entities: BibleEntity[];
+  scenes: ProjectScene[];
+  visibleSceneLinks: BibleSceneLink[];
+  entitiesById: Map<string, BibleEntity>;
+  scenesById: Map<string, ProjectScene>;
+  resolvedEntityId: string;
+  resolvedSceneId: string;
+  notes: string;
+  errorMessage: string | null;
+  onEntityChange: (value: string) => void;
+  onSceneChange: (value: string) => void;
+  onNotesChange: (value: string) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onDelete: (sceneLinkId: string) => void | Promise<void>;
+}
+
+function SectionError({ message }: { message: string | null }): ReactElement | null {
+  if (!message) {
+    return null;
+  }
+
+  return <p className="rounded-md bg-destructive/10 p-2 text-sm text-destructive">{message}</p>;
+}
+
+function SelectField({
+  id,
+  label,
+  value,
+  disabled,
+  options,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  disabled: boolean;
+  options: Array<{ value: string; label: string }>;
+  onChange: (value: string) => void;
+}): ReactElement {
+  return (
+    <div className="space-y-2">
+      <label className="text-sm font-semibold" htmlFor={id}>
+        {label}
+      </label>
+      <select
+        id={id}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+        disabled={disabled}
+      >
+        {options.map((option) => (
+          <option value={option.value} key={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function NotesField({ value, onChange }: { value: string; onChange: (value: string) => void }): ReactElement {
+  return (
+    <div className="space-y-2 md:col-span-2">
+      <label className="text-sm font-semibold" htmlFor="scene-link-notes">
+        Notes
+      </label>
+      <input
+        id="scene-link-notes"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+        maxLength={500}
+      />
+    </div>
+  );
+}
+
+function SceneLinkForm({
+  entities,
+  scenes,
+  resolvedEntityId,
+  resolvedSceneId,
+  notes,
+  onEntityChange,
+  onSceneChange,
+  onNotesChange,
+  onSubmit,
+}: SceneLinkFormProps): ReactElement {
+  const entityOptions = entities.map((entity) => ({ value: entity.id, label: entity.name }));
+  const sceneOptions = scenes.map((scene) => ({ value: scene.id, label: scene.title }));
+
+  return (
+    <form className="grid gap-3 md:grid-cols-2" onSubmit={onSubmit}>
+      <SelectField
+        id="scene-link-entity"
+        label="Entity"
+        value={resolvedEntityId}
+        options={entityOptions}
+        disabled={entities.length === 0}
+        onChange={onEntityChange}
+      />
+      <SelectField
+        id="scene-link-scene"
+        label="Scene"
+        value={resolvedSceneId}
+        options={sceneOptions}
+        disabled={scenes.length === 0}
+        onChange={onSceneChange}
+      />
+      <NotesField value={notes} onChange={onNotesChange} />
+      <SceneLinkSubmitButton disabled={entities.length === 0 || scenes.length === 0} />
+    </form>
+  );
+}
+
+function SceneLinkSubmitButton({ disabled }: { disabled: boolean }): ReactElement {
+  return (
+    <div className="md:col-span-2">
+      <button
+        type="submit"
+        className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground"
+        disabled={disabled}
+      >
+        Save scene link
+      </button>
+    </div>
+  );
+}
+
+function SceneLinksSection({
+  entities,
+  scenes,
+  visibleSceneLinks,
+  entitiesById,
+  scenesById,
+  resolvedEntityId,
+  resolvedSceneId,
+  notes,
+  errorMessage,
+  onEntityChange,
+  onSceneChange,
+  onNotesChange,
+  onSubmit,
+  onDelete,
+}: SceneLinksSectionProps): ReactElement {
+  return (
+    <section className="space-y-4 rounded-lg border bg-card p-4 text-card-foreground">
+      <h3 className="text-base font-bold">Scene links</h3>
+      <SectionError message={errorMessage} />
+      <SceneLinkForm
+        entities={entities}
+        scenes={scenes}
+        resolvedEntityId={resolvedEntityId}
+        resolvedSceneId={resolvedSceneId}
+        notes={notes}
+        onEntityChange={onEntityChange}
+        onSceneChange={onSceneChange}
+        onNotesChange={onNotesChange}
+        onSubmit={onSubmit}
+      />
+      <SceneLinksList
+        links={visibleSceneLinks}
+        entitiesById={entitiesById}
+        scenesById={scenesById}
+        onDelete={onDelete}
+      />
+    </section>
+  );
+}
+
+function SceneLinksList({
+  links,
+  entitiesById,
+  scenesById,
+  onDelete,
+}: {
+  links: BibleSceneLink[];
+  entitiesById: Map<string, BibleEntity>;
+  scenesById: Map<string, ProjectScene>;
+  onDelete: (sceneLinkId: string) => void | Promise<void>;
+}): ReactElement {
+  if (links.length === 0) {
+    return <p className="text-sm text-muted-foreground">No scene links found.</p>;
+  }
+
+  return (
+    <ul className="space-y-2">
+      {links.map((sceneLink) => (
+        <SceneLinksListItem
+          key={sceneLink.id}
+          sceneLink={sceneLink}
+          entityName={entitiesById.get(sceneLink.entityId)?.name ?? sceneLink.entityId}
+          sceneName={scenesById.get(sceneLink.sceneId)?.title ?? sceneLink.sceneId}
+          onDelete={onDelete}
+        />
+      ))}
+    </ul>
+  );
+}
+
+function SceneLinksListItem({
+  sceneLink,
+  entityName,
+  sceneName,
+  onDelete,
+}: {
+  sceneLink: BibleSceneLink;
+  entityName: string;
+  sceneName: string;
+  onDelete: (sceneLinkId: string) => void | Promise<void>;
+}): ReactElement {
+  return (
+    <li className="rounded-md border px-3 py-2">
+      <p className="text-sm">
+        <span className="font-semibold">{entityName}</span> in <span className="font-semibold">{sceneName}</span>
+      </p>
+      {sceneLink.notes ? <p className="text-xs text-muted-foreground">{sceneLink.notes}</p> : null}
+      <button
+        type="button"
+        onClick={() => void onDelete(sceneLink.id)}
+        className="mt-2 text-xs font-semibold text-destructive"
+      >
+        Remove
+      </button>
+    </li>
+  );
+}
+
 export function SceneLinks({
   projectId,
   entities,
@@ -29,128 +272,31 @@ export function SceneLinks({
   onSave,
   onDelete,
 }: SceneLinksProps): ReactElement {
-  const [entityId, setEntityId] = useState('');
-  const [sceneId, setSceneId] = useState('');
-  const [notes, setNotes] = useState('');
-  const entitiesById = useMemo(
-    () => new Map(entities.map((entity) => [entity.id, entity])),
-    [entities],
-  );
-  const entityIds = useMemo(() => new Set(entities.map((entity) => entity.id)), [entities]);
-  const scenesById = useMemo(
-    () => new Map(scenes.map((scene) => [scene.id, scene])),
-    [scenes],
-  );
-  const sceneIds = useMemo(() => new Set(scenes.map((scene) => scene.id)), [scenes]);
-  const visibleSceneLinks = selectedEntityId
-    ? sceneLinks.filter((sceneLink) => sceneLink.entityId === selectedEntityId)
-    : sceneLinks;
-  const resolvedEntityId = useMemo(() => {
-    if (entityIds.has(entityId)) {
-      return entityId;
-    }
-    return selectedEntityId ?? entities[0]?.id ?? '';
-  }, [entities, entityId, entityIds, selectedEntityId]);
-  const resolvedSceneId = useMemo(() => {
-    if (sceneIds.has(sceneId)) {
-      return sceneId;
-    }
-    return scenes[0]?.id ?? '';
-  }, [sceneId, sceneIds, scenes]);
-
-  const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
-    event.preventDefault();
-    void onSave({
-      projectId,
-      entityId: resolvedEntityId,
-      sceneId: resolvedSceneId,
-      notes,
-    });
-    setNotes('');
-  };
+  const editorState = useSceneLinksEditorState({
+    projectId,
+    entities,
+    scenes,
+    sceneLinks,
+    selectedEntityId,
+    onSave,
+  });
 
   return (
-    <section className="space-y-4 rounded-lg border bg-card p-4 text-card-foreground">
-      <h3 className="text-base font-bold">Scene links</h3>
-      {errorMessage ? <p className="rounded-md bg-destructive/10 p-2 text-sm text-destructive">{errorMessage}</p> : null}
-      <form className="grid gap-3 md:grid-cols-2" onSubmit={handleSubmit}>
-        <div className="space-y-2">
-          <label className="text-sm font-semibold" htmlFor="scene-link-entity">
-            Entity
-          </label>
-          <select
-            id="scene-link-entity"
-            value={resolvedEntityId}
-            onChange={(event) => setEntityId(event.target.value)}
-            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
-            disabled={entities.length === 0}
-          >
-            {entities.map((entity) => (
-              <option value={entity.id} key={entity.id}>
-                {entity.name}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div className="space-y-2">
-          <label className="text-sm font-semibold" htmlFor="scene-link-scene">
-            Scene
-          </label>
-          <select
-            id="scene-link-scene"
-            value={resolvedSceneId}
-            onChange={(event) => setSceneId(event.target.value)}
-            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
-            disabled={scenes.length === 0}
-          >
-            {scenes.map((scene) => (
-              <option value={scene.id} key={scene.id}>
-                {scene.title}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div className="space-y-2 md:col-span-2">
-          <label className="text-sm font-semibold" htmlFor="scene-link-notes">
-            Notes
-          </label>
-          <input
-            id="scene-link-notes"
-            value={notes}
-            onChange={(event) => setNotes(event.target.value)}
-            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
-            maxLength={500}
-          />
-        </div>
-        <div className="md:col-span-2">
-          <button
-            type="submit"
-            className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground"
-            disabled={entities.length === 0 || scenes.length === 0}
-          >
-            Save scene link
-          </button>
-        </div>
-      </form>
-      <ul className="space-y-2">
-        {visibleSceneLinks.map((sceneLink) => (
-          <li key={sceneLink.id} className="rounded-md border px-3 py-2">
-            <p className="text-sm">
-              <span className="font-semibold">{entitiesById.get(sceneLink.entityId)?.name ?? sceneLink.entityId}</span> in{' '}
-              <span className="font-semibold">{scenesById.get(sceneLink.sceneId)?.title ?? sceneLink.sceneId}</span>
-            </p>
-            {sceneLink.notes ? <p className="text-xs text-muted-foreground">{sceneLink.notes}</p> : null}
-            <button
-              type="button"
-              onClick={() => void onDelete(sceneLink.id)}
-              className="mt-2 text-xs font-semibold text-destructive"
-            >
-              Remove
-            </button>
-          </li>
-        ))}
-      </ul>
-      {visibleSceneLinks.length === 0 ? <p className="text-sm text-muted-foreground">No scene links found.</p> : null}
-    </section>
+    <SceneLinksSection
+      entities={entities}
+      scenes={scenes}
+      visibleSceneLinks={editorState.visibleSceneLinks}
+      entitiesById={editorState.entitiesById}
+      scenesById={editorState.scenesById}
+      resolvedEntityId={editorState.resolvedEntityId}
+      resolvedSceneId={editorState.resolvedSceneId}
+      notes={editorState.state.notes}
+      errorMessage={errorMessage}
+      onEntityChange={editorState.setEntityId}
+      onSceneChange={editorState.setSceneId}
+      onNotesChange={editorState.setNotes}
+      onSubmit={editorState.handleSubmit}
+      onDelete={onDelete}
+    />
   );
 }

--- a/src/data/bible/local-bible-repository.ts
+++ b/src/data/bible/local-bible-repository.ts
@@ -11,12 +11,6 @@ import type {
   ProjectScene,
 } from '@/domain/bible/types';
 
-const EMPTY_BIBLE_STORAGE: BibleStorageDocument = {
-  entities: [],
-  relationships: [],
-  sceneLinks: [],
-};
-
 function cloneEmptyBibleStorage(): BibleStorageDocument {
   return {
     entities: [],
@@ -315,4 +309,6 @@ export class LocalBibleRepository implements BibleRepository {
   }
 }
 
-export const emptyBibleStorage = EMPTY_BIBLE_STORAGE;
+export function createEmptyBibleStorage(): BibleStorageDocument {
+  return cloneEmptyBibleStorage();
+}

--- a/src/data/bible/local-bible-repository.ts
+++ b/src/data/bible/local-bible-repository.ts
@@ -1,0 +1,318 @@
+import { bibleEntitySchema, bibleRelationshipSchema, bibleSceneLinkSchema, bibleStorageSchema, projectSceneSchema, projectScenesSchema } from '@/domain/bible/schemas';
+import type { BibleRepository } from '@/domain/bible/repository';
+import type {
+  BibleEntity,
+  BibleEntityFilters,
+  BibleRelationship,
+  BibleRelationshipFilters,
+  BibleSceneLink,
+  BibleSceneLinkFilters,
+  BibleStorageDocument,
+  ProjectScene,
+} from '@/domain/bible/types';
+
+const EMPTY_BIBLE_STORAGE: BibleStorageDocument = {
+  entities: [],
+  relationships: [],
+  sceneLinks: [],
+};
+
+function cloneEmptyBibleStorage(): BibleStorageDocument {
+  return {
+    entities: [],
+    relationships: [],
+    sceneLinks: [],
+  };
+}
+
+function normalizeProjectId(projectId: string): string {
+  const normalizedProjectId = projectId.trim();
+  if (!normalizedProjectId) {
+    throw new Error('projectId is required');
+  }
+  return normalizedProjectId;
+}
+
+function parseJson(rawValue: string | null): unknown | null {
+  if (!rawValue) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(rawValue) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function toComparableDate(value: string): number {
+  const numericDate = Date.parse(value);
+  return Number.isNaN(numericDate) ? 0 : numericDate;
+}
+
+function toSearchHaystack(entity: BibleEntity): string {
+  return [entity.name, entity.summary, entity.tags.join(' ')].join(' ').toLowerCase();
+}
+
+export class LocalBibleRepository implements BibleRepository {
+  private readonly storage: Storage;
+
+  public constructor(storage?: Storage) {
+    if (storage) {
+      this.storage = storage;
+      return;
+    }
+
+    if (typeof window !== 'undefined' && window.localStorage) {
+      this.storage = window.localStorage;
+      return;
+    }
+
+    throw new Error('Storage backend is unavailable');
+  }
+
+  public listEntities(projectId: string, filters?: BibleEntityFilters): BibleEntity[] {
+    const { entities } = this.readBible(projectId);
+    const category = filters?.category;
+    const searchTerm = filters?.search?.trim().toLowerCase();
+
+    return entities
+      .filter((entity) => (category ? entity.category === category : true))
+      .filter((entity) => (searchTerm ? toSearchHaystack(entity).includes(searchTerm) : true))
+      .sort((left, right) => toComparableDate(right.updatedAt) - toComparableDate(left.updatedAt));
+  }
+
+  public getEntity(projectId: string, entityId: string): BibleEntity | null {
+    const normalizedProjectId = normalizeProjectId(projectId);
+    const normalizedEntityId = entityId.trim();
+    if (!normalizedEntityId) {
+      return null;
+    }
+
+    const { entities } = this.readBible(normalizedProjectId);
+    return entities.find((entity) => entity.id === normalizedEntityId) ?? null;
+  }
+
+  public upsertEntity(entity: BibleEntity): BibleEntity {
+    const parsedEntity = bibleEntitySchema.parse(entity);
+    const normalizedProjectId = normalizeProjectId(parsedEntity.projectId);
+    const bibleStorage = this.readBible(normalizedProjectId);
+    const entityIndex = bibleStorage.entities.findIndex((item) => item.id === parsedEntity.id);
+
+    if (entityIndex < 0) {
+      bibleStorage.entities.push(parsedEntity);
+    } else {
+      bibleStorage.entities[entityIndex] = parsedEntity;
+    }
+
+    this.writeBible(normalizedProjectId, bibleStorage);
+    return parsedEntity;
+  }
+
+  public deleteEntity(projectId: string, entityId: string): void {
+    const normalizedProjectId = normalizeProjectId(projectId);
+    const normalizedEntityId = entityId.trim();
+    const bibleStorage = this.readBible(normalizedProjectId);
+
+    bibleStorage.entities = bibleStorage.entities.filter((entity) => entity.id !== normalizedEntityId);
+    bibleStorage.relationships = bibleStorage.relationships.filter(
+      (relationship) =>
+        relationship.fromEntityId !== normalizedEntityId && relationship.toEntityId !== normalizedEntityId,
+    );
+    bibleStorage.sceneLinks = bibleStorage.sceneLinks.filter((sceneLink) => sceneLink.entityId !== normalizedEntityId);
+    this.writeBible(normalizedProjectId, bibleStorage);
+  }
+
+  public listRelationships(projectId: string, filters?: BibleRelationshipFilters): BibleRelationship[] {
+    const { relationships } = this.readBible(projectId);
+    const relationshipType = filters?.type;
+    const fromEntityId = filters?.fromEntityId;
+    const toEntityId = filters?.toEntityId;
+    const entityId = filters?.entityId;
+
+    return relationships.filter((relationship) => {
+      if (relationshipType && relationship.type !== relationshipType) {
+        return false;
+      }
+      if (fromEntityId && relationship.fromEntityId !== fromEntityId) {
+        return false;
+      }
+      if (toEntityId && relationship.toEntityId !== toEntityId) {
+        return false;
+      }
+      if (entityId && relationship.fromEntityId !== entityId && relationship.toEntityId !== entityId) {
+        return false;
+      }
+      return true;
+    });
+  }
+
+  public upsertRelationship(relationship: BibleRelationship): BibleRelationship {
+    const parsedRelationship = bibleRelationshipSchema.parse(relationship);
+    const normalizedProjectId = normalizeProjectId(parsedRelationship.projectId);
+    const bibleStorage = this.readBible(normalizedProjectId);
+    const relationshipIndex = bibleStorage.relationships.findIndex(
+      (item) => item.id === parsedRelationship.id,
+    );
+
+    if (relationshipIndex < 0) {
+      bibleStorage.relationships.push(parsedRelationship);
+    } else {
+      bibleStorage.relationships[relationshipIndex] = parsedRelationship;
+    }
+
+    this.writeBible(normalizedProjectId, bibleStorage);
+    return parsedRelationship;
+  }
+
+  public deleteRelationship(projectId: string, relationshipId: string): void {
+    const normalizedProjectId = normalizeProjectId(projectId);
+    const normalizedRelationshipId = relationshipId.trim();
+    const bibleStorage = this.readBible(normalizedProjectId);
+
+    bibleStorage.relationships = bibleStorage.relationships.filter(
+      (relationship) => relationship.id !== normalizedRelationshipId,
+    );
+    this.writeBible(normalizedProjectId, bibleStorage);
+  }
+
+  public listSceneLinks(projectId: string, filters?: BibleSceneLinkFilters): BibleSceneLink[] {
+    const { sceneLinks } = this.readBible(projectId);
+    const entityId = filters?.entityId;
+    const sceneId = filters?.sceneId;
+
+    return sceneLinks.filter((sceneLink) => {
+      if (entityId && sceneLink.entityId !== entityId) {
+        return false;
+      }
+      if (sceneId && sceneLink.sceneId !== sceneId) {
+        return false;
+      }
+      return true;
+    });
+  }
+
+  public upsertSceneLink(sceneLink: BibleSceneLink): BibleSceneLink {
+    const parsedSceneLink = bibleSceneLinkSchema.parse(sceneLink);
+    const normalizedProjectId = normalizeProjectId(parsedSceneLink.projectId);
+    const bibleStorage = this.readBible(normalizedProjectId);
+    const sceneLinkIndex = bibleStorage.sceneLinks.findIndex((item) => item.id === parsedSceneLink.id);
+
+    if (sceneLinkIndex < 0) {
+      bibleStorage.sceneLinks.push(parsedSceneLink);
+    } else {
+      bibleStorage.sceneLinks[sceneLinkIndex] = parsedSceneLink;
+    }
+
+    this.writeBible(normalizedProjectId, bibleStorage);
+    return parsedSceneLink;
+  }
+
+  public deleteSceneLink(projectId: string, sceneLinkId: string): void {
+    const normalizedProjectId = normalizeProjectId(projectId);
+    const normalizedSceneLinkId = sceneLinkId.trim();
+    const bibleStorage = this.readBible(normalizedProjectId);
+
+    bibleStorage.sceneLinks = bibleStorage.sceneLinks.filter((sceneLink) => sceneLink.id !== normalizedSceneLinkId);
+    this.writeBible(normalizedProjectId, bibleStorage);
+  }
+
+  public listScenes(projectId: string): ProjectScene[] {
+    const normalizedProjectId = normalizeProjectId(projectId);
+    const projectScenes = this.readScenes(normalizedProjectId);
+    return projectScenes.sort((left, right) => left.order - right.order);
+  }
+
+  public upsertScene(scene: ProjectScene): ProjectScene {
+    const parsedScene = projectSceneSchema.parse(scene);
+    const normalizedProjectId = normalizeProjectId(parsedScene.projectId);
+    const projectScenes = this.readScenes(normalizedProjectId);
+    const sceneIndex = projectScenes.findIndex((item) => item.id === parsedScene.id);
+
+    if (sceneIndex < 0) {
+      projectScenes.push(parsedScene);
+    } else {
+      projectScenes[sceneIndex] = parsedScene;
+    }
+
+    this.writeScenes(normalizedProjectId, projectScenes);
+    return parsedScene;
+  }
+
+  public bulkSeedScenes(projectId: string, scenes: ProjectScene[]): ProjectScene[] {
+    const normalizedProjectId = normalizeProjectId(projectId);
+    const existingScenes = this.readScenes(normalizedProjectId);
+    if (existingScenes.length > 0) {
+      return existingScenes.sort((left, right) => left.order - right.order);
+    }
+
+    const parsedScenes = scenes
+      .map((scene) => projectSceneSchema.parse(scene))
+      .filter((scene) => scene.projectId === normalizedProjectId);
+
+    this.writeScenes(normalizedProjectId, parsedScenes);
+    return parsedScenes.sort((left, right) => left.order - right.order);
+  }
+
+  private readBible(projectId: string): BibleStorageDocument {
+    const normalizedProjectId = normalizeProjectId(projectId);
+    const rawValue = this.storage.getItem(this.bibleStorageKey(normalizedProjectId));
+    const parsedValue = parseJson(rawValue);
+
+    if (!parsedValue) {
+      return cloneEmptyBibleStorage();
+    }
+
+    const parsedStorage = bibleStorageSchema.safeParse(parsedValue);
+    if (!parsedStorage.success) {
+      return cloneEmptyBibleStorage();
+    }
+
+    return {
+      entities: [...parsedStorage.data.entities],
+      relationships: [...parsedStorage.data.relationships],
+      sceneLinks: [...parsedStorage.data.sceneLinks],
+    };
+  }
+
+  private writeBible(projectId: string, bibleStorage: BibleStorageDocument): void {
+    const normalizedProjectId = normalizeProjectId(projectId);
+    const parsedStorage = bibleStorageSchema.parse(bibleStorage);
+    const payload = JSON.stringify(parsedStorage);
+    this.storage.setItem(this.bibleStorageKey(normalizedProjectId), payload);
+  }
+
+  private readScenes(projectId: string): ProjectScene[] {
+    const normalizedProjectId = normalizeProjectId(projectId);
+    const rawValue = this.storage.getItem(this.projectScenesStorageKey(normalizedProjectId));
+    const parsedValue = parseJson(rawValue);
+
+    if (!parsedValue) {
+      return [];
+    }
+
+    const parsedScenes = projectScenesSchema.safeParse(parsedValue);
+    if (!parsedScenes.success) {
+      return [];
+    }
+
+    return [...parsedScenes.data];
+  }
+
+  private writeScenes(projectId: string, scenes: ProjectScene[]): void {
+    const normalizedProjectId = normalizeProjectId(projectId);
+    const parsedScenes = projectScenesSchema.parse(scenes);
+    const payload = JSON.stringify(parsedScenes);
+    this.storage.setItem(this.projectScenesStorageKey(normalizedProjectId), payload);
+  }
+
+  private bibleStorageKey(projectId: string): string {
+    return `ainkwell:projects:${projectId}:bible:v1`;
+  }
+
+  private projectScenesStorageKey(projectId: string): string {
+    return `ainkwell:projects:${projectId}:scenes:v1`;
+  }
+}
+
+export const emptyBibleStorage = EMPTY_BIBLE_STORAGE;

--- a/src/domain/bible/repository.ts
+++ b/src/domain/bible/repository.ts
@@ -1,0 +1,25 @@
+import type {
+  BibleEntity,
+  BibleEntityFilters,
+  BibleRelationship,
+  BibleRelationshipFilters,
+  BibleSceneLink,
+  BibleSceneLinkFilters,
+  ProjectScene,
+} from '@/domain/bible/types';
+
+export interface BibleRepository {
+  listEntities(projectId: string, filters?: BibleEntityFilters): BibleEntity[];
+  getEntity(projectId: string, entityId: string): BibleEntity | null;
+  upsertEntity(entity: BibleEntity): BibleEntity;
+  deleteEntity(projectId: string, entityId: string): void;
+  listRelationships(projectId: string, filters?: BibleRelationshipFilters): BibleRelationship[];
+  upsertRelationship(relationship: BibleRelationship): BibleRelationship;
+  deleteRelationship(projectId: string, relationshipId: string): void;
+  listSceneLinks(projectId: string, filters?: BibleSceneLinkFilters): BibleSceneLink[];
+  upsertSceneLink(sceneLink: BibleSceneLink): BibleSceneLink;
+  deleteSceneLink(projectId: string, sceneLinkId: string): void;
+  listScenes(projectId: string): ProjectScene[];
+  upsertScene(scene: ProjectScene): ProjectScene;
+  bulkSeedScenes(projectId: string, scenes: ProjectScene[]): ProjectScene[];
+}

--- a/src/domain/bible/schemas.ts
+++ b/src/domain/bible/schemas.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+import { BIBLE_ENTITY_CATEGORIES, RELATIONSHIP_TYPES } from '@/domain/bible/types';
+
+const idSchema = z.string().trim().min(1).max(120);
+const projectIdSchema = z.string().trim().min(1).max(120);
+const timestampSchema = z.string().trim().min(1).max(64);
+const trimmedStringSchema = z.string().trim();
+
+export const bibleEntitySchema = z.object({
+  id: idSchema,
+  projectId: projectIdSchema,
+  category: z.enum(BIBLE_ENTITY_CATEGORIES),
+  name: trimmedStringSchema.min(1).max(120),
+  summary: trimmedStringSchema.max(280),
+  details: trimmedStringSchema.max(5000),
+  tags: z.array(trimmedStringSchema.min(1).max(30)).max(12),
+  createdAt: timestampSchema,
+  updatedAt: timestampSchema,
+});
+
+export const bibleRelationshipSchema = z
+  .object({
+    id: idSchema,
+    projectId: projectIdSchema,
+    type: z.enum(RELATIONSHIP_TYPES),
+    fromEntityId: idSchema,
+    toEntityId: idSchema,
+    notes: trimmedStringSchema.max(500),
+    createdAt: timestampSchema,
+    updatedAt: timestampSchema,
+  })
+  .refine((relationship) => relationship.fromEntityId !== relationship.toEntityId, {
+    message: 'Self references are not allowed',
+    path: ['toEntityId'],
+  });
+
+export const bibleSceneLinkSchema = z.object({
+  id: idSchema,
+  projectId: projectIdSchema,
+  sceneId: idSchema,
+  entityId: idSchema,
+  notes: trimmedStringSchema.max(500),
+  createdAt: timestampSchema,
+  updatedAt: timestampSchema,
+});
+
+export const projectSceneSchema = z.object({
+  id: idSchema,
+  projectId: projectIdSchema,
+  title: trimmedStringSchema.min(1).max(160),
+  order: z.number().int().min(0),
+});
+
+export const bibleStorageSchema = z.object({
+  entities: z.array(bibleEntitySchema).default([]),
+  relationships: z.array(bibleRelationshipSchema).default([]),
+  sceneLinks: z.array(bibleSceneLinkSchema).default([]),
+});
+
+export const projectScenesSchema = z.array(projectSceneSchema).default([]);

--- a/src/domain/bible/types.ts
+++ b/src/domain/bible/types.ts
@@ -1,0 +1,106 @@
+export const BIBLE_ENTITY_CATEGORIES = ['character', 'location', 'faction', 'lore'] as const;
+export type BibleEntityCategory = (typeof BIBLE_ENTITY_CATEGORIES)[number];
+
+export const RELATIONSHIP_TYPES = [
+  'ally_of',
+  'enemy_of',
+  'member_of',
+  'located_in',
+  'parent_of',
+  'sibling_of',
+  'mentor_of',
+  'rival_of',
+  'controls',
+  'knows',
+] as const;
+export type RelationshipType = (typeof RELATIONSHIP_TYPES)[number];
+
+export interface BibleEntity {
+  id: string;
+  projectId: string;
+  category: BibleEntityCategory;
+  name: string;
+  summary: string;
+  details: string;
+  tags: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BibleRelationship {
+  id: string;
+  projectId: string;
+  type: RelationshipType;
+  fromEntityId: string;
+  toEntityId: string;
+  notes: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BibleSceneLink {
+  id: string;
+  projectId: string;
+  sceneId: string;
+  entityId: string;
+  notes: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProjectScene {
+  id: string;
+  projectId: string;
+  title: string;
+  order: number;
+}
+
+export interface BibleStorageDocument {
+  entities: BibleEntity[];
+  relationships: BibleRelationship[];
+  sceneLinks: BibleSceneLink[];
+}
+
+export interface BibleEntityFilters {
+  category?: BibleEntityCategory;
+  search?: string;
+}
+
+export interface BibleRelationshipFilters {
+  entityId?: string;
+  fromEntityId?: string;
+  toEntityId?: string;
+  type?: RelationshipType;
+}
+
+export interface BibleSceneLinkFilters {
+  entityId?: string;
+  sceneId?: string;
+}
+
+export interface SaveBibleEntityInput {
+  projectId: string;
+  entityId?: string;
+  category: BibleEntityCategory;
+  name: string;
+  summary?: string;
+  details?: string;
+  tags?: string[];
+}
+
+export interface SaveBibleRelationshipInput {
+  projectId: string;
+  relationshipId?: string;
+  type: RelationshipType;
+  fromEntityId: string;
+  toEntityId: string;
+  notes?: string;
+}
+
+export interface SaveBibleSceneLinkInput {
+  projectId: string;
+  sceneLinkId?: string;
+  sceneId: string;
+  entityId: string;
+  notes?: string;
+}

--- a/src/domain/project/schemas.ts
+++ b/src/domain/project/schemas.ts
@@ -81,54 +81,72 @@ export const writingProjectSchema = z
     scenes: z.record(projectSceneSchema),
   })
   .superRefine((value, context) => {
-    const orderedSceneIdentifiers = new Set<string>();
-
-    for (const sceneId of value.sceneOrder) {
-      if (orderedSceneIdentifiers.has(sceneId)) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Duplicate scene reference for ${sceneId}.`,
-          path: ['sceneOrder'],
-        });
-        continue;
-      }
-
-      orderedSceneIdentifiers.add(sceneId);
-      if (!(sceneId in value.scenes)) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Missing scene reference for ${sceneId}.`,
-          path: ['sceneOrder'],
-        });
-      }
-    }
-
-    for (const [sceneId, scene] of Object.entries(value.scenes)) {
-      if (!orderedSceneIdentifiers.has(sceneId)) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Scene ${sceneId} is missing from sceneOrder.`,
-          path: ['scenes', sceneId],
-        });
-      }
-
-      if (scene.id !== sceneId) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Scene key ${sceneId} does not match scene.id.`,
-          path: ['scenes', sceneId, 'id'],
-        });
-      }
-
-      if (scene.projectId !== value.id) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Scene ${sceneId} belongs to another project.`,
-          path: ['scenes', sceneId, 'projectId'],
-        });
-      }
-    }
+    const orderedSceneIds = validateOrderedScenes(value.sceneOrder, value.scenes, context);
+    validateSceneRecordEntries(value.id, orderedSceneIds, value.scenes, context);
   });
+
+function addCustomIssue(
+  context: z.RefinementCtx,
+  message: string,
+  path: Array<string>,
+): void {
+  context.addIssue({
+    code: z.ZodIssueCode.custom,
+    message,
+    path,
+  });
+}
+
+function validateOrderedScenes(
+  sceneOrder: string[],
+  scenes: Record<string, z.infer<typeof projectSceneSchema>>,
+  context: z.RefinementCtx,
+): Set<string> {
+  const orderedSceneIdentifiers = new Set<string>();
+
+  for (const sceneId of sceneOrder) {
+    if (orderedSceneIdentifiers.has(sceneId)) {
+      addCustomIssue(context, `Duplicate scene reference for ${sceneId}.`, ['sceneOrder']);
+      continue;
+    }
+
+    orderedSceneIdentifiers.add(sceneId);
+    if (!(sceneId in scenes)) {
+      addCustomIssue(context, `Missing scene reference for ${sceneId}.`, ['sceneOrder']);
+    }
+  }
+
+  return orderedSceneIdentifiers;
+}
+
+function validateSceneRecordEntries(
+  projectId: string,
+  orderedSceneIdentifiers: Set<string>,
+  scenes: Record<string, z.infer<typeof projectSceneSchema>>,
+  context: z.RefinementCtx,
+): void {
+  for (const [sceneId, scene] of Object.entries(scenes)) {
+    if (!orderedSceneIdentifiers.has(sceneId)) {
+      addCustomIssue(context, `Scene ${sceneId} is missing from sceneOrder.`, ['scenes', sceneId]);
+    }
+
+    if (scene.id !== sceneId) {
+      addCustomIssue(context, `Scene key ${sceneId} does not match scene.id.`, [
+        'scenes',
+        sceneId,
+        'id',
+      ]);
+    }
+
+    if (scene.projectId !== projectId) {
+      addCustomIssue(context, `Scene ${sceneId} belongs to another project.`, [
+        'scenes',
+        sceneId,
+        'projectId',
+      ]);
+    }
+  }
+}
 
 const legacyWritingProjectSchema = z.object({
   id: projectIdSchema,

--- a/src/domain/scene/schemas.ts
+++ b/src/domain/scene/schemas.ts
@@ -57,54 +57,72 @@ export const projectStoreSchema = z
     scenes: z.record(legacySceneSchema),
   })
   .superRefine((value, context) => {
-    const orderedIds = new Set<string>();
-
-    for (const sceneId of value.sceneOrder) {
-      if (orderedIds.has(sceneId)) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Duplicate scene reference for ${sceneId}.`,
-          path: ['sceneOrder'],
-        });
-        continue;
-      }
-
-      orderedIds.add(sceneId);
-      if (!(sceneId in value.scenes)) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Missing scene reference for ${sceneId}.`,
-          path: ['sceneOrder'],
-        });
-      }
-    }
-
-    for (const [sceneId, scene] of Object.entries(value.scenes)) {
-      if (!orderedIds.has(sceneId)) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Scene ${sceneId} is not present in sceneOrder.`,
-          path: ['scenes', sceneId],
-        });
-      }
-
-      if (scene.id !== sceneId) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Scene key ${sceneId} does not match scene.id.`,
-          path: ['scenes', sceneId, 'id'],
-        });
-      }
-
-      if (scene.projectId !== value.id) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Scene ${sceneId} belongs to another project.`,
-          path: ['scenes', sceneId, 'projectId'],
-        });
-      }
-    }
+    const orderedIds = validateSceneOrder(value.sceneOrder, value.scenes, context);
+    validateSceneRecords(value.id, orderedIds, value.scenes, context);
   });
+
+function addValidationIssue(
+  context: z.RefinementCtx,
+  message: string,
+  path: Array<string>,
+): void {
+  context.addIssue({
+    code: z.ZodIssueCode.custom,
+    message,
+    path,
+  });
+}
+
+function validateSceneOrder(
+  sceneOrder: string[],
+  scenes: Record<string, z.infer<typeof legacySceneSchema>>,
+  context: z.RefinementCtx,
+): Set<string> {
+  const orderedIds = new Set<string>();
+
+  for (const sceneId of sceneOrder) {
+    if (orderedIds.has(sceneId)) {
+      addValidationIssue(context, `Duplicate scene reference for ${sceneId}.`, ['sceneOrder']);
+      continue;
+    }
+
+    orderedIds.add(sceneId);
+    if (!(sceneId in scenes)) {
+      addValidationIssue(context, `Missing scene reference for ${sceneId}.`, ['sceneOrder']);
+    }
+  }
+
+  return orderedIds;
+}
+
+function validateSceneRecords(
+  projectId: string,
+  orderedIds: Set<string>,
+  scenes: Record<string, z.infer<typeof legacySceneSchema>>,
+  context: z.RefinementCtx,
+): void {
+  for (const [sceneId, scene] of Object.entries(scenes)) {
+    if (!orderedIds.has(sceneId)) {
+      addValidationIssue(context, `Scene ${sceneId} is not present in sceneOrder.`, ['scenes', sceneId]);
+    }
+
+    if (scene.id !== sceneId) {
+      addValidationIssue(context, `Scene key ${sceneId} does not match scene.id.`, [
+        'scenes',
+        sceneId,
+        'id',
+      ]);
+    }
+
+    if (scene.projectId !== projectId) {
+      addValidationIssue(context, `Scene ${sceneId} belongs to another project.`, [
+        'scenes',
+        sceneId,
+        'projectId',
+      ]);
+    }
+  }
+}
 
 export const workspaceStoreSchema = z.object({
   version: z.literal(1),

--- a/src/hooks/use-scene-editor.ts
+++ b/src/hooks/use-scene-editor.ts
@@ -154,52 +154,54 @@ function useLoadScene(
   patchViewState: ViewStateSetter,
   replaceViewState: ViewStateReplacer,
 ): void {
+  const { projectId, sceneId, service } = input;
+
   useEffect(() => {
-    const loadScene = async (): Promise<void> => {
-      patchViewState({ loadState: 'loading', saveError: null });
+    void loadSceneState({ projectId, sceneId, service }, runtimeRefs, patchViewState, replaceViewState);
+  }, [patchViewState, projectId, replaceViewState, runtimeRefs, sceneId, service]);
+}
 
-      try {
-        const result = await input.service.loadScene({
-          projectId: input.projectId,
-          sceneId: input.sceneId,
-        });
+async function loadSceneState(
+  input: UseSceneEditorInput,
+  runtimeRefs: SceneRuntimeRefs,
+  patchViewState: ViewStateSetter,
+  replaceViewState: ViewStateReplacer,
+): Promise<void> {
+  patchViewState({ loadState: 'loading', saveError: null });
 
-        if (!runtimeRefs.isMountedRef.current) {
-          return;
-        }
+  try {
+    const result = await input.service.loadScene({
+      projectId: input.projectId,
+      sceneId: input.sceneId,
+    });
 
-        if (result.state === 'project-not-found') {
-          applyUnavailableScene(runtimeRefs, replaceViewState, 'project-not-found');
-          return;
-        }
+    if (!runtimeRefs.isMountedRef.current) {
+      return;
+    }
 
-        if (result.state === 'scene-not-found') {
-          applyUnavailableScene(runtimeRefs, replaceViewState, 'scene-not-found');
-          return;
-        }
+    if (result.state !== 'ready') {
+      applyUnavailableScene(runtimeRefs, replaceViewState, result.state);
+      return;
+    }
 
-        applyLoadedScene({
-          runtimeRefs,
-          replaceViewState,
-          scene: result.scene,
-          previousSceneId: result.previousSceneId,
-          nextSceneId: result.nextSceneId,
-        });
-      } catch (error) {
-        if (!runtimeRefs.isMountedRef.current) {
-          return;
-        }
+    applyLoadedScene({
+      runtimeRefs,
+      replaceViewState,
+      scene: result.scene,
+      previousSceneId: result.previousSceneId,
+      nextSceneId: result.nextSceneId,
+    });
+  } catch (error) {
+    if (!runtimeRefs.isMountedRef.current) {
+      return;
+    }
 
-        patchViewState({
-          loadState: 'error',
-          isSaving: false,
-          saveError: input.service.toUserErrorMessage(error),
-        });
-      }
-    };
-
-    void loadScene();
-  }, [input.projectId, input.sceneId, input.service, patchViewState, replaceViewState, runtimeRefs]);
+    patchViewState({
+      loadState: 'error',
+      isSaving: false,
+      saveError: input.service.toUserErrorMessage(error),
+    });
+  }
 }
 
 function useAutosave(

--- a/src/test/bible/bible-page.test.tsx
+++ b/src/test/bible/bible-page.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { BiblePageClient } from '@/components/bible/bible-page-client';
+
+describe('BiblePage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('creates entities, relationships, and scene links with persisted state after reload', async () => {
+    const user = userEvent.setup();
+    const projectId = 'demo-project';
+    const { unmount } = render(<BiblePageClient projectId={projectId} />);
+
+    const nameInput = await screen.findByLabelText('Name');
+    await user.type(nameInput, 'Aria');
+    await user.click(screen.getByRole('button', { name: 'Save entity' }));
+    await screen.findByRole('button', { name: /Aria/i });
+
+    await user.click(screen.getByRole('button', { name: 'New entity' }));
+    const secondNameInput = screen.getByLabelText('Name');
+    await user.clear(secondNameInput);
+    await user.type(secondNameInput, 'Citadel');
+    await user.selectOptions(screen.getByLabelText('Category', { selector: '#entity-category' }), 'location');
+    await user.click(screen.getByRole('button', { name: 'Save entity' }));
+    await screen.findByRole('button', { name: /Citadel/i });
+
+    const fromEntitySelect = screen.getByLabelText('From entity');
+    const toEntitySelect = screen.getByLabelText('To entity');
+    const relationshipTypeSelect = screen.getByLabelText('Type');
+    await user.selectOptions(fromEntitySelect, within(fromEntitySelect).getByRole('option', { name: 'Aria' }));
+    await user.selectOptions(toEntitySelect, within(toEntitySelect).getByRole('option', { name: 'Citadel' }));
+    await user.selectOptions(
+      relationshipTypeSelect,
+      within(relationshipTypeSelect).getByRole('option', { name: 'located_in' }),
+    );
+    await user.click(screen.getByRole('button', { name: 'Save relationship' }));
+    const bibleStorageKey = `ainkwell:projects:${projectId}:bible:v1`;
+    const relationshipData = JSON.parse(window.localStorage.getItem(bibleStorageKey) ?? '{}') as {
+      relationships?: Array<unknown>;
+    };
+    expect(relationshipData.relationships).toHaveLength(1);
+
+    const sceneLinkEntitySelect = screen.getByLabelText('Entity');
+    const sceneLinkSceneSelect = screen.getByLabelText('Scene');
+    await user.selectOptions(
+      sceneLinkEntitySelect,
+      within(sceneLinkEntitySelect).getByRole('option', { name: 'Aria' }),
+    );
+    await user.selectOptions(
+      sceneLinkSceneSelect,
+      within(sceneLinkSceneSelect).getByRole('option', { name: 'Scene 1' }),
+    );
+    await user.click(screen.getByRole('button', { name: 'Save scene link' }));
+    const sceneLinkData = JSON.parse(window.localStorage.getItem(bibleStorageKey) ?? '{}') as {
+      sceneLinks?: Array<unknown>;
+    };
+    expect(sceneLinkData.sceneLinks).toHaveLength(1);
+
+    unmount();
+    render(<BiblePageClient projectId={projectId} />);
+
+    await screen.findByRole('button', { name: /Aria/i });
+    const persistedData = JSON.parse(window.localStorage.getItem(bibleStorageKey) ?? '{}') as {
+      relationships?: Array<unknown>;
+      sceneLinks?: Array<unknown>;
+    };
+    expect(persistedData.relationships).toHaveLength(1);
+    expect(persistedData.sceneLinks).toHaveLength(1);
+  });
+});

--- a/src/test/bible/local-bible-repository.test.ts
+++ b/src/test/bible/local-bible-repository.test.ts
@@ -3,8 +3,8 @@ import { BibleService, BibleValidationError } from '@/application/bible/bible-se
 import { LocalBibleRepository } from '@/data/bible/local-bible-repository';
 import type { BibleEntityCategory } from '@/domain/bible/types';
 
-const PROJECT_A = 'project-a';
-const PROJECT_B = 'project-b';
+const PROJECT_A = '8b5d05ea-3f90-4fd4-91cb-c18edfd3de71';
+const PROJECT_B = '6a7c61fb-5f70-47d5-aac9-f1f466f13de4';
 
 function createService(projectId?: string): BibleService {
   const repository = new LocalBibleRepository(window.localStorage);

--- a/src/test/bible/local-bible-repository.test.ts
+++ b/src/test/bible/local-bible-repository.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { BibleService, BibleValidationError } from '@/application/bible/bible-service';
+import { LocalBibleRepository } from '@/data/bible/local-bible-repository';
+import type { BibleEntityCategory } from '@/domain/bible/types';
+
+const PROJECT_A = 'project-a';
+const PROJECT_B = 'project-b';
+
+function createService(projectId?: string): BibleService {
+  const repository = new LocalBibleRepository(window.localStorage);
+  const service = new BibleService(repository);
+  if (projectId) {
+    service.seedScenes(projectId);
+  }
+  return service;
+}
+
+describe('LocalBibleRepository and BibleService', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('creates entities across all categories', () => {
+    const service = createService();
+    const categories: BibleEntityCategory[] = ['character', 'location', 'faction', 'lore'];
+
+    for (const category of categories) {
+      service.saveEntity({
+        projectId: PROJECT_A,
+        category,
+        name: `Entity ${category}`,
+      });
+    }
+
+    const entities = service.listEntities(PROJECT_A);
+    expect(entities).toHaveLength(categories.length);
+    expect(new Set(entities.map((entity) => entity.category))).toEqual(new Set(categories));
+  });
+
+  it('rejects relationship creation when entities are not in the same project scope', () => {
+    const service = createService();
+    const entityA = service.saveEntity({
+      projectId: PROJECT_A,
+      category: 'character',
+      name: 'A',
+    });
+    const entityB = service.saveEntity({
+      projectId: PROJECT_B,
+      category: 'location',
+      name: 'B',
+    });
+
+    expect(() =>
+      service.saveRelationship({
+        projectId: PROJECT_A,
+        type: 'located_in',
+        fromEntityId: entityA.id,
+        toEntityId: entityB.id,
+      }),
+    ).toThrow(BibleValidationError);
+  });
+
+  it('rejects self references in relationships', () => {
+    const service = createService();
+    const entity = service.saveEntity({
+      projectId: PROJECT_A,
+      category: 'character',
+      name: 'Solo',
+    });
+
+    expect(() =>
+      service.saveRelationship({
+        projectId: PROJECT_A,
+        type: 'knows',
+        fromEntityId: entity.id,
+        toEntityId: entity.id,
+      }),
+    ).toThrow('Self references are not allowed');
+  });
+
+  it('rejects directional cycles', () => {
+    const service = createService();
+    const a = service.saveEntity({ projectId: PROJECT_A, category: 'character', name: 'A' });
+    const b = service.saveEntity({ projectId: PROJECT_A, category: 'character', name: 'B' });
+    const c = service.saveEntity({ projectId: PROJECT_A, category: 'character', name: 'C' });
+
+    service.saveRelationship({
+      projectId: PROJECT_A,
+      type: 'ally_of',
+      fromEntityId: a.id,
+      toEntityId: b.id,
+    });
+    service.saveRelationship({
+      projectId: PROJECT_A,
+      type: 'ally_of',
+      fromEntityId: b.id,
+      toEntityId: c.id,
+    });
+
+    expect(() =>
+      service.saveRelationship({
+        projectId: PROJECT_A,
+        type: 'ally_of',
+        fromEntityId: c.id,
+        toEntityId: a.id,
+      }),
+    ).toThrow('directional cycle');
+  });
+
+  it('cascades relationship and scene-link deletion when deleting an entity', () => {
+    const service = createService(PROJECT_A);
+    const character = service.saveEntity({
+      projectId: PROJECT_A,
+      category: 'character',
+      name: 'Hero',
+    });
+    const location = service.saveEntity({
+      projectId: PROJECT_A,
+      category: 'location',
+      name: 'Harbor',
+    });
+
+    service.saveRelationship({
+      projectId: PROJECT_A,
+      type: 'located_in',
+      fromEntityId: character.id,
+      toEntityId: location.id,
+    });
+    const sceneId = service.listScenes(PROJECT_A)[0].id;
+    service.saveSceneLink({
+      projectId: PROJECT_A,
+      entityId: character.id,
+      sceneId,
+    });
+    service.deleteEntity(PROJECT_A, character.id);
+
+    expect(service.listRelationships(PROJECT_A)).toHaveLength(0);
+    expect(service.listSceneLinks(PROJECT_A)).toHaveLength(0);
+  });
+
+  it('filters entities by category and search term', () => {
+    const service = createService();
+    service.saveEntity({
+      projectId: PROJECT_A,
+      category: 'character',
+      name: 'Ari',
+      summary: 'Captain of the watch',
+      tags: ['leader'],
+    });
+    service.saveEntity({
+      projectId: PROJECT_A,
+      category: 'location',
+      name: 'Citadel',
+      summary: 'Ancient stone bastion',
+      tags: ['fortress'],
+    });
+
+    const result = service.listEntities(PROJECT_A, {
+      category: 'location',
+      search: 'stone',
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Citadel');
+  });
+
+  it('persists and reloads data from localStorage', () => {
+    const service = createService(PROJECT_A);
+    service.saveEntity({
+      projectId: PROJECT_A,
+      category: 'faction',
+      name: 'The Tidebound',
+    });
+
+    const reloadedService = createService(PROJECT_A);
+    const entities = reloadedService.listEntities(PROJECT_A);
+    expect(entities).toHaveLength(1);
+    expect(entities[0].name).toBe('The Tidebound');
+  });
+});


### PR DESCRIPTION
## Summary
- align the workspace layout and story-bible-aware project landing page so navigation now surfaces the bible experience
- update the bible domain/service/repository layers plus editor/list/relationship helpers to match the revised model and ensure the client page renders the current structure
- refresh related scene-link components and existing tests so they cover the new interactions and data wiring

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Story Bible Feature Integration

### Key Changes

**Frontend – Workspace Navigation & UI**
- New Story Bible page at `/workspace/[projectId]/bible` with comprehensive entity, relationship, and scene-link management
- Story Bible card integrated into workspace project detail view for quick navigation
- Split-panel UI with entity list, editor, relationship manager, and scene link manager

**Frontend – Components**
- New reusable components: `BibleEditor`, `BibleList`, `RelationshipEditor`, `SceneLinks`
- Client-side page orchestration via `BiblePageClient` with dedicated controller hook
- Modular state management hooks: `useBiblePageController`, `useRelationshipEditorState`, `useSceneLinksEditorState`

**Backend – Domain & Service Layer**
- New `BibleService` with comprehensive CRUD, filtering, and validation for entities, relationships, and scene links
- Cycle detection and self-reference prevention in relationship graphs
- Project-scoped access boundaries and cascade delete support
- Deterministic scene seeding with default scenes
- Zod schema validation for all Bible domain models

**Data Layer**
- New `LocalBibleRepository` implementing local-first storage with per-project keys
- Full query and filter support (by category, entity, search term)
- Automatic schema validation and fallback on parse errors

**Testing**
- Comprehensive test suite covering repository integrity, service validation, and page-level integration
- Tests for entity CRUD, relationship cycles, cross-project boundaries, and persistence

**Developer Experience**
- Refactored component hierarchies into focused, composable helpers
- Extracted relationship and scene-link state management into reusable hooks
- Centralized error handling and operation workflows
- Simplified scene load flow in editor

**Bug Fixes**
- Resolved hydration warnings by adding `suppressHydrationWarning` to `<body>` element

### Affected Areas
- **Frontend:** Workspace layout, new routes, client-side state management, UI components
- **Backend:** Domain models, service layer, repository pattern, validation logic
- **Data:** Local storage integration, schema validation
- **Testing:** Unit and integration test coverage for new features

### Notes
- All changes are additive; no breaking changes to existing APIs
- Feature is project-scoped with built-in access control and data isolation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->