### PR TITLE
feat: Writing Goals & Sessions

### DIFF
--- a/src/app/workspace/[projectId]/goals/page.tsx
+++ b/src/app/workspace/[projectId]/goals/page.tsx
@@ -62,18 +62,23 @@ export default function WritingGoalsPage(): ReactElement {
   const projectService = useMemo(() => createProjectService(repository), [repository]);
 
   const [project, setProject] = useState<WritingProject | null>(null);
-  const [loadState, setLoadState] = useState<'loading' | 'ready' | 'not-found'>('loading');
+  const [loadState, setLoadState] = useState<'loading' | 'ready' | 'not-found' | 'error'>('loading');
 
   useEffect(() => {
     let isMounted = true;
 
     if (projectId) {
-      void projectService.getProjectById(projectId).then((loaded) => {
-        if (!isMounted) return;
-        if (!loaded) { setLoadState('not-found'); return; }
-        setProject(loaded);
-        setLoadState('ready');
-      });
+      void projectService.getProjectById(projectId)
+        .then((loaded) => {
+          if (!isMounted) return;
+          if (!loaded) { setLoadState('not-found'); return; }
+          setProject(loaded);
+          setLoadState('ready');
+        })
+        .catch(() => {
+          if (!isMounted) return;
+          setLoadState('error');
+        });
     }
 
     return () => {
@@ -87,6 +92,18 @@ export default function WritingGoalsPage(): ReactElement {
 
   if (loadState === 'loading') {
     return <LoadingMessage />;
+  }
+
+  if (loadState === 'error') {
+    return (
+      <main className="mx-auto flex min-h-screen w-full max-w-4xl flex-col items-start justify-center gap-3 px-4">
+        <h1 className="text-2xl font-headline font-semibold">Unable to load project</h1>
+        <p className="text-sm text-destructive">An error occurred while loading this project.</p>
+        <Link className="text-sm font-medium text-primary underline" href="/workspace">
+          Back to workspace
+        </Link>
+      </main>
+    );
   }
 
   if (loadState === 'not-found' || !project) {

--- a/src/app/workspace/[projectId]/goals/page.tsx
+++ b/src/app/workspace/[projectId]/goals/page.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import type { ReactElement } from 'react';
+import { useMemo } from 'react';
+import { useParams } from 'next/navigation';
+
+import { createProjectService } from '@/application/project/project-service';
+import { LocalProjectRepository } from '@/data/project/local-project-repository';
+import { GoalsPageClient } from '@/components/writing-session/goals-page-client';
+import { projectIdSchema } from '@/domain/project/schemas';
+import { useEffect, useState } from 'react';
+import type { WritingProject } from '@/domain/project/types';
+import Link from 'next/link';
+
+const getProjectIdParam = (input: string | string[] | undefined): string => {
+  if (Array.isArray(input)) {
+    return input[0] ?? '';
+  }
+
+  return input ?? '';
+};
+
+function LoadingMessage(): ReactElement {
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-4xl items-center justify-center px-4">
+      <p>Loading project...</p>
+    </main>
+  );
+}
+
+function InvalidProjectMessage(): ReactElement {
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-4xl flex-col items-start justify-center gap-3 px-4">
+      <h1 className="text-2xl font-headline font-semibold">Invalid project id</h1>
+      <p className="text-sm text-muted-foreground">The URL does not contain a valid project identifier.</p>
+      <Link className="text-sm font-medium text-primary underline" href="/workspace">
+        Back to workspace
+      </Link>
+    </main>
+  );
+}
+
+function ProjectNotFoundMessage(): ReactElement {
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-4xl flex-col items-start justify-center gap-3 px-4">
+      <h1 className="text-2xl font-headline font-semibold">Project not found</h1>
+      <p className="text-sm text-muted-foreground">This project does not exist in local storage.</p>
+      <Link className="text-sm font-medium text-primary underline" href="/workspace">
+        Back to workspace
+      </Link>
+    </main>
+  );
+}
+
+export default function WritingGoalsPage(): ReactElement {
+  const params = useParams<{ projectId: string }>();
+  const projectIdParam = getProjectIdParam(params.projectId);
+  const parsedProjectId = projectIdSchema.safeParse(projectIdParam);
+  const projectId = parsedProjectId.success ? parsedProjectId.data : null;
+
+  const repository = useMemo(() => new LocalProjectRepository(), []);
+  const projectService = useMemo(() => createProjectService(repository), [repository]);
+
+  const [project, setProject] = useState<WritingProject | null>(null);
+  const [loadState, setLoadState] = useState<'loading' | 'ready' | 'not-found'>('loading');
+
+  useEffect(() => {
+    let isMounted = true;
+
+    if (projectId) {
+      void projectService.getProjectById(projectId).then((loaded) => {
+        if (!isMounted) return;
+        if (!loaded) { setLoadState('not-found'); return; }
+        setProject(loaded);
+        setLoadState('ready');
+      });
+    }
+
+    return () => {
+      isMounted = false;
+    };
+  }, [projectId, projectService]);
+
+  if (!projectId) {
+    return <InvalidProjectMessage />;
+  }
+
+  if (loadState === 'loading') {
+    return <LoadingMessage />;
+  }
+
+  if (loadState === 'not-found' || !project) {
+    return <ProjectNotFoundMessage />;
+  }
+
+  return <GoalsPageClient projectId={projectId} projectTitle={project.title} />;
+}

--- a/src/app/workspace/[projectId]/page.tsx
+++ b/src/app/workspace/[projectId]/page.tsx
@@ -278,6 +278,25 @@ function ProjectStoryBibleSection({ projectId }: { projectId: string }): ReactEl
   );
 }
 
+function ProjectWritingGoalsSection({ projectId }: { projectId: string }): ReactElement {
+  return (
+    <section className="rounded-lg border p-4">
+      <h2 className="text-2xl font-headline font-semibold">Writing Goals</h2>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Track daily word count goals, writing sessions, streaks, and weekly progress.
+      </p>
+      <div className="mt-3">
+        <Link
+          className="inline-flex rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground"
+          href={`/workspace/${projectId}/goals`}
+        >
+          Open Writing Goals
+        </Link>
+      </div>
+    </section>
+  );
+}
+
 function ProjectDetailView({
   project,
   projectId,
@@ -300,6 +319,7 @@ function ProjectDetailView({
       <ProjectStats project={project} />
       <ProjectScenesSection projectId={projectId} project={project} actions={actions} />
       <ProjectStoryBibleSection projectId={projectId} />
+      <ProjectWritingGoalsSection projectId={projectId} />
       <Link className="text-sm font-medium text-primary underline" href="/workspace">
         Back to workspace
       </Link>

--- a/src/application/writing-session/writing-session-service.ts
+++ b/src/application/writing-session/writing-session-service.ts
@@ -1,0 +1,201 @@
+import { endSessionInputSchema, setDailyGoalInputSchema, startSessionInputSchema, writingSessionSchema } from '@/domain/writing-session/schemas';
+import type { WritingSessionRepository } from '@/domain/writing-session/repository';
+import type {
+  DailyProgress,
+  EndSessionInput,
+  SessionDashboard,
+  SetDailyGoalInput,
+  StartSessionInput,
+  StreakInfo,
+  WeeklySummary,
+  WritingSession,
+} from '@/domain/writing-session/types';
+
+export class WritingSessionValidationError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = 'WritingSessionValidationError';
+  }
+}
+
+const RECENT_SESSIONS_LIMIT = 50;
+const WEEKLY_DAYS_COUNT = 7;
+
+function localDateString(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function isoToLocalDateString(isoString: string): string {
+  return localDateString(new Date(isoString));
+}
+
+function generateId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  const randomPart = Math.random().toString(36).slice(2, 10);
+  const timePart = Date.now().toString(36);
+  return `${timePart}-${randomPart}`;
+}
+
+export class WritingSessionService {
+  private readonly repository: WritingSessionRepository;
+  private readonly now: () => string;
+
+  public constructor(repository: WritingSessionRepository, nowProvider: () => string = () => new Date().toISOString()) {
+    this.repository = repository;
+    this.now = nowProvider;
+  }
+
+  public setDailyGoal(input: SetDailyGoalInput): void {
+    const parsed = setDailyGoalInputSchema.safeParse(input);
+    if (!parsed.success) {
+      throw new WritingSessionValidationError('Invalid daily goal input');
+    }
+    this.repository.setDailyGoal(parsed.data);
+  }
+
+  public startSession(input: StartSessionInput): WritingSession {
+    const parsed = startSessionInputSchema.safeParse(input);
+    if (!parsed.success) {
+      throw new WritingSessionValidationError('Invalid start session input');
+    }
+
+    const startedAt = parsed.data.startedAt ?? this.now();
+    const session = writingSessionSchema.parse({
+      id: generateId(),
+      projectId: parsed.data.projectId,
+      startedAt,
+      endedAt: startedAt,
+      durationSeconds: 0,
+      wordsWritten: 0,
+    });
+
+    return this.repository.saveSession(session);
+  }
+
+  public endSession(input: EndSessionInput): WritingSession {
+    const parsed = endSessionInputSchema.safeParse(input);
+    if (!parsed.success) {
+      throw new WritingSessionValidationError('Invalid end session input');
+    }
+
+    const sessions = this.repository.listSessions(parsed.data.projectId);
+    const existing = sessions.find((session) => session.id === parsed.data.sessionId);
+    if (!existing) {
+      throw new WritingSessionValidationError(`Session not found: ${parsed.data.sessionId}`);
+    }
+
+    const endedAt = parsed.data.endedAt ?? this.now();
+    const durationSeconds = Math.max(
+      0,
+      Math.round((new Date(endedAt).getTime() - new Date(existing.startedAt).getTime()) / 1000),
+    );
+
+    const updatedSession = writingSessionSchema.parse({
+      ...existing,
+      endedAt,
+      durationSeconds,
+      wordsWritten: parsed.data.wordsWritten,
+    });
+
+    return this.repository.saveSession(updatedSession);
+  }
+
+  public getDashboard(projectId: string): SessionDashboard {
+    const projectData = this.repository.getProjectData(projectId);
+    const now = this.now();
+    const todayProgress = this.computeTodayProgress(projectData.sessions, projectData.dailyGoal, now);
+    const streak = this.computeStreak(projectData.sessions, now);
+    const weekly = this.computeWeekly(projectData.sessions, projectData.dailyGoal, now);
+    const recentSessions = [...projectData.sessions]
+      .sort((left, right) => new Date(right.startedAt).getTime() - new Date(left.startedAt).getTime())
+      .slice(0, RECENT_SESSIONS_LIMIT);
+
+    return { projectId, dailyGoal: projectData.dailyGoal, todayProgress, streak, weekly, recentSessions };
+  }
+
+  private computeTodayProgress(sessions: WritingSession[], dailyGoal: number | null, now: string): DailyProgress {
+    const today = isoToLocalDateString(now);
+    const wordsWritten = sessions
+      .filter((session) => isoToLocalDateString(session.startedAt) === today)
+      .reduce((total, session) => total + session.wordsWritten, 0);
+    const goalMet = dailyGoal !== null && wordsWritten >= dailyGoal;
+
+    return { date: today, wordsWritten, goalMet };
+  }
+
+  private computeStreak(sessions: WritingSession[], now: string): StreakInfo {
+    const dailyWordMap = new Map<string, number>();
+    for (const session of sessions) {
+      const date = isoToLocalDateString(session.startedAt);
+      dailyWordMap.set(date, (dailyWordMap.get(date) ?? 0) + session.wordsWritten);
+    }
+
+    const nowDate = new Date(now);
+    const todayYear = nowDate.getFullYear();
+    const todayMonth = nowDate.getMonth();
+    const todayDay = nowDate.getDate();
+
+    let currentStreak = 0;
+    for (let offset = 0; ; offset++) {
+      const checkDate = new Date(todayYear, todayMonth, todayDay - offset);
+      const dateStr = localDateString(checkDate);
+      if ((dailyWordMap.get(dateStr) ?? 0) === 0) {
+        break;
+      }
+      currentStreak += 1;
+    }
+
+    const sortedDates = Array.from(dailyWordMap.entries())
+      .filter(([, words]) => words > 0)
+      .map(([date]) => date)
+      .sort();
+
+    let longestStreak = 0;
+    let tempStreak = 0;
+    let previousDate: string | null = null;
+
+    for (const date of sortedDates) {
+      if (previousDate === null) {
+        tempStreak = 1;
+      } else {
+        const prev = new Date(`${previousDate}T12:00:00`);
+        const curr = new Date(`${date}T12:00:00`);
+        const diffDays = Math.round((curr.getTime() - prev.getTime()) / (1000 * 60 * 60 * 24));
+        tempStreak = diffDays === 1 ? tempStreak + 1 : 1;
+      }
+
+      longestStreak = Math.max(longestStreak, tempStreak);
+      previousDate = date;
+    }
+
+    return { currentStreak, longestStreak };
+  }
+
+  private computeWeekly(sessions: WritingSession[], dailyGoal: number | null, now: string): WeeklySummary {
+    const nowDate = new Date(now);
+    const todayYear = nowDate.getFullYear();
+    const todayMonth = nowDate.getMonth();
+    const todayDay = nowDate.getDate();
+    const days: DailyProgress[] = [];
+
+    for (let offset = WEEKLY_DAYS_COUNT - 1; offset >= 0; offset--) {
+      const date = new Date(todayYear, todayMonth, todayDay - offset);
+      const dateString = localDateString(date);
+
+      const wordsWritten = sessions
+        .filter((session) => isoToLocalDateString(session.startedAt) === dateString)
+        .reduce((total, session) => total + session.wordsWritten, 0);
+
+      days.push({ date: dateString, wordsWritten, goalMet: dailyGoal !== null && wordsWritten >= dailyGoal });
+    }
+
+    const totalWordsThisWeek = days.reduce((total, day) => total + day.wordsWritten, 0);
+    return { days, totalWordsThisWeek };
+  }
+}

--- a/src/components/scene/scene-editor-shell.tsx
+++ b/src/components/scene/scene-editor-shell.tsx
@@ -8,18 +8,25 @@ import {
   SceneEditorService,
   type SceneEditorServicePort,
 } from '@/application/scene/scene-editor-service';
+import { WritingSessionService } from '@/application/writing-session/writing-session-service';
 import { SceneToolbar } from '@/components/scene/scene-toolbar';
 import { LocalProjectRepository } from '@/data/project/local-project-repository';
+import { LocalWritingSessionRepository } from '@/data/writing-session/local-writing-session-repository';
 import { useSceneEditor, type UseSceneEditorResult } from '@/hooks/use-scene-editor';
+import { useWritingSession } from '@/hooks/use-writing-session';
 
 type SceneEditorShellProps = {
   projectId: string;
   sceneId: string;
   service?: SceneEditorServicePort;
+  writingService?: WritingSessionService;
 };
 
 const createSceneEditorService = (): SceneEditorServicePort =>
   new SceneEditorService(new LocalProjectRepository());
+
+const createWritingSessionService = (): WritingSessionService =>
+  new WritingSessionService(new LocalWritingSessionRepository());
 
 type SceneStateViewProps = {
   projectId: string;
@@ -199,7 +206,18 @@ export function SceneEditorShell(props: SceneEditorShellProps): ReactElement {
     [props.service],
   );
 
-  const sceneEditor = useSceneEditor({ projectId: props.projectId, sceneId: props.sceneId, service });
+  const writingService = useMemo<WritingSessionService>(
+    () => props.writingService ?? createWritingSessionService(),
+    [props.writingService],
+  );
+
+  const writingSession = useWritingSession({ projectId: props.projectId, service: writingService });
+  const sceneEditor = useSceneEditor({
+    projectId: props.projectId,
+    sceneId: props.sceneId,
+    service,
+    onWordsSaved: writingSession.onWordsSaved,
+  });
   const stateView = getSceneStateView({
     projectId: props.projectId,
     sceneId: props.sceneId,

--- a/src/components/writing-session/daily-goal-form.tsx
+++ b/src/components/writing-session/daily-goal-form.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import type { FormEvent, ReactElement } from 'react';
+import { useState } from 'react';
+
+interface DailyGoalFormProps {
+  currentGoal: number | null;
+  onSave: (goal: number | null) => void;
+}
+
+function parseGoalInput(value: string): number | null | 'invalid' {
+  const trimmed = value.trim();
+  if (trimmed === '') return null;
+  const parsed = parseInt(trimmed, 10);
+  if (!Number.isInteger(parsed) || parsed < 0 || String(parsed) !== trimmed) {
+    return 'invalid';
+  }
+  return parsed;
+}
+
+function GoalInputRow({ value, onChange }: { value: string; onChange: (value: string) => void }): ReactElement {
+  return (
+    <div className="flex gap-2">
+      <input
+        id="daily-goal-input"
+        type="number"
+        min="0"
+        step="1"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder="e.g. 500"
+        className="w-32 rounded-md border bg-background px-3 py-2 text-sm"
+      />
+      <button
+        type="submit"
+        className="inline-flex rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground"
+      >
+        Save goal
+      </button>
+    </div>
+  );
+}
+
+export function DailyGoalForm({ currentGoal, onSave }: DailyGoalFormProps): ReactElement {
+  const [inputValue, setInputValue] = useState<string>(currentGoal?.toString() ?? '');
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    setValidationError(null);
+    const result = parseGoalInput(inputValue);
+    if (result === 'invalid') {
+      setValidationError('Daily goal must be a non-negative whole number.');
+      return;
+    }
+    onSave(result);
+  };
+
+  const handleChange = (value: string): void => {
+    setInputValue(value);
+    setValidationError(null);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <div className="space-y-1">
+        <label htmlFor="daily-goal-input" className="text-sm font-medium">
+          Daily word count goal
+        </label>
+        <GoalInputRow value={inputValue} onChange={handleChange} />
+      </div>
+      {validationError ? <p className="text-sm text-destructive">{validationError}</p> : null}
+    </form>
+  );
+}

--- a/src/components/writing-session/daily-goal-form.tsx
+++ b/src/components/writing-session/daily-goal-form.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { FormEvent, ReactElement } from 'react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 interface DailyGoalFormProps {
   currentGoal: number | null;
@@ -44,6 +44,10 @@ function GoalInputRow({ value, onChange }: { value: string; onChange: (value: st
 export function DailyGoalForm({ currentGoal, onSave }: DailyGoalFormProps): ReactElement {
   const [inputValue, setInputValue] = useState<string>(currentGoal?.toString() ?? '');
   const [validationError, setValidationError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setInputValue(currentGoal?.toString() ?? '');
+  }, [currentGoal]);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
     event.preventDefault();

--- a/src/components/writing-session/daily-progress.tsx
+++ b/src/components/writing-session/daily-progress.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import type { ReactElement } from 'react';
+
+import type { DailyProgress as DailyProgressType } from '@/domain/writing-session/types';
+
+interface DailyProgressProps {
+  progress: DailyProgressType;
+  dailyGoal: number | null;
+}
+
+export function DailyProgress({ progress, dailyGoal }: DailyProgressProps): ReactElement {
+  const percentage =
+    dailyGoal !== null && dailyGoal > 0 ? Math.min(100, Math.round((progress.wordsWritten / dailyGoal) * 100)) : 0;
+
+  return (
+    <div className="space-y-3 rounded-lg border p-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h2 className="text-lg font-headline font-semibold">Today&apos;s Progress</h2>
+        {progress.goalMet ? (
+          <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-200">
+            Goal met!
+          </span>
+        ) : null}
+      </div>
+      <p className="text-2xl font-bold tabular-nums">
+        {progress.wordsWritten.toLocaleString()}
+        {dailyGoal !== null ? (
+          <span className="text-base font-normal text-muted-foreground"> / {dailyGoal.toLocaleString()} words</span>
+        ) : (
+          <span className="text-base font-normal text-muted-foreground"> words</span>
+        )}
+      </p>
+      {dailyGoal !== null && dailyGoal > 0 ? (
+        <div className="h-2 w-full overflow-hidden rounded-full bg-secondary">
+          <div
+            className="h-full rounded-full bg-primary transition-all"
+            style={{ width: `${percentage}%` }}
+            role="progressbar"
+            aria-valuenow={progress.wordsWritten}
+            aria-valuemin={0}
+            aria-valuemax={dailyGoal}
+          />
+        </div>
+      ) : null}
+      {dailyGoal === null ? (
+        <p className="text-sm text-muted-foreground">Set a daily goal to track your progress.</p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/writing-session/goals-page-client.tsx
+++ b/src/components/writing-session/goals-page-client.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import Link from 'next/link';
+import type { ReactElement } from 'react';
+import { useMemo, useState } from 'react';
+
+import { WritingSessionService } from '@/application/writing-session/writing-session-service';
+import { LocalWritingSessionRepository } from '@/data/writing-session/local-writing-session-repository';
+import { useWritingSession } from '@/hooks/use-writing-session';
+
+import { DailyGoalForm } from './daily-goal-form';
+import { DailyProgress } from './daily-progress';
+import { SessionHistory } from './session-history';
+import { SessionTimer } from './session-timer';
+import { WeeklyChart } from './weekly-chart';
+import type { SessionDashboard } from '@/domain/writing-session/types';
+
+interface GoalsPageClientProps {
+  projectId: string;
+  projectTitle: string;
+}
+
+function GoalsPageHeader({ projectId, projectTitle }: { projectId: string; projectTitle: string }): ReactElement {
+  return (
+    <header className="space-y-2">
+      <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+        <Link href="/workspace" className="hover:underline">Workspace</Link>
+        <span>/</span>
+        <Link href={`/workspace/${projectId}`} className="hover:underline">{projectTitle}</Link>
+        <span>/</span>
+        <span>Writing Goals</span>
+      </div>
+      <h1 className="text-3xl font-headline font-bold">Writing Goals</h1>
+    </header>
+  );
+}
+
+interface StreakSectionProps { currentStreak: number; longestStreak: number }
+
+function StreakSection({ currentStreak, longestStreak }: StreakSectionProps): ReactElement {
+  return (
+    <div className="space-y-2 rounded-lg border p-4">
+      <h2 className="text-lg font-headline font-semibold">Streak</h2>
+      {currentStreak === 0 ? (
+        <p className="text-sm text-muted-foreground">No active streak. Write today to start one!</p>
+      ) : (
+        <p className="text-2xl font-bold">
+          {currentStreak}
+          <span className="text-base font-normal text-muted-foreground"> day streak</span>
+        </p>
+      )}
+      {longestStreak > 0 ? (
+        <p className="text-sm text-muted-foreground">
+          Longest streak: {longestStreak} day{longestStreak === 1 ? '' : 's'}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function DashboardPanels({ dashboard }: { dashboard: SessionDashboard }): ReactElement {
+  return (
+    <>
+      <DailyProgress progress={dashboard.todayProgress} dailyGoal={dashboard.dailyGoal} />
+      <StreakSection currentStreak={dashboard.streak.currentStreak} longestStreak={dashboard.streak.longestStreak} />
+      <WeeklyChart weekly={dashboard.weekly} dailyGoal={dashboard.dailyGoal} />
+      <SessionHistory sessions={dashboard.recentSessions} />
+    </>
+  );
+}
+
+export function GoalsPageClient({ projectId, projectTitle }: GoalsPageClientProps): ReactElement {
+  const repository = useMemo(() => new LocalWritingSessionRepository(), []);
+  const service = useMemo(() => new WritingSessionService(repository), [repository]);
+  const [sessionWords, setSessionWords] = useState<number>(0);
+
+  const { dashboard, isRunning, elapsedSeconds, error, startSession, stopSession, setDailyGoal } =
+    useWritingSession({ projectId, service });
+
+  const handleStart = (): void => {
+    setSessionWords(0);
+    startSession();
+  };
+
+  const handleStop = async (): Promise<void> => {
+    await stopSession(sessionWords);
+    setSessionWords(0);
+  };
+
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-4xl flex-col gap-6 px-4 py-10">
+      <GoalsPageHeader projectId={projectId} projectTitle={projectTitle} />
+      {error ? <p className="rounded-lg border border-destructive p-3 text-sm text-destructive">{error}</p> : null}
+      <DailyGoalForm currentGoal={dashboard?.dailyGoal ?? null} onSave={setDailyGoal} />
+      <SessionTimer isRunning={isRunning} elapsedSeconds={elapsedSeconds} onStart={handleStart} onStop={handleStop} />
+      {dashboard ? <DashboardPanels dashboard={dashboard} /> : (
+        <div className="flex items-center justify-center py-10">
+          <p className="text-sm text-muted-foreground">Loading writing goals...</p>
+        </div>
+      )}
+      <Link className="text-sm font-medium text-primary underline" href={`/workspace/${projectId}`}>
+        Back to project
+      </Link>
+    </main>
+  );
+}

--- a/src/components/writing-session/session-history.tsx
+++ b/src/components/writing-session/session-history.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import type { ReactElement } from 'react';
+import { useState } from 'react';
+
+import type { WritingSession } from '@/domain/writing-session/types';
+
+interface SessionHistoryProps {
+  sessions: WritingSession[];
+}
+
+const INITIAL_DISPLAY_COUNT = 20;
+
+function formatDuration(totalSeconds: number): string {
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`;
+  }
+
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+
+  if (hours === 0) {
+    return `${minutes}m`;
+  }
+
+  return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+}
+
+function formatSessionDate(isoString: string): string {
+  return new Date(isoString).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function SessionRow({ session }: { session: WritingSession }): ReactElement {
+  return (
+    <li className="flex flex-wrap items-center justify-between gap-2 rounded-lg border px-4 py-3 text-sm">
+      <span className="text-muted-foreground">{formatSessionDate(session.startedAt)}</span>
+      <div className="flex gap-4">
+        <span>{formatDuration(session.durationSeconds)}</span>
+        <span className="font-medium">{session.wordsWritten.toLocaleString()} words</span>
+      </div>
+    </li>
+  );
+}
+
+export function SessionHistory({ sessions }: SessionHistoryProps): ReactElement {
+  const [showAll, setShowAll] = useState<boolean>(false);
+  const displayedSessions = showAll ? sessions : sessions.slice(0, INITIAL_DISPLAY_COUNT);
+
+  if (sessions.length === 0) {
+    return (
+      <div className="space-y-3 rounded-lg border p-4">
+        <h2 className="text-lg font-headline font-semibold">Session History</h2>
+        <p className="text-sm text-muted-foreground">No sessions recorded yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3 rounded-lg border p-4">
+      <h2 className="text-lg font-headline font-semibold">Session History</h2>
+      <ul className="space-y-2">
+        {displayedSessions.map((session) => (
+          <SessionRow key={session.id} session={session} />
+        ))}
+      </ul>
+      {sessions.length > INITIAL_DISPLAY_COUNT && !showAll ? (
+        <button
+          type="button"
+          onClick={() => setShowAll(true)}
+          className="text-sm font-medium text-primary underline"
+        >
+          Show {sessions.length - INITIAL_DISPLAY_COUNT} more
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/writing-session/session-timer.tsx
+++ b/src/components/writing-session/session-timer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { ReactElement } from 'react';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 interface SessionTimerProps {
   isRunning: boolean;
@@ -20,6 +20,12 @@ function formatDuration(totalSeconds: number): string {
 export function SessionTimer({ isRunning, elapsedSeconds, onStart, onStop }: SessionTimerProps): ReactElement {
   const [isStopping, setIsStopping] = useState<boolean>(false);
   const isMountedRef = useRef<boolean>(true);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   const handleStop = async (): Promise<void> => {
     setIsStopping(true);

--- a/src/components/writing-session/session-timer.tsx
+++ b/src/components/writing-session/session-timer.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import type { ReactElement } from 'react';
+import { useRef, useState } from 'react';
+
+interface SessionTimerProps {
+  isRunning: boolean;
+  elapsedSeconds: number;
+  onStart: () => void;
+  onStop: () => Promise<void>;
+}
+
+function formatDuration(totalSeconds: number): string {
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return [hours, minutes, seconds].map((unit) => String(unit).padStart(2, '0')).join(':');
+}
+
+export function SessionTimer({ isRunning, elapsedSeconds, onStart, onStop }: SessionTimerProps): ReactElement {
+  const [isStopping, setIsStopping] = useState<boolean>(false);
+  const isMountedRef = useRef<boolean>(true);
+
+  const handleStop = async (): Promise<void> => {
+    setIsStopping(true);
+    try {
+      await onStop();
+    } finally {
+      if (isMountedRef.current) {
+        setIsStopping(false);
+      }
+    }
+  };
+
+  return (
+    <div className="space-y-3 rounded-lg border p-4">
+      <h2 className="text-lg font-headline font-semibold">Writing Session</h2>
+      <div className="flex items-center gap-4">
+        <span className="font-mono text-3xl tabular-nums">{formatDuration(elapsedSeconds)}</span>
+        {isRunning ? (
+          <button
+            type="button"
+            onClick={() => { void handleStop(); }}
+            disabled={isStopping}
+            className="inline-flex rounded-md border bg-destructive px-4 py-2 text-sm font-medium text-destructive-foreground disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isStopping ? 'Stopping...' : 'Stop session'}
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={onStart}
+            className="inline-flex rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
+          >
+            Start session
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/writing-session/weekly-chart.tsx
+++ b/src/components/writing-session/weekly-chart.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import type { ReactElement } from 'react';
+
+import type { WeeklySummary } from '@/domain/writing-session/types';
+
+interface WeeklyChartProps {
+  weekly: WeeklySummary;
+  dailyGoal: number | null;
+}
+
+const SHORT_WEEKDAY_LABELS: Record<number, string> = { 0: 'Su', 1: 'Mo', 2: 'Tu', 3: 'We', 4: 'Th', 5: 'Fr', 6: 'Sa' };
+
+function getShortWeekday(dateString: string): string {
+  const dayOfWeek = new Date(`${dateString}T12:00:00`).getDay();
+  return SHORT_WEEKDAY_LABELS[dayOfWeek] ?? '??';
+}
+
+export function WeeklyChart({ weekly, dailyGoal }: WeeklyChartProps): ReactElement {
+  const maxWords = Math.max(...weekly.days.map((day) => day.wordsWritten), dailyGoal ?? 0, 1);
+
+  return (
+    <div className="space-y-3 rounded-lg border p-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h2 className="text-lg font-headline font-semibold">This Week</h2>
+        <span className="text-sm text-muted-foreground">
+          {weekly.totalWordsThisWeek.toLocaleString()} words total
+        </span>
+      </div>
+      <div className="flex items-end gap-1 h-24">
+        {weekly.days.map((day) => {
+          const heightPercent = Math.round((day.wordsWritten / maxWords) * 100);
+          const isGoalMet = day.goalMet;
+          return (
+            <div key={day.date} className="flex flex-1 flex-col items-center gap-1">
+              <div className="flex w-full flex-1 items-end">
+                <div
+                  className={`w-full rounded-t transition-all ${isGoalMet ? 'bg-primary' : 'bg-secondary'}`}
+                  style={{ height: `${heightPercent}%`, minHeight: day.wordsWritten > 0 ? '2px' : '0' }}
+                  title={`${day.wordsWritten} words`}
+                />
+              </div>
+              <span className="text-xs text-muted-foreground">{getShortWeekday(day.date)}</span>
+            </div>
+          );
+        })}
+      </div>
+      {dailyGoal !== null ? (
+        <p className="text-xs text-muted-foreground">Highlighted bars reached the {dailyGoal.toLocaleString()} word goal.</p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/data/writing-session/local-writing-session-repository.ts
+++ b/src/data/writing-session/local-writing-session-repository.ts
@@ -1,0 +1,117 @@
+import { sessionStorageSchema, writingSessionSchema } from '@/domain/writing-session/schemas';
+import type { WritingSessionRepository } from '@/domain/writing-session/repository';
+import type { ProjectSessionData, SetDailyGoalInput, WritingSession } from '@/domain/writing-session/types';
+
+export const WRITING_SESSION_STORAGE_KEY = 'ainkwell:writing-sessions:v1';
+
+function cloneEmptyProjectSessionData(): ProjectSessionData {
+  return { dailyGoal: null, sessions: [] };
+}
+
+function normalizeProjectId(projectId: string): string {
+  const normalizedProjectId = projectId.trim();
+  if (!normalizedProjectId) {
+    throw new Error('projectId is required');
+  }
+  return normalizedProjectId;
+}
+
+function parseJson(rawValue: string | null): unknown | null {
+  if (!rawValue) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(rawValue) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function upsertRecord<T extends { id: string }>(records: T[], record: T): void {
+  const index = records.findIndex((item) => item.id === record.id);
+  if (index < 0) {
+    records.push(record);
+  } else {
+    records[index] = record;
+  }
+}
+
+export class LocalWritingSessionRepository implements WritingSessionRepository {
+  private readonly storage: Storage;
+
+  public constructor(storage?: Storage) {
+    if (storage) {
+      this.storage = storage;
+      return;
+    }
+
+    if (typeof window !== 'undefined' && window.localStorage) {
+      this.storage = window.localStorage;
+      return;
+    }
+
+    throw new Error('Storage backend is unavailable');
+  }
+
+  public getProjectData(projectId: string): ProjectSessionData {
+    const normalizedProjectId = normalizeProjectId(projectId);
+    const storageData = this.readStorage();
+    const projectData = storageData.projects[normalizedProjectId];
+    if (!projectData) {
+      return cloneEmptyProjectSessionData();
+    }
+
+    return { dailyGoal: projectData.dailyGoal, sessions: [...projectData.sessions] };
+  }
+
+  public saveSession(session: WritingSession): WritingSession {
+    const parsedSession = writingSessionSchema.parse(session);
+    const normalizedProjectId = normalizeProjectId(parsedSession.projectId);
+    const storageData = this.readStorage();
+
+    const projectData = storageData.projects[normalizedProjectId] ?? cloneEmptyProjectSessionData();
+    upsertRecord(projectData.sessions, parsedSession);
+    storageData.projects[normalizedProjectId] = projectData;
+    this.writeStorage(storageData);
+    return parsedSession;
+  }
+
+  public setDailyGoal(input: SetDailyGoalInput): void {
+    const normalizedProjectId = normalizeProjectId(input.projectId);
+    const storageData = this.readStorage();
+
+    const projectData = storageData.projects[normalizedProjectId] ?? cloneEmptyProjectSessionData();
+    projectData.dailyGoal = input.goal;
+    storageData.projects[normalizedProjectId] = projectData;
+    this.writeStorage(storageData);
+  }
+
+  public listSessions(projectId: string): WritingSession[] {
+    const normalizedProjectId = normalizeProjectId(projectId);
+    const projectData = this.getProjectData(normalizedProjectId);
+    return [...projectData.sessions];
+  }
+
+  private readStorage(): { version: 1; projects: Record<string, ProjectSessionData> } {
+    const rawValue = this.storage.getItem(WRITING_SESSION_STORAGE_KEY);
+    const parsedValue = parseJson(rawValue);
+
+    if (!parsedValue) {
+      return { version: 1, projects: {} };
+    }
+
+    const parsedStorage = sessionStorageSchema.safeParse(parsedValue);
+    if (!parsedStorage.success) {
+      return { version: 1, projects: {} };
+    }
+
+    return { version: 1, projects: { ...parsedStorage.data.projects } };
+  }
+
+  private writeStorage(data: { version: 1; projects: Record<string, ProjectSessionData> }): void {
+    const parsedStorage = sessionStorageSchema.parse(data);
+    const payload = JSON.stringify(parsedStorage);
+    this.storage.setItem(WRITING_SESSION_STORAGE_KEY, payload);
+  }
+}

--- a/src/domain/writing-session/repository.ts
+++ b/src/domain/writing-session/repository.ts
@@ -1,0 +1,8 @@
+import type { ProjectSessionData, SetDailyGoalInput, WritingSession } from '@/domain/writing-session/types';
+
+export interface WritingSessionRepository {
+  getProjectData(projectId: string): ProjectSessionData;
+  saveSession(session: WritingSession): WritingSession;
+  setDailyGoal(input: SetDailyGoalInput): void;
+  listSessions(projectId: string): WritingSession[];
+}

--- a/src/domain/writing-session/schemas.ts
+++ b/src/domain/writing-session/schemas.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+
+const idSchema = z.string().trim().min(1).max(120);
+const projectIdSchema = z.string().trim().min(1).max(120);
+const timestampSchema = z.string().trim().min(1).max(64);
+
+export const writingSessionSchema = z.object({
+  id: idSchema,
+  projectId: projectIdSchema,
+  startedAt: timestampSchema,
+  endedAt: timestampSchema,
+  durationSeconds: z.number().int().min(0),
+  wordsWritten: z.number().int().min(0),
+});
+
+export const projectSessionDataSchema = z.object({
+  dailyGoal: z.number().int().min(0).nullable(),
+  sessions: z.array(writingSessionSchema).default([]),
+});
+
+export const sessionStorageSchema = z.object({
+  version: z.literal(1),
+  projects: z.record(projectSessionDataSchema).default({}),
+});
+
+export const startSessionInputSchema = z.object({
+  projectId: projectIdSchema,
+  startedAt: timestampSchema.optional(),
+});
+
+export const endSessionInputSchema = z.object({
+  sessionId: idSchema,
+  projectId: projectIdSchema,
+  endedAt: timestampSchema.optional(),
+  wordsWritten: z.number().int().min(0),
+});
+
+export const setDailyGoalInputSchema = z.object({
+  projectId: projectIdSchema,
+  goal: z.number().int().min(0).nullable(),
+});

--- a/src/domain/writing-session/types.ts
+++ b/src/domain/writing-session/types.ts
@@ -1,0 +1,60 @@
+export interface WritingSession {
+  id: string;
+  projectId: string;
+  startedAt: string;
+  endedAt: string;
+  durationSeconds: number;
+  wordsWritten: number;
+}
+
+export interface ProjectSessionData {
+  dailyGoal: number | null;
+  sessions: WritingSession[];
+}
+
+export interface SessionStorage {
+  version: 1;
+  projects: Record<string, ProjectSessionData>;
+}
+
+export interface DailyProgress {
+  date: string;
+  wordsWritten: number;
+  goalMet: boolean;
+}
+
+export interface WeeklySummary {
+  days: DailyProgress[];
+  totalWordsThisWeek: number;
+}
+
+export interface StreakInfo {
+  currentStreak: number;
+  longestStreak: number;
+}
+
+export interface SessionDashboard {
+  projectId: string;
+  dailyGoal: number | null;
+  todayProgress: DailyProgress;
+  streak: StreakInfo;
+  weekly: WeeklySummary;
+  recentSessions: WritingSession[];
+}
+
+export interface StartSessionInput {
+  projectId: string;
+  startedAt?: string;
+}
+
+export interface EndSessionInput {
+  sessionId: string;
+  projectId: string;
+  endedAt?: string;
+  wordsWritten: number;
+}
+
+export interface SetDailyGoalInput {
+  projectId: string;
+  goal: number | null;
+}

--- a/src/hooks/use-scene-editor-runtime.ts
+++ b/src/hooks/use-scene-editor-runtime.ts
@@ -52,6 +52,8 @@ type SaveSuccessInput = {
   requestId: number;
   payload: SavePayload;
   savedScene: Scene;
+  wordsDelta?: number;
+  onWordsSaved?: (delta: number) => void;
 };
 
 type SaveFailureInput = {
@@ -179,7 +181,7 @@ export const createSavePayload = (runtimeRefs: SceneRuntimeRefs): SavePayload | 
 };
 
 export const applySaveSuccess = (input: SaveSuccessInput): void => {
-  const { runtimeRefs, patchViewState, requestId, payload, savedScene } = input;
+  const { runtimeRefs, patchViewState, requestId, payload, savedScene, wordsDelta, onWordsSaved } = input;
   if (!runtimeRefs.isMountedRef.current || requestId < runtimeRefs.latestAppliedRequestRef.current) {
     return;
   }
@@ -198,6 +200,10 @@ export const applySaveSuccess = (input: SaveSuccessInput): void => {
 
   if (!payloadStillCurrent) {
     return;
+  }
+
+  if (onWordsSaved && wordsDelta !== undefined && wordsDelta !== 0) {
+    onWordsSaved(wordsDelta);
   }
 
   assignRef(runtimeRefs.isDirtyRef, false);

--- a/src/hooks/use-scene-editor.ts
+++ b/src/hooks/use-scene-editor.ts
@@ -32,6 +32,7 @@ type UseSceneEditorInput = {
   projectId: string;
   sceneId: string;
   service: SceneEditorServicePort;
+  onWordsSaved?: (delta: number) => void;
 };
 
 export type UseSceneEditorResult = {
@@ -98,6 +99,33 @@ function useRuntimeRefs(): SceneRuntimeRefs {
   );
 }
 
+type SaveAttemptInput = {
+  input: UseSceneEditorInput;
+  runtimeRefs: SceneRuntimeRefs;
+  patchViewState: ViewStateSetter;
+  payload: ReturnType<typeof createSavePayload> & object;
+  requestId: number;
+  previousWordCount: number;
+};
+
+async function executeSave(attempt: SaveAttemptInput): Promise<void> {
+  const { input, runtimeRefs, patchViewState, payload, requestId, previousWordCount } = attempt;
+  try {
+    const savedScene = await input.service.saveScene(payload);
+    const wordsDelta = input.service.countWords(savedScene.content) - previousWordCount;
+    applySaveSuccess({
+      runtimeRefs, patchViewState, requestId, payload, savedScene, wordsDelta, onWordsSaved: input.onWordsSaved,
+    });
+  } catch (error) {
+    applySaveFailure({ runtimeRefs, patchViewState, service: input.service, requestId, error });
+  } finally {
+    const inFlightCount = decrementRef(runtimeRefs.inFlightRequestCountRef);
+    if (runtimeRefs.isMountedRef.current && inFlightCount === 0) {
+      patchViewState({ isSaving: false });
+    }
+  }
+}
+
 function useRunSaveCycle(
   input: UseSceneEditorInput,
   runtimeRefs: SceneRuntimeRefs,
@@ -113,28 +141,12 @@ function useRunSaveCycle(
       return;
     }
 
+    const previousWordCount = input.service.countWords(runtimeRefs.sceneRef.current.content);
     const requestId = incrementRef(runtimeRefs.latestRequestRef);
     incrementRef(runtimeRefs.inFlightRequestCountRef);
     patchViewState({ isSaving: true });
-
-    try {
-      const savedScene = await input.service.saveScene(payload);
-      applySaveSuccess({ runtimeRefs, patchViewState, requestId, payload, savedScene });
-    } catch (error) {
-      applySaveFailure({
-        runtimeRefs,
-        patchViewState,
-        service: input.service,
-        requestId,
-        error,
-      });
-    } finally {
-      const inFlightCount = decrementRef(runtimeRefs.inFlightRequestCountRef);
-      if (runtimeRefs.isMountedRef.current && inFlightCount === 0) {
-        patchViewState({ isSaving: false });
-      }
-    }
-  }, [input.service, patchViewState, runtimeRefs]);
+    await executeSave({ input, runtimeRefs, patchViewState, payload, requestId, previousWordCount });
+  }, [input, patchViewState, runtimeRefs]);
 }
 
 function useMountLifecycle(runtimeRefs: SceneRuntimeRefs): void {

--- a/src/hooks/use-writing-session-runtime.ts
+++ b/src/hooks/use-writing-session-runtime.ts
@@ -1,0 +1,63 @@
+import type { MutableRefObject } from 'react';
+
+import type { SessionDashboard } from '@/domain/writing-session/types';
+
+export type SessionViewState = {
+  dashboard: SessionDashboard | null;
+  isRunning: boolean;
+  elapsedSeconds: number;
+  error: string | null;
+};
+
+export type SessionRuntimeRefs = {
+  sessionIdRef: MutableRefObject<string | null>;
+  wordsDeltaRef: MutableRefObject<number>;
+  elapsedSecondsRef: MutableRefObject<number>;
+  intervalRef: MutableRefObject<ReturnType<typeof setInterval> | null>;
+  isMountedRef: MutableRefObject<boolean>;
+};
+
+export type SessionViewStateSetter = (patch: Partial<SessionViewState>) => void;
+
+export const initialSessionViewState: SessionViewState = {
+  dashboard: null,
+  isRunning: false,
+  elapsedSeconds: 0,
+  error: null,
+};
+
+export const assignSessionRef = <T>(ref: MutableRefObject<T>, value: T): void => {
+  ref.current = value;
+};
+
+export const incrementSessionRef = (ref: MutableRefObject<number>): number => {
+  ref.current += 1;
+  return ref.current;
+};
+
+export const clearSessionInterval = (intervalRef: MutableRefObject<ReturnType<typeof setInterval> | null>): void => {
+  if (!intervalRef.current) {
+    return;
+  }
+
+  clearInterval(intervalRef.current);
+  assignSessionRef(intervalRef, null);
+};
+
+export const applySessionStarted = (patchViewState: SessionViewStateSetter): void => {
+  patchViewState({ isRunning: true, elapsedSeconds: 0, error: null });
+};
+
+export const applySessionEnded = (
+  patchViewState: SessionViewStateSetter,
+  dashboard: SessionDashboard,
+): void => {
+  patchViewState({ isRunning: false, elapsedSeconds: 0, dashboard, error: null });
+};
+
+export const applyDashboardLoaded = (
+  patchViewState: SessionViewStateSetter,
+  dashboard: SessionDashboard,
+): void => {
+  patchViewState({ dashboard });
+};

--- a/src/hooks/use-writing-session.ts
+++ b/src/hooks/use-writing-session.ts
@@ -1,0 +1,150 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import type { WritingSessionService } from '@/application/writing-session/writing-session-service';
+import type { SessionDashboard } from '@/domain/writing-session/types';
+
+import {
+  applyDashboardLoaded,
+  applySessionEnded,
+  applySessionStarted,
+  assignSessionRef,
+  clearSessionInterval,
+  incrementSessionRef,
+  initialSessionViewState,
+  type SessionRuntimeRefs,
+  type SessionViewState,
+  type SessionViewStateSetter,
+} from './use-writing-session-runtime';
+
+type UseWritingSessionInput = {
+  projectId: string;
+  service: WritingSessionService;
+};
+
+export type UseWritingSessionResult = {
+  dashboard: SessionDashboard | null;
+  isRunning: boolean;
+  elapsedSeconds: number;
+  error: string | null;
+  startSession: () => void;
+  stopSession: (wordsWritten: number) => Promise<void>;
+  setDailyGoal: (goal: number | null) => void;
+  onWordsSaved: (delta: number) => void;
+};
+
+function useViewState(): { viewState: SessionViewState; patchViewState: SessionViewStateSetter } {
+  const [viewState, setViewState] = useState<SessionViewState>(initialSessionViewState);
+  const patchViewState = useCallback((patch: Partial<SessionViewState>): void => {
+    setViewState((previousState) => ({ ...previousState, ...patch }));
+  }, []);
+  return { viewState, patchViewState };
+}
+
+function useRuntimeRefs(): SessionRuntimeRefs {
+  const sessionIdRef = useRef<string | null>(null);
+  const wordsDeltaRef = useRef<number>(0);
+  const elapsedSecondsRef = useRef<number>(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const isMountedRef = useRef<boolean>(false);
+  return useMemo(() => ({ sessionIdRef, wordsDeltaRef, elapsedSecondsRef, intervalRef, isMountedRef }), []);
+}
+
+function useLoadDashboard(input: UseWritingSessionInput, patchViewState: SessionViewStateSetter): () => void {
+  return useCallback((): void => {
+    try {
+      applyDashboardLoaded(patchViewState, input.service.getDashboard(input.projectId));
+    } catch {
+      patchViewState({ error: 'Failed to load writing goals data.' });
+    }
+  }, [input.projectId, input.service, patchViewState]);
+}
+
+function useStartStop(
+  input: UseWritingSessionInput,
+  runtimeRefs: SessionRuntimeRefs,
+  patchViewState: SessionViewStateSetter,
+): Pick<UseWritingSessionResult, 'startSession' | 'stopSession'> {
+  const startSession = useCallback((): void => {
+    try {
+      const session = input.service.startSession({ projectId: input.projectId });
+      assignSessionRef(runtimeRefs.sessionIdRef, session.id);
+      assignSessionRef(runtimeRefs.wordsDeltaRef, 0);
+      assignSessionRef(runtimeRefs.elapsedSecondsRef, 0);
+      applySessionStarted(patchViewState);
+      assignSessionRef(runtimeRefs.intervalRef, setInterval(() => {
+        if (!runtimeRefs.isMountedRef.current) return;
+        patchViewState({ elapsedSeconds: incrementSessionRef(runtimeRefs.elapsedSecondsRef) });
+      }, 1000));
+    } catch {
+      patchViewState({ error: 'Failed to start writing session.' });
+    }
+  }, [input, patchViewState, runtimeRefs]);
+
+  const stopSession = useCallback(async (wordsWritten: number): Promise<void> => {
+    const sessionId = runtimeRefs.sessionIdRef.current;
+    if (!sessionId) return;
+    clearSessionInterval(runtimeRefs.intervalRef);
+    assignSessionRef(runtimeRefs.sessionIdRef, null);
+    assignSessionRef(runtimeRefs.wordsDeltaRef, 0);
+    assignSessionRef(runtimeRefs.elapsedSecondsRef, 0);
+    try {
+      await Promise.resolve(input.service.endSession({ sessionId, projectId: input.projectId, wordsWritten }));
+      applySessionEnded(patchViewState, input.service.getDashboard(input.projectId));
+    } catch {
+      patchViewState({ isRunning: false, elapsedSeconds: 0, error: 'Failed to save writing session.' });
+    }
+  }, [input, patchViewState, runtimeRefs]);
+
+  return { startSession, stopSession };
+}
+
+function useGoalAndWords(
+  input: UseWritingSessionInput,
+  runtimeRefs: SessionRuntimeRefs,
+  patchViewState: SessionViewStateSetter,
+  loadDashboard: () => void,
+): Pick<UseWritingSessionResult, 'setDailyGoal' | 'onWordsSaved'> {
+  const setDailyGoal = useCallback((goal: number | null): void => {
+    try {
+      input.service.setDailyGoal({ projectId: input.projectId, goal });
+      loadDashboard();
+    } catch {
+      patchViewState({ error: 'Failed to update daily goal.' });
+    }
+  }, [input, loadDashboard, patchViewState]);
+
+  const onWordsSaved = useCallback((delta: number): void => {
+    if (!runtimeRefs.sessionIdRef.current) return;
+    assignSessionRef(runtimeRefs.wordsDeltaRef, runtimeRefs.wordsDeltaRef.current + delta);
+  }, [runtimeRefs]);
+
+  return { setDailyGoal, onWordsSaved };
+}
+
+export function useWritingSession(input: UseWritingSessionInput): UseWritingSessionResult {
+  const runtimeRefs = useRuntimeRefs();
+  const { viewState, patchViewState } = useViewState();
+  const loadDashboard = useLoadDashboard(input, patchViewState);
+  const { startSession, stopSession } = useStartStop(input, runtimeRefs, patchViewState);
+  const { setDailyGoal, onWordsSaved } = useGoalAndWords(input, runtimeRefs, patchViewState, loadDashboard);
+
+  useEffect(() => {
+    assignSessionRef(runtimeRefs.isMountedRef, true);
+    loadDashboard();
+    return () => {
+      assignSessionRef(runtimeRefs.isMountedRef, false);
+      clearSessionInterval(runtimeRefs.intervalRef);
+    };
+  }, [loadDashboard, runtimeRefs]);
+
+  return {
+    dashboard: viewState.dashboard,
+    isRunning: viewState.isRunning,
+    elapsedSeconds: viewState.elapsedSeconds,
+    error: viewState.error,
+    startSession,
+    stopSession,
+    setDailyGoal,
+    onWordsSaved,
+  };
+}

--- a/src/test/writing-session/goals-page.test.tsx
+++ b/src/test/writing-session/goals-page.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { LocalWritingSessionRepository } from '@/data/writing-session/local-writing-session-repository';
+import { GoalsPageClient } from '@/components/writing-session/goals-page-client';
+
+const PROJECT_A = '8b5d05ea-3f90-4fd4-91cb-c18edfd3de71';
+
+describe('GoalsPageClient', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders dashboard after mount', async () => {
+    render(<GoalsPageClient projectId={PROJECT_A} projectTitle="My Novel" />);
+    expect(await screen.findByText("Today's Progress")).toBeInTheDocument();
+  });
+
+  it('renders empty state for session history', async () => {
+    render(<GoalsPageClient projectId={PROJECT_A} projectTitle="My Novel" />);
+    expect(await screen.findByText('No sessions recorded yet.')).toBeInTheDocument();
+  });
+
+  it('renders weekly chart section', async () => {
+    render(<GoalsPageClient projectId={PROJECT_A} projectTitle="My Novel" />);
+    expect(await screen.findByText('This Week')).toBeInTheDocument();
+  });
+
+  it('daily goal form saves and updates persisted goal', async () => {
+    const user = userEvent.setup();
+    render(<GoalsPageClient projectId={PROJECT_A} projectTitle="My Novel" />);
+
+    const input = await screen.findByLabelText('Daily word count goal');
+    await user.clear(input);
+    await user.type(input, '300');
+    await user.click(screen.getByRole('button', { name: 'Save goal' }));
+
+    await waitFor(() => {
+      const repository = new LocalWritingSessionRepository(window.localStorage);
+      const data = repository.getProjectData(PROJECT_A);
+      expect(data.dailyGoal).toBe(300);
+    });
+  });
+
+  it('start and stop session cycle persists a session', async () => {
+    const user = userEvent.setup();
+    render(<GoalsPageClient projectId={PROJECT_A} projectTitle="My Novel" />);
+
+    await user.click(await screen.findByRole('button', { name: 'Start session' }));
+    await user.click(screen.getByRole('button', { name: 'Stop session' }));
+
+    await waitFor(() => {
+      const repository = new LocalWritingSessionRepository(window.localStorage);
+      const sessions = repository.listSessions(PROJECT_A);
+      expect(sessions.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/test/writing-session/local-writing-session-repository.test.ts
+++ b/src/test/writing-session/local-writing-session-repository.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { LocalWritingSessionRepository, WRITING_SESSION_STORAGE_KEY } from '@/data/writing-session/local-writing-session-repository';
+import type { WritingSession } from '@/domain/writing-session/types';
+
+const PROJECT_A = '8b5d05ea-3f90-4fd4-91cb-c18edfd3de71';
+const PROJECT_B = '6a7c61fb-5f70-47d5-aac9-f1f466f13de4';
+
+function createRepository(): LocalWritingSessionRepository {
+  return new LocalWritingSessionRepository(window.localStorage);
+}
+
+function buildSession(overrides: Partial<WritingSession> = {}): WritingSession {
+  return {
+    id: 'session-1',
+    projectId: PROJECT_A,
+    startedAt: '2024-01-15T10:00:00.000Z',
+    endedAt: '2024-01-15T10:30:00.000Z',
+    durationSeconds: 1800,
+    wordsWritten: 250,
+    ...overrides,
+  };
+}
+
+describe('LocalWritingSessionRepository', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns empty project data when storage is empty', () => {
+    const repository = createRepository();
+    const data = repository.getProjectData(PROJECT_A);
+
+    expect(data.dailyGoal).toBeNull();
+    expect(data.sessions).toHaveLength(0);
+  });
+
+  it('saves a session to the correct localStorage key', () => {
+    const repository = createRepository();
+    const session = buildSession();
+    repository.saveSession(session);
+
+    const raw = window.localStorage.getItem(WRITING_SESSION_STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    expect(raw).toContain('session-1');
+  });
+
+  it('upserts a session with the same id leaving only one record', () => {
+    const repository = createRepository();
+    const session = buildSession({ wordsWritten: 100 });
+    repository.saveSession(session);
+    repository.saveSession({ ...session, wordsWritten: 200 });
+
+    const sessions = repository.listSessions(PROJECT_A);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].wordsWritten).toBe(200);
+  });
+
+  it('sets daily goal without clobbering sessions', () => {
+    const repository = createRepository();
+    repository.saveSession(buildSession());
+    repository.setDailyGoal({ projectId: PROJECT_A, goal: 500 });
+
+    const data = repository.getProjectData(PROJECT_A);
+    expect(data.dailyGoal).toBe(500);
+    expect(data.sessions).toHaveLength(1);
+  });
+
+  it('falls back to empty data when storage contains invalid JSON', () => {
+    window.localStorage.setItem(WRITING_SESSION_STORAGE_KEY, 'not-json');
+    const repository = createRepository();
+    const data = repository.getProjectData(PROJECT_A);
+
+    expect(data.dailyGoal).toBeNull();
+    expect(data.sessions).toHaveLength(0);
+  });
+
+  it('isolates data between multiple projects', () => {
+    const repository = createRepository();
+    repository.saveSession(buildSession({ id: 'a1', projectId: PROJECT_A }));
+    repository.saveSession(buildSession({ id: 'b1', projectId: PROJECT_B }));
+
+    expect(repository.listSessions(PROJECT_A)).toHaveLength(1);
+    expect(repository.listSessions(PROJECT_B)).toHaveLength(1);
+    expect(repository.listSessions(PROJECT_A)[0].id).toBe('a1');
+    expect(repository.listSessions(PROJECT_B)[0].id).toBe('b1');
+  });
+});

--- a/src/test/writing-session/use-writing-session.test.ts
+++ b/src/test/writing-session/use-writing-session.test.ts
@@ -1,0 +1,89 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { WritingSessionService } from '@/application/writing-session/writing-session-service';
+import { LocalWritingSessionRepository } from '@/data/writing-session/local-writing-session-repository';
+import { useWritingSession } from '@/hooks/use-writing-session';
+
+const PROJECT_A = '8b5d05ea-3f90-4fd4-91cb-c18edfd3de71';
+
+function createService(): WritingSessionService {
+  const repository = new LocalWritingSessionRepository(window.localStorage);
+  return new WritingSessionService(repository);
+}
+
+describe('useWritingSession', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts in idle state with dashboard loaded on mount', () => {
+    const service = createService();
+    const { result } = renderHook(() => useWritingSession({ projectId: PROJECT_A, service }));
+
+    expect(result.current.isRunning).toBe(false);
+    expect(result.current.elapsedSeconds).toBe(0);
+    expect(result.current.dashboard).not.toBeNull();
+  });
+
+  it('sets isRunning to true after startSession', () => {
+    const service = createService();
+    const { result } = renderHook(() => useWritingSession({ projectId: PROJECT_A, service }));
+
+    act(() => {
+      result.current.startSession();
+    });
+
+    expect(result.current.isRunning).toBe(true);
+  });
+
+  it('increments elapsedSeconds via timer tick', () => {
+    const service = createService();
+    const { result } = renderHook(() => useWritingSession({ projectId: PROJECT_A, service }));
+
+    act(() => {
+      result.current.startSession();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(result.current.elapsedSeconds).toBe(3);
+  });
+
+  it('stopSession clears interval and resets isRunning', async () => {
+    const service = createService();
+    const { result } = renderHook(() => useWritingSession({ projectId: PROJECT_A, service }));
+
+    act(() => {
+      result.current.startSession();
+    });
+
+    await act(async () => {
+      await result.current.stopSession(100);
+    });
+
+    expect(result.current.isRunning).toBe(false);
+    expect(result.current.elapsedSeconds).toBe(0);
+  });
+
+  it('clears timer on unmount during active session', () => {
+    const service = createService();
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
+    const { result, unmount } = renderHook(() => useWritingSession({ projectId: PROJECT_A, service }));
+
+    act(() => {
+      result.current.startSession();
+    });
+
+    unmount();
+
+    expect(clearIntervalSpy).toHaveBeenCalled();
+  });
+});

--- a/src/test/writing-session/writing-session-service.test.ts
+++ b/src/test/writing-session/writing-session-service.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { WritingSessionService, WritingSessionValidationError } from '@/application/writing-session/writing-session-service';
+import { LocalWritingSessionRepository } from '@/data/writing-session/local-writing-session-repository';
+
+const PROJECT_A = '8b5d05ea-3f90-4fd4-91cb-c18edfd3de71';
+
+function createService(nowProvider?: () => string): WritingSessionService {
+  const repository = new LocalWritingSessionRepository(window.localStorage);
+  return new WritingSessionService(repository, nowProvider);
+}
+
+describe('WritingSessionService', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  describe('setDailyGoal', () => {
+    it('persists goal to storage', () => {
+      const service = createService();
+      service.setDailyGoal({ projectId: PROJECT_A, goal: 500 });
+      const dashboard = service.getDashboard(PROJECT_A);
+      expect(dashboard.dailyGoal).toBe(500);
+    });
+
+    it('accepts null to clear goal', () => {
+      const service = createService();
+      service.setDailyGoal({ projectId: PROJECT_A, goal: 500 });
+      service.setDailyGoal({ projectId: PROJECT_A, goal: null });
+      expect(service.getDashboard(PROJECT_A).dailyGoal).toBeNull();
+    });
+
+    it('rejects negative numbers', () => {
+      const service = createService();
+      expect(() => service.setDailyGoal({ projectId: PROJECT_A, goal: -1 })).toThrow();
+    });
+  });
+
+  describe('startSession', () => {
+    it('creates a session with correct initial state', () => {
+      const now = '2024-01-15T10:00:00.000Z';
+      const service = createService(() => now);
+      const session = service.startSession({ projectId: PROJECT_A });
+
+      expect(session.projectId).toBe(PROJECT_A);
+      expect(session.startedAt).toBe(now);
+      expect(session.durationSeconds).toBe(0);
+      expect(session.wordsWritten).toBe(0);
+      expect(session.id).toBeTruthy();
+    });
+
+    it('generates a unique UUID for each session', () => {
+      const service = createService();
+      const sessionA = service.startSession({ projectId: PROJECT_A });
+      const sessionB = service.startSession({ projectId: PROJECT_A });
+      expect(sessionA.id).not.toBe(sessionB.id);
+    });
+  });
+
+  describe('endSession', () => {
+    it('patches duration and wordsWritten on the existing session', () => {
+      const startedAt = '2024-01-15T10:00:00.000Z';
+      const endedAt = '2024-01-15T10:30:00.000Z';
+      const service = createService(() => startedAt);
+      const session = service.startSession({ projectId: PROJECT_A });
+
+      const ended = service.endSession({ sessionId: session.id, projectId: PROJECT_A, endedAt, wordsWritten: 300 });
+
+      expect(ended.durationSeconds).toBe(1800);
+      expect(ended.wordsWritten).toBe(300);
+      expect(ended.endedAt).toBe(endedAt);
+    });
+
+    it('throws when sessionId is not found', () => {
+      const service = createService();
+      expect(() =>
+        service.endSession({ sessionId: 'nonexistent', projectId: PROJECT_A, wordsWritten: 0 }),
+      ).toThrow(WritingSessionValidationError);
+    });
+  });
+
+  describe('computeTodayProgress', () => {
+    it('sums only today sessions', () => {
+      const today = '2024-01-15T10:00:00.000Z';
+      const yesterday = '2024-01-14T10:00:00.000Z';
+      const service = createService(() => today);
+      const s1 = service.startSession({ projectId: PROJECT_A });
+      service.endSession({ sessionId: s1.id, projectId: PROJECT_A, wordsWritten: 200 });
+
+      const oldService = createService(() => yesterday);
+      const s2 = oldService.startSession({ projectId: PROJECT_A });
+      oldService.endSession({ sessionId: s2.id, projectId: PROJECT_A, wordsWritten: 100 });
+
+      const dashboard = service.getDashboard(PROJECT_A);
+      expect(dashboard.todayProgress.wordsWritten).toBe(200);
+    });
+
+    it('returns zero when no sessions exist', () => {
+      const service = createService();
+      const dashboard = service.getDashboard(PROJECT_A);
+      expect(dashboard.todayProgress.wordsWritten).toBe(0);
+      expect(dashboard.todayProgress.goalMet).toBe(false);
+    });
+  });
+
+  describe('computeStreak', () => {
+    it('returns streak of 3 for 3 consecutive days', () => {
+      const day3 = '2024-01-15T10:00:00.000Z';
+      const day2 = '2024-01-14T10:00:00.000Z';
+      const day1 = '2024-01-13T10:00:00.000Z';
+
+      for (const dayNow of [day1, day2]) {
+        const svc = createService(() => dayNow);
+        const s = svc.startSession({ projectId: PROJECT_A });
+        svc.endSession({ sessionId: s.id, projectId: PROJECT_A, wordsWritten: 100 });
+      }
+
+      const service = createService(() => day3);
+      const s = service.startSession({ projectId: PROJECT_A });
+      service.endSession({ sessionId: s.id, projectId: PROJECT_A, wordsWritten: 100 });
+
+      const dashboard = service.getDashboard(PROJECT_A);
+      expect(dashboard.streak.currentStreak).toBe(3);
+    });
+
+    it('breaks streak on gap', () => {
+      const day3 = '2024-01-15T10:00:00.000Z';
+      const day1 = '2024-01-13T10:00:00.000Z';
+
+      const svc1 = createService(() => day1);
+      const s1 = svc1.startSession({ projectId: PROJECT_A });
+      svc1.endSession({ sessionId: s1.id, projectId: PROJECT_A, wordsWritten: 100 });
+
+      const service = createService(() => day3);
+      const s3 = service.startSession({ projectId: PROJECT_A });
+      service.endSession({ sessionId: s3.id, projectId: PROJECT_A, wordsWritten: 100 });
+
+      const dashboard = service.getDashboard(PROJECT_A);
+      expect(dashboard.streak.currentStreak).toBe(1);
+    });
+
+    it('tracks longestStreak correctly', () => {
+      const days = [
+        '2024-01-10T10:00:00.000Z',
+        '2024-01-11T10:00:00.000Z',
+        '2024-01-12T10:00:00.000Z',
+        '2024-01-15T10:00:00.000Z',
+      ];
+
+      for (const day of days) {
+        const svc = createService(() => day);
+        const s = svc.startSession({ projectId: PROJECT_A });
+        svc.endSession({ sessionId: s.id, projectId: PROJECT_A, wordsWritten: 100 });
+      }
+
+      const service = createService(() => days[days.length - 1]);
+      const dashboard = service.getDashboard(PROJECT_A);
+      expect(dashboard.streak.longestStreak).toBe(3);
+      expect(dashboard.streak.currentStreak).toBe(1);
+    });
+  });
+
+  describe('computeWeekly', () => {
+    it('produces exactly 7 entries', () => {
+      const service = createService();
+      const dashboard = service.getDashboard(PROJECT_A);
+      expect(dashboard.weekly.days).toHaveLength(7);
+    });
+
+    it('correctly assigns words to each day bucket', () => {
+      const now = '2024-01-15T10:00:00.000Z';
+      const service = createService(() => now);
+      const s = service.startSession({ projectId: PROJECT_A });
+      service.endSession({ sessionId: s.id, projectId: PROJECT_A, wordsWritten: 400 });
+
+      const dashboard = service.getDashboard(PROJECT_A);
+      const todayEntry = dashboard.weekly.days[dashboard.weekly.days.length - 1];
+      expect(todayEntry.date).toBe('2024-01-15');
+      expect(todayEntry.wordsWritten).toBe(400);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Context/problem:** Writers need a way to set daily word count goals, track timed writing sessions, monitor their writing streaks, and review weekly progress — all without a backend dependency.
- **Domain layer** (`src/domain/writing-session/`): adds `WritingSession`, `SessionDashboard`, `DailyProgress`, `WeeklySummary`, `StreakInfo` types, Zod schemas for all inputs, and the `WritingSessionRepository` interface.
- **Data layer** (`src/data/writing-session/`): `LocalWritingSessionRepository` persists everything to `ainkwell:writing-sessions:v1` in localStorage with versioned schema validation and corruption recovery.
- **Application layer** (`src/application/writing-session/`): `WritingSessionService` handles start/end session lifecycle, daily goal management, today progress, 7-day streak calculation (current + longest), and weekly bar chart aggregation — all time-injected for deterministic testing.
- **Hooks layer** (`src/hooks/`): `useWritingSession` drives the live HH:MM:SS timer via a 1-second setInterval, accumulates word deltas per session in a ref, and refreshes the dashboard after stop. Runtime state is isolated in `use-writing-session-runtime.ts` following the existing pattern.
- **useSceneEditor extension** (`src/hooks/use-scene-editor.ts`, `use-scene-editor-runtime.ts`): adds optional `onWordsSaved(delta)` callback fired on each autosave with the word-count delta, enabling the session hook to accumulate words written while typing.
- **UI components** (`src/components/writing-session/`): SessionTimer, DailyGoalForm, DailyProgress, WeeklyChart, SessionHistory, and GoalsPageClient composing the full dashboard.
- **App route** (`src/app/workspace/[projectId]/goals/page.tsx`): new Next.js client page with project-id validation, loading/not-found guards, and GoalsPageClient render.
- **Workspace entry point** (`src/app/workspace/[projectId]/page.tsx`): adds ProjectWritingGoalsSection card linking to the goals page from the project detail view.
- **Tests** (`src/test/writing-session/`): 4 test files covering the service, repository, hook, and page.

## Risks and Rollback

- Storage key `ainkwell:writing-sessions:v1` is new and independent — no migration risk to existing project or bible data.
- `onWordsSaved` on `useSceneEditor` is optional with no default; existing call sites are unaffected.
- Rollback: revert the 9 commits on this branch; no data migration needed as the key did not exist before.

## Validation

- [ ] lint (`npm run lint`)
- [ ] typecheck (`npm run typecheck`)
- [ ] test (`npm run test:run`)
- [ ] `npm run test:ci` passes end-to-end
- [ ] Manual: start a session, type in the scene editor, stop the session — verify word count is reflected
- [ ] Manual: set a daily goal, verify progress bar and weekly chart update after stopping a session
- [ ] Manual: verify streak increments on consecutive days (use system clock)
- [ ] Manual: verify localStorage key `ainkwell:writing-sessions:v1` contains expected JSON shape

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Release Notes: Writing Goals & Sessions Feature

## Overview
Introduces offline writing goals and timed writing sessions functionality with no backend dependency. Data persists locally to browser storage with versioned schema validation and corruption recovery.

## Key Changes

### Core Features
- **Writing Sessions**: Start/stop timed writing sessions that track duration and word count per project
- **Daily Goals**: Set and manage per-project daily word-count targets
- **Dashboard Metrics**: Track today's progress, current/longest streaks, weekly word totals, and session history
- **Session History**: View recent writing sessions with duration and word count

### Domain Layer
- New domain types and Zod schemas for WritingSession, SessionDashboard, DailyProgress, WeeklySummary, and StreakInfo
- WritingSessionRepository interface defining data access contract

### Data Layer
- LocalWritingSessionRepository persists data to `localStorage` under key `ainkwell:writing-sessions:v1` with versioned schema
- Automatic recovery from corrupted storage data
- Per-project session isolation and daily goal management

### Application Logic
- WritingSessionService manages session lifecycle (start/end), daily goal management, dashboard computation, and metrics
- Time provider injection for deterministic testing
- Input validation via WritingSessionValidationError

### UI Components
- SessionTimer: HH:MM:SS countdown with start/stop controls
- DailyGoalForm: Input form to set daily word-count targets
- DailyProgress: Displays today's progress with optional goal-met badge and progress bar
- WeeklyChart: Bar chart showing daily word counts for the past 7 days
- SessionHistory: Scrollable list of recent writing sessions with expandable "show more" functionality
- GoalsPageClient: Composed dashboard integrating all above components

### Hooks
- useWritingSession: Orchestrates session lifecycle, timer management, and dashboard state with deterministic 1-second timer intervals
- useSceneEditor extension: Optional onWordsSaved(delta) callback on autosave to report word-count deltas to session tracking
- use-writing-session-runtime: Runtime helpers for session refs, interval management, and state patching

### Routes & Integration
- New Next.js client page at `/workspace/[projectId]/goals/` with project validation and guards
- ProjectWritingGoalsSection component added to workspace project page with navigation link to goals dashboard
- useSceneEditor updated to compute and emit word-count deltas on save

### Testing
- Comprehensive test coverage for WritingSessionService, LocalWritingSessionRepository, useWritingSession hook, and GoalsPageClient
- localStorage clearing and fake timers for isolated, deterministic tests

## Affected Areas
- **Frontend**: New goals page, components, and hooks
- **Data Management**: Client-side localStorage persistence with validation
- **Application Logic**: Session and goal lifecycle management

## Migration & Compatibility
- New storage key is independent (no migration required)
- onWordsSaved callback is optional (backward compatible with existing useSceneEditor usage)
- Rollback available via reverting 9 commits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->