### PR TITLE
feat: multi-tag filtering for Story Bible entities

### DIFF
--- a/src/application/bible/bible-service.ts
+++ b/src/application/bible/bible-service.ts
@@ -55,6 +55,10 @@ export class BibleService {
     return this.repository.listEntities(this.normalizeProjectId(projectId), filters);
   }
 
+  public listAllTags(projectId: string): string[] {
+    return this.repository.listAllTags(this.normalizeProjectId(projectId));
+  }
+
   public getEntity(projectId: string, entityId: string): BibleEntity | null {
     return this.repository.getEntity(this.normalizeProjectId(projectId), entityId);
   }

--- a/src/components/bible/bible-editor.tsx
+++ b/src/components/bible/bible-editor.tsx
@@ -3,11 +3,13 @@
 import { type FormEvent, type ReactElement, useState } from 'react';
 import { BIBLE_ENTITY_CATEGORIES } from '@/domain/bible/types';
 import type { BibleEntity, BibleEntityCategory, SaveBibleEntityInput } from '@/domain/bible/types';
+import { TagsInput } from '@/components/bible/tags-input';
 
 interface BibleEditorProps {
   projectId: string;
   selectedEntity: BibleEntity | null;
   errorMessage: string | null;
+  suggestedTags?: string[];
   onSave: (input: SaveBibleEntityInput) => void | Promise<void>;
   onDelete: (entityId: string) => void | Promise<void>;
 }
@@ -17,33 +19,22 @@ interface EntityFormState {
   name: string;
   summary: string;
   details: string;
-  tagsInputValue: string;
+  tags: string[];
 }
 
 interface EntityFormProps {
   state: EntityFormState;
+  suggestedTags: string[];
   onCategoryChange: (value: BibleEntityCategory) => void;
   onNameChange: (value: string) => void;
   onSummaryChange: (value: string) => void;
   onDetailsChange: (value: string) => void;
-  onTagsInputValueChange: (value: string) => void;
+  onTagsChange: (value: string[]) => void;
 }
 
 interface EditorActionsHandlers {
   handleSubmit: (event: FormEvent<HTMLFormElement>) => void;
   handleDelete: () => void;
-}
-
-function toTagInputValue(tags: string[]): string {
-  return tags.join(', ');
-}
-
-function parseTagInputValue(value: string): string[] {
-  const tags = value
-    .split(',')
-    .map((tag) => tag.trim())
-    .filter(Boolean);
-  return Array.from(new Set(tags));
 }
 
 function getInitialFormState(selectedEntity: BibleEntity | null): EntityFormState {
@@ -53,7 +44,7 @@ function getInitialFormState(selectedEntity: BibleEntity | null): EntityFormStat
       name: '',
       summary: '',
       details: '',
-      tagsInputValue: '',
+      tags: [],
     };
   }
 
@@ -62,7 +53,7 @@ function getInitialFormState(selectedEntity: BibleEntity | null): EntityFormStat
     name: selectedEntity.name,
     summary: selectedEntity.summary,
     details: selectedEntity.details,
-    tagsInputValue: toTagInputValue(selectedEntity.tags),
+    tags: selectedEntity.tags,
   };
 }
 
@@ -72,22 +63,22 @@ function useEntityFormState(selectedEntity: BibleEntity | null): {
   setName: (value: string) => void;
   setSummary: (value: string) => void;
   setDetails: (value: string) => void;
-  setTagsInputValue: (value: string) => void;
+  setTags: (value: string[]) => void;
 } {
   const initialFormState = getInitialFormState(selectedEntity);
   const [category, setCategory] = useState<BibleEntityCategory>(initialFormState.category);
   const [name, setName] = useState(initialFormState.name);
   const [summary, setSummary] = useState(initialFormState.summary);
   const [details, setDetails] = useState(initialFormState.details);
-  const [tagsInputValue, setTagsInputValue] = useState(initialFormState.tagsInputValue);
+  const [tags, setTags] = useState<string[]>(initialFormState.tags);
 
   return {
-    state: { category, name, summary, details, tagsInputValue },
+    state: { category, name, summary, details, tags },
     setCategory,
     setName,
     setSummary,
     setDetails,
-    setTagsInputValue,
+    setTags,
   };
 }
 
@@ -105,11 +96,12 @@ function EditorError({ message }: { message: string | null }): ReactElement | nu
 
 function EntityFormFields({
   state,
+  suggestedTags,
   onCategoryChange,
   onNameChange,
   onSummaryChange,
   onDetailsChange,
-  onTagsInputValueChange,
+  onTagsChange,
 }: EntityFormProps): ReactElement {
   return (
     <>
@@ -117,7 +109,7 @@ function EntityFormFields({
       <CategoryField value={state.category} onChange={onCategoryChange} />
       <SummaryField value={state.summary} onChange={onSummaryChange} />
       <DetailsField value={state.details} onChange={onDetailsChange} />
-      <TagsField value={state.tagsInputValue} onChange={onTagsInputValueChange} />
+      <TagsInput tags={state.tags} suggestedTags={suggestedTags} onTagsChange={onTagsChange} />
     </>
   );
 }
@@ -202,23 +194,6 @@ function DetailsField({ value, onChange }: { value: string; onChange: (value: st
   );
 }
 
-function TagsField({ value, onChange }: { value: string; onChange: (value: string) => void }): ReactElement {
-  return (
-    <div className="space-y-2">
-      <label className="text-sm font-semibold" htmlFor="entity-tags">
-        Tags
-      </label>
-      <input
-        id="entity-tags"
-        value={value}
-        onChange={(event) => onChange(event.target.value)}
-        className="w-full rounded-md border bg-background px-3 py-2 text-sm"
-        placeholder="comma, separated, tags"
-      />
-    </div>
-  );
-}
-
 function EditorActions({
   selectedEntity,
   onDelete,
@@ -266,7 +241,7 @@ function useEditorActions({
       name: state.name,
       summary: state.summary,
       details: state.details,
-      tags: parseTagInputValue(state.tagsInputValue),
+      tags: state.tags,
     });
   };
 
@@ -284,11 +259,11 @@ export function BibleEditor({
   projectId,
   selectedEntity,
   errorMessage,
+  suggestedTags = [],
   onSave,
   onDelete,
 }: BibleEditorProps): ReactElement {
-  const { state, setCategory, setName, setSummary, setDetails, setTagsInputValue } =
-    useEntityFormState(selectedEntity);
+  const { state, setCategory, setName, setSummary, setDetails, setTags } = useEntityFormState(selectedEntity);
   const { handleSubmit, handleDelete } = useEditorActions({
     projectId,
     selectedEntity,
@@ -304,11 +279,12 @@ export function BibleEditor({
       <form className="space-y-3" onSubmit={handleSubmit}>
         <EntityFormFields
           state={state}
+          suggestedTags={suggestedTags}
           onCategoryChange={setCategory}
           onNameChange={setName}
           onSummaryChange={setSummary}
           onDetailsChange={setDetails}
-          onTagsInputValueChange={setTagsInputValue}
+          onTagsChange={setTags}
         />
         <EditorActions selectedEntity={selectedEntity} onDelete={handleDelete} />
       </form>

--- a/src/components/bible/bible-list.tsx
+++ b/src/components/bible/bible-list.tsx
@@ -1,14 +1,19 @@
 import type { ChangeEvent, ReactElement } from 'react';
 import type { BibleEntity, BibleEntityCategory } from '@/domain/bible/types';
 import { BIBLE_ENTITY_CATEGORIES } from '@/domain/bible/types';
+import { TagChip } from '@/components/bible/tag-chip';
+import { TagFilterPanel } from '@/components/bible/tag-filter-panel';
 
 interface BibleListProps {
   entities: BibleEntity[];
   selectedEntityId: string | null;
   searchValue: string;
   categoryFilter: BibleEntityCategory | 'all';
+  allTags: string[];
+  activeTagFilter: string[];
   onSearchChange: (value: string) => void;
   onCategoryFilterChange: (value: BibleEntityCategory | 'all') => void;
+  onTagFilterChange: (tags: string[]) => void;
   onSelectEntity: (entityId: string) => void;
   onCreateEntity: () => void;
 }
@@ -80,16 +85,26 @@ function BibleCategoryField({
 function BibleListFilters({
   searchValue,
   categoryFilter,
+  allTags,
+  activeTagFilter,
   onSearchChange,
   onCategoryFilterChange,
-}: Pick<BibleListProps, 'searchValue' | 'categoryFilter' | 'onSearchChange' | 'onCategoryFilterChange'>): ReactElement {
+  onTagFilterChange,
+}: Pick<
+  BibleListProps,
+  | 'searchValue'
+  | 'categoryFilter'
+  | 'allTags'
+  | 'activeTagFilter'
+  | 'onSearchChange'
+  | 'onCategoryFilterChange'
+  | 'onTagFilterChange'
+>): ReactElement {
   return (
     <>
       <BibleSearchField searchValue={searchValue} onSearchChange={onSearchChange} />
-      <BibleCategoryField
-        categoryFilter={categoryFilter}
-        onCategoryFilterChange={onCategoryFilterChange}
-      />
+      <BibleCategoryField categoryFilter={categoryFilter} onCategoryFilterChange={onCategoryFilterChange} />
+      <TagFilterPanel allTags={allTags} activeTagFilter={activeTagFilter} onTagFilterChange={onTagFilterChange} />
     </>
   );
 }
@@ -113,6 +128,13 @@ function BibleEntityItems({
             >
               <p className="font-semibold">{entity.name}</p>
               <p className="text-xs text-muted-foreground">{entity.category}</p>
+              {entity.tags.length > 0 ? (
+                <div className="mt-1 flex flex-wrap gap-1">
+                  {entity.tags.map((tag) => (
+                    <TagChip key={tag} label={tag} />
+                  ))}
+                </div>
+              ) : null}
             </button>
           </li>
         ))}
@@ -128,8 +150,11 @@ export function BibleList(props: BibleListProps): ReactElement {
       <BibleListFilters
         searchValue={props.searchValue}
         categoryFilter={props.categoryFilter}
+        allTags={props.allTags}
+        activeTagFilter={props.activeTagFilter}
         onSearchChange={props.onSearchChange}
         onCategoryFilterChange={props.onCategoryFilterChange}
+        onTagFilterChange={props.onTagFilterChange}
       />
       <button
         type="button"

--- a/src/components/bible/bible-page-client.tsx
+++ b/src/components/bible/bible-page-client.tsx
@@ -72,8 +72,11 @@ function BiblePanels({
         selectedEntityId={controller.activeSelectedEntityId}
         searchValue={controller.searchValue}
         categoryFilter={controller.categoryFilter}
+        allTags={controller.data.allTags}
+        activeTagFilter={controller.tagFilter}
         onSearchChange={controller.setSearchValue}
         onCategoryFilterChange={controller.setCategoryFilter}
+        onTagFilterChange={controller.setTagFilter}
         onSelectEntity={controller.onSelectEntity}
         onCreateEntity={controller.onCreateEntity}
       />
@@ -96,6 +99,7 @@ function BibleEditorsColumn({
         projectId={project.id}
         selectedEntity={controller.selectedEntity}
         errorMessage={controller.entityError}
+        suggestedTags={controller.data.allTags}
         onSave={controller.onSaveEntity}
         onDelete={controller.onDeleteEntity}
       />

--- a/src/components/bible/bible-page-controller.ts
+++ b/src/components/bible/bible-page-controller.ts
@@ -9,6 +9,7 @@ import { projectIdSchema } from '@/domain/project/schemas';
 import type { WritingProject } from '@/domain/project/types';
 import type {
   BibleEntityCategory,
+  BibleEntityFilters,
   SaveBibleEntityInput,
   SaveBibleRelationshipInput,
   SaveBibleSceneLinkInput,
@@ -27,6 +28,7 @@ export interface BibleDataSnapshot {
   relationships: ReturnType<BibleService['listRelationships']>;
   sceneLinks: ReturnType<BibleService['listSceneLinks']>;
   scenes: ReturnType<BibleService['listScenes']>;
+  allTags: string[];
 }
 
 export interface BiblePageController {
@@ -36,6 +38,7 @@ export interface BiblePageController {
   data: BibleDataSnapshot;
   searchValue: string;
   categoryFilter: BibleEntityCategory | 'all';
+  tagFilter: string[];
   selectedEntity: BibleDataSnapshot['entities'][number] | null;
   activeSelectedEntityId: string | null;
   entityError: string | null;
@@ -43,6 +46,7 @@ export interface BiblePageController {
   sceneLinkError: string | null;
   setSearchValue: (value: string) => void;
   setCategoryFilter: (value: BibleEntityCategory | 'all') => void;
+  setTagFilter: (tags: string[]) => void;
   onSelectEntity: (entityId: string) => void;
   onCreateEntity: () => void;
   onSaveEntity: (input: SaveBibleEntityInput) => Promise<void>;
@@ -76,6 +80,7 @@ const EMPTY_BIBLE_DATA: BibleDataSnapshot = {
   relationships: [],
   sceneLinks: [],
   scenes: [],
+  allTags: [],
 };
 
 const LOADING_PROJECT_ACCESS: ProjectAccess = {
@@ -210,27 +215,26 @@ function useBibleService(projectAccess: ProjectAccess): BibleService | null {
   }, [projectAccess.project, projectAccess.state]);
 }
 
-function useEntityFilters(): {
-  searchValue: string;
-  categoryFilter: BibleEntityCategory | 'all';
-  entityFilters: { search: string; category?: BibleEntityCategory };
-  setSearchValue: (value: string) => void;
-  setCategoryFilter: (value: BibleEntityCategory | 'all') => void;
-} {
+function useEntityFilters() {
   const [searchValue, setSearchValue] = useState('');
   const [categoryFilter, setCategoryFilter] = useState<BibleEntityCategory | 'all'>('all');
+  const [tagFilter, setTagFilter] = useState<string[]>([]);
   const entityFilters = useMemo(
-    () => ({ search: searchValue, category: categoryFilter === 'all' ? undefined : categoryFilter }),
-    [categoryFilter, searchValue],
+    () => ({
+      search: searchValue,
+      category: categoryFilter === 'all' ? undefined : categoryFilter,
+      tags: tagFilter.length > 0 ? tagFilter : undefined,
+    }),
+    [categoryFilter, searchValue, tagFilter],
   );
 
-  return { searchValue, categoryFilter, entityFilters, setSearchValue, setCategoryFilter };
+  return { searchValue, categoryFilter, tagFilter, entityFilters, setSearchValue, setCategoryFilter, setTagFilter };
 }
 
 function useBibleDataSnapshot(
   bibleService: BibleService | null,
   projectId: string | null,
-  entityFilters: { search: string; category?: BibleEntityCategory },
+  entityFilters: BibleEntityFilters,
 ): BibleDataSnapshot {
   if (!bibleService || !projectId) {
     return EMPTY_BIBLE_DATA;
@@ -241,6 +245,7 @@ function useBibleDataSnapshot(
     relationships: bibleService.listRelationships(projectId),
     sceneLinks: bibleService.listSceneLinks(projectId),
     scenes: bibleService.listScenes(projectId),
+    allTags: bibleService.listAllTags(projectId),
   };
 }
 
@@ -395,22 +400,30 @@ function useSceneLinkActions(
   return { error, saveSceneLink, deleteSceneLink };
 }
 
+function useBibleActions(
+  runOperation: EntityActionParams['runOperation'],
+  entityParams: Omit<EntityActionParams, 'runOperation'>,
+) {
+  const entityActions = useEntityActions({ runOperation, ...entityParams });
+  const relationshipActions = useRelationshipActions(runOperation);
+  const sceneLinkActions = useSceneLinkActions(runOperation);
+  return { entityActions, relationshipActions, sceneLinkActions };
+}
+
 export function useBiblePageController(projectId: string): BiblePageController {
   const projectAccess = useProjectAccess(projectId);
   const { project } = projectAccess;
   const bibleService = useBibleService(projectAccess);
-  const { searchValue, categoryFilter, entityFilters, setSearchValue, setCategoryFilter } = useEntityFilters();
+  const { searchValue, categoryFilter, tagFilter, entityFilters, setSearchValue, setCategoryFilter, setTagFilter } =
+    useEntityFilters();
   const data = useBibleDataSnapshot(bibleService, project?.id ?? null, entityFilters);
   const selection = useEntitySelection(data.entities);
   const runOperation = useRunBibleOperation(bibleService, project?.id ?? null, useRefreshTrigger());
-  const entityActions = useEntityActions({
-    runOperation,
+  const { entityActions, relationshipActions, sceneLinkActions } = useBibleActions(runOperation, {
     activeSelectedEntityId: selection.activeSelectedEntityId,
     setSelectedEntityId: selection.setSelectedEntityId,
     setIsCreatingEntity: selection.setIsCreatingEntity,
   });
-  const relationshipActions = useRelationshipActions(runOperation);
-  const sceneLinkActions = useSceneLinkActions(runOperation);
   return {
     projectAccess,
     project,
@@ -418,6 +431,7 @@ export function useBiblePageController(projectId: string): BiblePageController {
     data,
     searchValue,
     categoryFilter,
+    tagFilter,
     selectedEntity: selection.selectedEntity,
     activeSelectedEntityId: selection.activeSelectedEntityId,
     entityError: entityActions.error,
@@ -425,6 +439,7 @@ export function useBiblePageController(projectId: string): BiblePageController {
     sceneLinkError: sceneLinkActions.error,
     setSearchValue,
     setCategoryFilter,
+    setTagFilter,
     onSelectEntity: selection.onSelectEntity,
     onCreateEntity: selection.onCreateEntity,
     onSaveEntity: entityActions.saveEntity,

--- a/src/components/bible/bible-page-controller.ts
+++ b/src/components/bible/bible-page-controller.ts
@@ -417,6 +417,13 @@ export function useBiblePageController(projectId: string): BiblePageController {
   const { searchValue, categoryFilter, tagFilter, entityFilters, setSearchValue, setCategoryFilter, setTagFilter } =
     useEntityFilters();
   const data = useBibleDataSnapshot(bibleService, project?.id ?? null, entityFilters);
+  useEffect(() => {
+    if (tagFilter.length === 0) return;
+    const validTags = tagFilter.filter((tag) => data.allTags.includes(tag));
+    if (validTags.length !== tagFilter.length) {
+      setTagFilter(validTags);
+    }
+  }, [data.allTags, tagFilter, setTagFilter]);
   const selection = useEntitySelection(data.entities);
   const runOperation = useRunBibleOperation(bibleService, project?.id ?? null, useRefreshTrigger());
   const { entityActions, relationshipActions, sceneLinkActions } = useBibleActions(runOperation, {

--- a/src/components/bible/tag-chip.tsx
+++ b/src/components/bible/tag-chip.tsx
@@ -1,0 +1,25 @@
+import type { ReactElement } from 'react';
+import { X } from 'lucide-react';
+
+interface TagChipProps {
+  label: string;
+  onRemove?: () => void;
+}
+
+export function TagChip({ label, onRemove }: TagChipProps): ReactElement {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium">
+      {label}
+      {onRemove ? (
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label={`Remove tag ${label}`}
+          className="ml-0.5 rounded-full hover:bg-muted"
+        >
+          <X size={10} />
+        </button>
+      ) : null}
+    </span>
+  );
+}

--- a/src/components/bible/tag-filter-panel.tsx
+++ b/src/components/bible/tag-filter-panel.tsx
@@ -1,0 +1,70 @@
+import type { ReactElement } from 'react';
+
+interface TagFilterPanelProps {
+  allTags: string[];
+  activeTagFilter: string[];
+  onTagFilterChange: (tags: string[]) => void;
+}
+
+function TagFilterChips({
+  allTags,
+  activeTagFilter,
+  onToggle,
+}: {
+  allTags: string[];
+  activeTagFilter: string[];
+  onToggle: (tag: string) => void;
+}): ReactElement {
+  return (
+    <div className="flex flex-wrap gap-1">
+      {allTags.map((tag) => (
+        <button
+          key={tag}
+          type="button"
+          onClick={() => onToggle(tag)}
+          className={`rounded-full border px-2 py-0.5 text-xs font-medium transition-colors ${
+            activeTagFilter.includes(tag)
+              ? 'border-primary text-primary'
+              : 'border-border text-muted-foreground hover:border-foreground hover:text-foreground'
+          }`}
+        >
+          {tag}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function TagFilterPanel(
+  { allTags, activeTagFilter, onTagFilterChange }: TagFilterPanelProps,
+): ReactElement | null {
+  if (allTags.length === 0) {
+    return null;
+  }
+
+  const toggleTag = (tag: string): void => {
+    if (activeTagFilter.includes(tag)) {
+      onTagFilterChange(activeTagFilter.filter((activeTag) => activeTag !== tag));
+    } else {
+      onTagFilterChange([...activeTagFilter, tag]);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <label className="text-sm font-semibold">Tags</label>
+        {activeTagFilter.length > 0 ? (
+          <button
+            type="button"
+            onClick={() => onTagFilterChange([])}
+            className="text-xs text-muted-foreground hover:text-foreground"
+          >
+            Clear tags
+          </button>
+        ) : null}
+      </div>
+      <TagFilterChips allTags={allTags} activeTagFilter={activeTagFilter} onToggle={toggleTag} />
+    </div>
+  );
+}

--- a/src/components/bible/tag-filter-panel.tsx
+++ b/src/components/bible/tag-filter-panel.tsx
@@ -17,20 +17,24 @@ function TagFilterChips({
 }): ReactElement {
   return (
     <div className="flex flex-wrap gap-1">
-      {allTags.map((tag) => (
-        <button
-          key={tag}
-          type="button"
-          onClick={() => onToggle(tag)}
-          className={`rounded-full border px-2 py-0.5 text-xs font-medium transition-colors ${
-            activeTagFilter.includes(tag)
-              ? 'border-primary text-primary'
-              : 'border-border text-muted-foreground hover:border-foreground hover:text-foreground'
-          }`}
-        >
-          {tag}
-        </button>
-      ))}
+      {allTags.map((tag) => {
+        const isActive = activeTagFilter.includes(tag);
+        return (
+          <button
+            key={tag}
+            type="button"
+            onClick={() => onToggle(tag)}
+            aria-pressed={isActive}
+            className={`rounded-full border px-2 py-0.5 text-xs font-medium transition-colors ${
+              isActive
+                ? 'border-primary text-primary'
+                : 'border-border text-muted-foreground hover:border-foreground hover:text-foreground'
+            }`}
+          >
+            {tag}
+          </button>
+        );
+      })}
     </div>
   );
 }
@@ -53,7 +57,7 @@ export function TagFilterPanel(
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between">
-        <label className="text-sm font-semibold">Tags</label>
+        <p className="text-sm font-semibold">Tags</p>
         {activeTagFilter.length > 0 ? (
           <button
             type="button"

--- a/src/components/bible/tags-input.tsx
+++ b/src/components/bible/tags-input.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { type KeyboardEvent, type ReactElement, useState } from 'react';
+import { TagChip } from '@/components/bible/tag-chip';
+
+interface TagsInputProps {
+  tags: string[];
+  suggestedTags: string[];
+  onTagsChange: (tags: string[]) => void;
+}
+
+const DATALIST_ID = 'tags-input-suggestions';
+
+function ActiveTagList({
+  tags,
+  onRemove,
+}: {
+  tags: string[];
+  onRemove: (tag: string) => void;
+}): ReactElement | null {
+  if (tags.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-1">
+      {tags.map((tag) => (
+        <TagChip key={tag} label={tag} onRemove={() => onRemove(tag)} />
+      ))}
+    </div>
+  );
+}
+
+function TagSuggestions({
+  suggestedTags,
+  activeTags,
+}: {
+  suggestedTags: string[];
+  activeTags: string[];
+}): ReactElement {
+  return (
+    <datalist id={DATALIST_ID}>
+      {suggestedTags
+        .filter((tag) => !activeTags.includes(tag))
+        .map((tag) => (
+          <option key={tag} value={tag} />
+        ))}
+    </datalist>
+  );
+}
+
+export function TagsInput({ tags, suggestedTags, onTagsChange }: TagsInputProps): ReactElement {
+  const [pendingInput, setPendingInput] = useState('');
+
+  const addTag = (value: string): void => {
+    const trimmed = value.trim();
+    if (trimmed && !tags.includes(trimmed)) {
+      onTagsChange([...tags, trimmed]);
+    }
+    setPendingInput('');
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
+    if (event.key !== 'Enter' && event.key !== ',') return;
+    event.preventDefault();
+    addTag(pendingInput);
+  };
+
+  const removeTag = (tag: string): void => {
+    onTagsChange(tags.filter((existingTag) => existingTag !== tag));
+  };
+
+  return (
+    <div className="space-y-2">
+      <label className="text-sm font-semibold" htmlFor="entity-tags">
+        Tags
+      </label>
+      <ActiveTagList tags={tags} onRemove={removeTag} />
+      <input
+        id="entity-tags"
+        value={pendingInput}
+        onChange={(event) => setPendingInput(event.target.value)}
+        onKeyDown={handleKeyDown}
+        list={DATALIST_ID}
+        placeholder="Add a tag and press Enter"
+        className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+      />
+      <TagSuggestions suggestedTags={suggestedTags} activeTags={tags} />
+    </div>
+  );
+}

--- a/src/components/bible/tags-input.tsx
+++ b/src/components/bible/tags-input.tsx
@@ -73,8 +73,10 @@ export function TagsInput({ tags, suggestedTags, onTagsChange }: TagsInputProps)
         Tags
       </label>
       <ActiveTagList tags={tags} onRemove={removeTag} />
+      <span id="tags-input-hint" className="sr-only">Press Enter or comma to add a tag</span>
       <input
         id="entity-tags"
+        aria-describedby="tags-input-hint"
         value={pendingInput}
         onChange={(event) => setPendingInput(event.target.value)}
         onKeyDown={handleKeyDown}

--- a/src/data/bible/local-bible-repository.ts
+++ b/src/data/bible/local-bible-repository.ts
@@ -78,11 +78,26 @@ export class LocalBibleRepository implements BibleRepository {
     const { entities } = this.readBible(projectId);
     const category = filters?.category;
     const searchTerm = filters?.search?.trim().toLowerCase();
+    const tags = filters?.tags;
 
     return entities
       .filter((entity) => (category ? entity.category === category : true))
       .filter((entity) => (searchTerm ? toSearchHaystack(entity).includes(searchTerm) : true))
+      .filter((entity) => {
+        if (!tags || tags.length === 0) return true;
+        const entityTagSet = new Set(entity.tags);
+        return tags.every((tag) => entityTagSet.has(tag));
+      })
       .sort((left, right) => toComparableDate(right.updatedAt) - toComparableDate(left.updatedAt));
+  }
+
+  public listAllTags(projectId: string): string[] {
+    const { entities } = this.readBible(projectId);
+    const tagSet = new Set<string>();
+    for (const entity of entities) {
+      for (const tag of entity.tags) tagSet.add(tag);
+    }
+    return Array.from(tagSet).sort();
   }
 
   public getEntity(projectId: string, entityId: string): BibleEntity | null {

--- a/src/domain/bible/repository.ts
+++ b/src/domain/bible/repository.ts
@@ -19,6 +19,7 @@ export interface BibleRepository {
   listSceneLinks(projectId: string, filters?: BibleSceneLinkFilters): BibleSceneLink[];
   upsertSceneLink(sceneLink: BibleSceneLink): BibleSceneLink;
   deleteSceneLink(projectId: string, sceneLinkId: string): void;
+  listAllTags(projectId: string): string[];
   listScenes(projectId: string): ProjectScene[];
   upsertScene(scene: ProjectScene): ProjectScene;
   bulkSeedScenes(projectId: string, scenes: ProjectScene[]): ProjectScene[];

--- a/src/domain/bible/types.ts
+++ b/src/domain/bible/types.ts
@@ -64,6 +64,7 @@ export interface BibleStorageDocument {
 export interface BibleEntityFilters {
   category?: BibleEntityCategory;
   search?: string;
+  tags?: string[];
 }
 
 export interface BibleRelationshipFilters {

--- a/src/test/bible/bible-page.test.tsx
+++ b/src/test/bible/bible-page.test.tsx
@@ -94,3 +94,116 @@ describe('BiblePage', () => {
     ).toBeInTheDocument();
   });
 });
+
+describe('BiblePage tag filtering and TagsInput', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders tag chips in the filter panel when entities with tags exist', async () => {
+    const user = userEvent.setup();
+    const projectRepository = new LocalProjectRepository();
+    const project = await projectRepository.create({ title: 'Tag Filter Test', description: '' });
+    render(<BiblePageClient projectId={project.id} />);
+
+    const nameInput = await screen.findByLabelText('Name');
+    await user.type(nameInput, 'Aria');
+    const tagsInput = screen.getByLabelText('Tags');
+    await user.type(tagsInput, 'protagonist');
+    await user.keyboard('{Enter}');
+    await user.click(screen.getByRole('button', { name: 'Save entity' }));
+    await screen.findByRole('button', { name: /Aria/i });
+
+    expect(screen.getByRole('button', { name: 'protagonist' })).toBeInTheDocument();
+  });
+
+  it('filters the entity list when a tag chip is clicked', async () => {
+    const user = userEvent.setup();
+    const projectRepository = new LocalProjectRepository();
+    const project = await projectRepository.create({ title: 'Tag Filter Test 2', description: '' });
+    render(<BiblePageClient projectId={project.id} />);
+
+    const nameInput = await screen.findByLabelText('Name');
+    await user.type(nameInput, 'Aria');
+    const tagsInput = screen.getByLabelText('Tags');
+    await user.type(tagsInput, 'protagonist');
+    await user.keyboard('{Enter}');
+    await user.click(screen.getByRole('button', { name: 'Save entity' }));
+    await screen.findByRole('button', { name: /Aria/i });
+
+    await user.click(screen.getByRole('button', { name: 'New entity' }));
+    const secondNameInput = screen.getByLabelText('Name');
+    await user.clear(secondNameInput);
+    await user.type(secondNameInput, 'Citadel');
+    await user.click(screen.getByRole('button', { name: 'Save entity' }));
+    await screen.findByRole('button', { name: /Citadel/i });
+
+    await user.click(screen.getByRole('button', { name: 'protagonist' }));
+
+    expect(screen.getByRole('button', { name: /Aria/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Citadel/i })).not.toBeInTheDocument();
+  });
+
+  it('clears the tag filter when "Clear tags" is clicked', async () => {
+    const user = userEvent.setup();
+    const projectRepository = new LocalProjectRepository();
+    const project = await projectRepository.create({ title: 'Tag Filter Test 3', description: '' });
+    render(<BiblePageClient projectId={project.id} />);
+
+    const nameInput = await screen.findByLabelText('Name');
+    await user.type(nameInput, 'Aria');
+    const tagsInput = screen.getByLabelText('Tags');
+    await user.type(tagsInput, 'protagonist');
+    await user.keyboard('{Enter}');
+    await user.click(screen.getByRole('button', { name: 'Save entity' }));
+    await screen.findByRole('button', { name: /Aria/i });
+
+    await user.click(screen.getByRole('button', { name: 'New entity' }));
+    const secondNameInput = screen.getByLabelText('Name');
+    await user.clear(secondNameInput);
+    await user.type(secondNameInput, 'Citadel');
+    await user.click(screen.getByRole('button', { name: 'Save entity' }));
+    await screen.findByRole('button', { name: /Citadel/i });
+
+    await user.click(screen.getByRole('button', { name: 'protagonist' }));
+    expect(screen.queryByRole('button', { name: /Citadel/i })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Clear tags' }));
+
+    expect(screen.getByRole('button', { name: /Aria/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Citadel/i })).toBeInTheDocument();
+  });
+
+  it('adds a tag chip in BibleEditor when Enter is pressed', async () => {
+    const user = userEvent.setup();
+    const projectRepository = new LocalProjectRepository();
+    const project = await projectRepository.create({ title: 'Tags Input Test', description: '' });
+    render(<BiblePageClient projectId={project.id} />);
+
+    const nameInput = await screen.findByLabelText('Name');
+    await user.type(nameInput, 'Aria');
+    const tagsInput = screen.getByLabelText('Tags');
+    await user.type(tagsInput, 'hero');
+    await user.keyboard('{Enter}');
+
+    expect(screen.getByRole('button', { name: 'Remove tag hero' })).toBeInTheDocument();
+  });
+
+  it('removes a tag chip when its x button is clicked', async () => {
+    const user = userEvent.setup();
+    const projectRepository = new LocalProjectRepository();
+    const project = await projectRepository.create({ title: 'Tags Remove Test', description: '' });
+    render(<BiblePageClient projectId={project.id} />);
+
+    const nameInput = await screen.findByLabelText('Name');
+    await user.type(nameInput, 'Aria');
+    const tagsInput = screen.getByLabelText('Tags');
+    await user.type(tagsInput, 'hero');
+    await user.keyboard('{Enter}');
+    expect(screen.getByRole('button', { name: 'Remove tag hero' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Remove tag hero' }));
+
+    expect(screen.queryByRole('button', { name: 'Remove tag hero' })).not.toBeInTheDocument();
+  });
+});

--- a/src/test/bible/local-bible-repository.test.ts
+++ b/src/test/bible/local-bible-repository.test.ts
@@ -178,3 +178,115 @@ describe('LocalBibleRepository and BibleService', () => {
     expect(entities[0].name).toBe('The Tidebound');
   });
 });
+
+describe('tag filtering', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('filters entities that match a single active tag', () => {
+    const service = createService();
+    service.saveEntity({ projectId: PROJECT_A, category: 'character', name: 'Hero', tags: ['protagonist'] });
+    service.saveEntity({ projectId: PROJECT_A, category: 'character', name: 'Villain', tags: ['antagonist'] });
+
+    const result = service.listEntities(PROJECT_A, { tags: ['protagonist'] });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Hero');
+  });
+
+  it('filters entities with AND semantics when multiple tags are active', () => {
+    const service = createService();
+    service.saveEntity({
+      projectId: PROJECT_A,
+      category: 'character',
+      name: 'Hero',
+      tags: ['protagonist', 'chapter-1'],
+    });
+    service.saveEntity({
+      projectId: PROJECT_A,
+      category: 'character',
+      name: 'Sidekick',
+      tags: ['protagonist'],
+    });
+
+    const result = service.listEntities(PROJECT_A, { tags: ['protagonist', 'chapter-1'] });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Hero');
+  });
+
+  it('returns all entities when tagFilter is empty array', () => {
+    const service = createService();
+    service.saveEntity({ projectId: PROJECT_A, category: 'character', name: 'A', tags: ['tag-a'] });
+    service.saveEntity({ projectId: PROJECT_A, category: 'location', name: 'B', tags: ['tag-b'] });
+
+    const result = service.listEntities(PROJECT_A, { tags: [] });
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns all entities when tagFilter is undefined', () => {
+    const service = createService();
+    service.saveEntity({ projectId: PROJECT_A, category: 'character', name: 'A', tags: ['tag-a'] });
+    service.saveEntity({ projectId: PROJECT_A, category: 'location', name: 'B' });
+
+    const result = service.listEntities(PROJECT_A, {});
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('excludes entities missing any one of the required tags', () => {
+    const service = createService();
+    service.saveEntity({
+      projectId: PROJECT_A,
+      category: 'character',
+      name: 'Partial',
+      tags: ['protagonist'],
+    });
+
+    const result = service.listEntities(PROJECT_A, { tags: ['protagonist', 'chapter-1'] });
+
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe('listAllTags', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns an empty array when no entities exist', () => {
+    const service = createService();
+
+    expect(service.listAllTags(PROJECT_A)).toEqual([]);
+  });
+
+  it('returns a sorted deduplicated list of all tags across entities', () => {
+    const service = createService();
+    service.saveEntity({ projectId: PROJECT_A, category: 'character', name: 'A', tags: ['zebra', 'alpha'] });
+    service.saveEntity({ projectId: PROJECT_A, category: 'location', name: 'B', tags: ['alpha', 'beta'] });
+
+    expect(service.listAllTags(PROJECT_A)).toEqual(['alpha', 'beta', 'zebra']);
+  });
+
+  it('includes tags only from the specified project', () => {
+    const service = createService();
+    service.saveEntity({ projectId: PROJECT_A, category: 'character', name: 'A', tags: ['tag-a'] });
+    service.saveEntity({ projectId: PROJECT_B, category: 'character', name: 'B', tags: ['tag-b'] });
+
+    expect(service.listAllTags(PROJECT_A)).toEqual(['tag-a']);
+    expect(service.listAllTags(PROJECT_B)).toEqual(['tag-b']);
+  });
+
+  it('reflects newly added tags after upsert', () => {
+    const service = createService();
+    service.saveEntity({ projectId: PROJECT_A, category: 'character', name: 'A', tags: ['existing'] });
+
+    expect(service.listAllTags(PROJECT_A)).toEqual(['existing']);
+
+    service.saveEntity({ projectId: PROJECT_A, category: 'location', name: 'B', tags: ['new-tag'] });
+
+    expect(service.listAllTags(PROJECT_A)).toEqual(['existing', 'new-tag']);
+  });
+});


### PR DESCRIPTION
## Summary

- Context: the Story Bible entity list had no way to narrow results by tag; users with many tagged entities had to rely on text search alone
- Add AND-semantics multi-tag filtering on BibleEntity list: selecting multiple tags returns only entities that carry every selected tag
- Introduce listAllTags across the full stack (domain interface, repository implementation, application service) so the UI always reflects the live tag vocabulary
- Replace the plain comma-separated tags text field in BibleEditor with a chip-based TagsInput component that supports Enter/comma commit and datalist suggestions drawn from existing project tags
- Add TagChip (read-only or removable) and TagFilterPanel (toggle chips + Clear action) as standalone presentational components

## Risks and Rollback

- No schema changes: tags was already persisted per entity; filtering is read-only
- All new state (tagFilter, allTags) is ephemeral React state; a page refresh resets to unfiltered view
- TagsInput replaces TagsField entirely; if a rollback is needed, revert bible-editor.tsx to restore the string-input path
- listAllTags iterates all entities on each render snapshot; acceptable for localStorage scale, worth revisiting if entity counts grow large

## Validation

- [ ] lint
- [ ] typecheck
- [ ] test - includes 9 new unit tests for tag filtering and listAllTags, and 5 new integration tests for TagFilterPanel and TagsInput
- [ ] manual: create entities with tags, verify filter panel appears, toggle tags, confirm AND filtering, verify Clear tags resets list
- [ ] manual: verify tag suggestions appear in TagsInput datalist and do not re-suggest already-added tags

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes: Multi-Tag Filtering for Story Bible Entities

### Key Features
- **Multi-tag filtering with AND semantics**: Select multiple tags to filter the Story Bible entity list; only entities containing all selected tags are displayed
- **Live tag vocabulary API**: New `listAllTags()` method exposes all tags used across entities in a project (domain interface, repository implementation, service layer)
- **Enhanced tag input UI**: Replaced comma-separated text field with a chip-based `TagsInput` component featuring:
  - Tag suggestions drawn from existing project tags via datalist
  - Enter or comma key to add tags
  - Removable tag chips with visual feedback
- **Tag filtering UI panel**: New `TagFilterPanel` component displays available tags as toggleable chips with a "Clear tags" action

### Affected Areas

**Frontend**
- New presentational components: `TagChip` (read-only or removable), `TagFilterPanel` (toggle chips + clear action), `TagsInput` (with suggestions and array-based state)
- Updated Bible Editor to use `TagsInput` instead of plain text field
- Updated Bible List to display tag chips on entities and render filter panel
- Page-level state management: new ephemeral React state for `tagFilter` and `allTags` (resets on page refresh)

**Service & Repository**
- Added `listAllTags(projectId)` method across domain interface, repository implementation, and service layer
- Implemented AND-semantics tag filtering in local repository: only entities matching all active tags are returned
- No database schema changes; tags already persisted per entity

**Domain**
- `BibleEntityFilters` now accepts optional `tags?: string[]` property
- `BibleRepository` interface extended with `listAllTags()` method declaration

### Breaking Changes
- `BibleEditorProps` now includes optional `suggestedTags?: string[]`
- `EntityFormProps` now requires `suggestedTags: string[]` and `onTagsChange: (value: string[]) => void`
- `BibleListProps` updated with `allTags: string[]`, `activeTagFilter: string[]`, and `onTagFilterChange` handler
- Tag state in Bible Editor changed from string (`tagsInputValue`) to string array (`tags`)

### Testing
- Added 9 new unit tests covering tag filtering logic and `listAllTags` aggregation
- Added 5 new integration tests validating tag filter UI interactions and tag input component behaviour

### Notes
- Filtering state is ephemeral; page refresh resets to unfiltered view
- `listAllTags` implementation iterates entities on each render snapshot (suitable for localStorage scale)
- To rollback `TagsInput` changes, restore `bible-editor.tsx` to prior string-input implementation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->