### PR TITLE
📝 docs: add retroactive implementation plans for all merged PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ npm run test:ci      # lint + typecheck + test:run (required before commit/PR)
 
 Run a single test file:
 ```bash
-npx vitest run src/test/bible/local-bible-repository.test.ts
+npx vitest run src/test/<feature>/<file>.test.ts
 ```
 
 ## Architecture
@@ -29,10 +29,10 @@ domain/ → application/ → data/ → components/ → app/
 ```
 
 - **`src/domain/`** — Pure types, interfaces, and Zod schemas. No implementation. Defines `ProjectRepository` and `BibleRepository` interfaces.
-- **`src/application/`** — Business logic services (`ProjectService`, `BibleService`, `SceneEditorService`). Validated via Zod schemas. Depend only on domain interfaces.
-- **`src/data/`** — Concrete repository implementations (`LocalProjectRepository`, `LocalBibleRepository`). Both persist exclusively to `window.localStorage`. No cloud/server dependency.
-- **`src/components/`** — React components organized by feature (`bible/`, `scene/`, `workspace/`). Page-level controllers (e.g. `bible-page-controller.ts`) are hooks that compose services and manage state.
-- **`src/hooks/`** — Shared hooks. `use-scene-editor.ts` implements autosave with 800ms debounce; its runtime refs are isolated in `use-scene-editor-runtime.ts`.
+- **`src/application/`** — Business logic services (`ProjectService`, `ChapterService`, `BibleService`, `SceneEditorService`, `WritingSessionService`). Validated via Zod schemas. Depend only on domain interfaces.
+- **`src/data/`** — Concrete repository implementations (`LocalProjectRepository`, `LocalBibleRepository`, `LocalWritingSessionRepository`). All persist exclusively to `window.localStorage`. No cloud/server dependency.
+- **`src/components/`** — React components organized by feature (`bible/`, `scene/`, `workspace/`, `writing-session/`). Page-level controllers (e.g. `bible-page-controller.ts`) are hooks that compose services and manage state.
+- **`src/hooks/`** — Shared hooks. `use-scene-editor.ts` (autosave, 800ms debounce) and `use-writing-session.ts` (live timer, word delta). Both isolate mutable refs in a companion `*-runtime.ts` hook to prevent stale closures.
 - **`src/app/`** — Next.js App Router pages. All pages are client components (`'use client'`) due to localStorage dependency.
 
 ## Local Storage Keys
@@ -42,6 +42,7 @@ domain/ → application/ → data/ → components/ → app/
 | `ainkwell.projects.v1` | All projects + embedded scenes (JSON) |
 | `ainkwell:projects:{id}:bible:v1` | Bible entities/relationships/scene-links per project |
 | `ainkwell:projects:{id}:scenes:v1` | Bible's own scene list per project |
+| `ainkwell:projects:{id}:sessions:v1` | Writing sessions + daily goal per project |
 | `ainkwell:workspace:v1` | Legacy key — migrated automatically on first read |
 
 ## Code Conventions
@@ -58,6 +59,14 @@ domain/ → application/ → data/ → components/ → app/
 - Branches: `feature/`, `bugfix/`, `hotfix/`, `release/vX.Y.Z`. `main` and `develop` are protected.
 - Commit format: `<gitmoji> <intent>: <description>` — intent is one of `feat/fix/refactor/style/perf/docs/build/wip`.
 - Commit bullets must list all changed files/components/services, present tense, 3–5+ bullets.
+
+## Dark Mode
+
+Toggled via `.dark` class on `<html>`. Persisted to `localStorage` at key `ainkwell:theme`. `ThemeToggle` (`src/components/theme-toggle.tsx`) handles toggle + flash prevention via `next/script beforeInteractive`.
+
+## Implementation Plans
+
+Plans live in `docs/plans/` as `YYYY-MM-DD-<feature>.plan.md`. Create one before implementing a feature; mark todos `status: done` after merge. Never delete — they serve as architectural history.
 
 ## Testing
 

--- a/docs/plans/2026-02-25-oss-local-first-no-firebase.plan.md
+++ b/docs/plans/2026-02-25-oss-local-first-no-firebase.plan.md
@@ -1,0 +1,55 @@
+---
+name: OSS Local-First (No Firebase)
+overview: Strip Firebase from the Next.js starter and replace with a pure local-first baseline using localStorage — zero cloud dependency, zero account required.
+status: done
+merged: "2026-02-25"
+pr: 1
+todos:
+  - id: 1
+    content: "Remove Firebase runtime and dependency from package.json"
+    status: done
+    dependencies: []
+  - id: 2
+    content: "Delete Firebase client provider and config files"
+    status: done
+    dependencies: [1]
+  - id: 3
+    content: "Update layout.tsx and page.tsx to remove Firebase references"
+    status: done
+    dependencies: [2]
+  - id: 4
+    content: "Update .gitignore and .env.example for local-first setup"
+    status: done
+    dependencies: []
+  - id: 5
+    content: "Update README to document local-first OSS baseline"
+    status: done
+    dependencies: []
+---
+
+# OSS Local-First (No Firebase) — Retroactive Plan
+
+> This plan was written retroactively after the feature was merged (PR #1).
+
+**Goal:** Start from a Firebase-based Next.js starter and strip it down to a clean local-first OSS baseline. No cloud, no account, no environment variables required to run.
+
+## Context
+
+The project started from a Next.js + Firebase starter template. Firebase was entirely replaced by `localStorage` as the persistence layer. This was the foundational decision that makes Ainkwell local-first by default.
+
+## Files Changed
+
+| Action | Path |
+|--------|------|
+| Delete | `src/firebase/client-provider.tsx` |
+| Modify | `package.json` — remove firebase dependency |
+| Modify | `package-lock.json` — ~980 lines removed |
+| Modify | `src/app/layout.tsx` |
+| Modify | `src/app/page.tsx` |
+| Modify | `.env.example` |
+| Modify | `.gitignore` |
+| Modify | `README.md` |
+
+## Key Decision
+
+**localStorage over Firebase** — The app is designed for writers who want full ownership of their data. No account, no internet, no vendor lock-in. All data lives in the browser's localStorage. This decision shaped the entire architecture: all repositories are `Local*Repository` implementations, all pages are `'use client'` components.

--- a/docs/plans/2026-02-27-project-workspace.plan.md
+++ b/docs/plans/2026-02-27-project-workspace.plan.md
@@ -1,0 +1,78 @@
+---
+name: Project Workspace
+overview: Build the full project management layer — domain types, localStorage repository, application service, and workspace UI with project CRUD.
+status: done
+merged: "2026-02-27"
+pr: 2
+todos:
+  - id: 1
+    content: "Define WritingProject domain type and Zod schema"
+    status: done
+    dependencies: []
+  - id: 2
+    content: "Define ProjectRepository interface"
+    status: done
+    dependencies: [1]
+  - id: 3
+    content: "Implement LocalProjectRepository persisting to localStorage"
+    status: done
+    dependencies: [2]
+  - id: 4
+    content: "Build ProjectService with CRUD operations"
+    status: done
+    dependencies: [3]
+  - id: 5
+    content: "Build workspace page with project list"
+    status: done
+    dependencies: [4]
+  - id: 6
+    content: "Build project detail page"
+    status: done
+    dependencies: [4]
+  - id: 7
+    content: "Build ProjectForm, ProjectCard, ProjectFormFields components"
+    status: done
+    dependencies: [5]
+  - id: 8
+    content: "Write tests for project repository and service"
+    status: done
+    dependencies: [4]
+---
+
+# Project Workspace — Retroactive Plan
+
+> This plan was written retroactively after the feature was merged (PR #2).
+
+**Goal:** A writer can create, view, edit, and delete writing projects from a central workspace. Each project has a title, description, language, and optional target word count.
+
+## Architecture
+
+First full vertical slice of the layered architecture:
+
+```
+domain/project/ → application/project/ → data/project/ → components/workspace/ → app/workspace/
+```
+
+Storage key: `ainkwell.projects.v1` — a JSON map of `{ [projectId]: WritingProject }`.
+
+## Files Changed
+
+| Action | Path |
+|--------|------|
+| Create | `src/domain/project/project.ts` |
+| Create | `src/domain/project/project-repository.ts` |
+| Create | `src/data/project/local-project-repository.ts` |
+| Create | `src/application/project/project-service.ts` |
+| Create | `src/components/workspace/project-card.tsx` |
+| Create | `src/components/workspace/project-form.tsx` |
+| Create | `src/components/workspace/project-form-fields.tsx` |
+| Create | `src/app/workspace/page.tsx` |
+| Create | `src/app/workspace/[projectId]/page.tsx` |
+| Modify | `src/app/page.tsx` |
+| Modify | `README.md` |
+
+## Key Decisions
+
+- **All pages are `'use client'`** — localStorage is only available client-side; rather than shimming SSR, every page opts into client rendering explicitly
+- **Projects stored as a flat map** — `Record<string, WritingProject>` in a single localStorage key; simple to read/write, no joins needed at this scale
+- **Zod validation at boundaries** — all `ProjectService` inputs are validated with Zod schemas before touching storage, even though this is local-only (protects against localStorage corruption)

--- a/docs/plans/2026-02-27-scene-editor-markdown.plan.md
+++ b/docs/plans/2026-02-27-scene-editor-markdown.plan.md
@@ -1,0 +1,89 @@
+---
+name: Scene Editor (Markdown)
+overview: Add a full-featured scene editor with Markdown textarea, status workflow (draft/revise/final), 800ms autosave, word count, and navigation between scenes.
+status: done
+merged: "2026-02-27"
+pr: 3
+todos:
+  - id: 1
+    content: "Add Scene domain type and embed scenes in WritingProject"
+    status: done
+    dependencies: []
+  - id: 2
+    content: "Add scene CRUD to ProjectRepository interface"
+    status: done
+    dependencies: [1]
+  - id: 3
+    content: "Implement scene operations in LocalProjectRepository"
+    status: done
+    dependencies: [2]
+  - id: 4
+    content: "Build SceneEditorService with load, save, wordCount, navigation"
+    status: done
+    dependencies: [3]
+  - id: 5
+    content: "Build SceneEditorShell component with textarea and toolbar"
+    status: done
+    dependencies: [4]
+  - id: 6
+    content: "Build SceneToolbar with status selector, word count, save state"
+    status: done
+    dependencies: []
+  - id: 7
+    content: "Build SceneStatusBadge component"
+    status: done
+    dependencies: []
+  - id: 8
+    content: "Implement useSceneEditor hook with 800ms autosave debounce"
+    status: done
+    dependencies: [4]
+  - id: 9
+    content: "Isolate runtime refs in useSceneEditorRuntime"
+    status: done
+    dependencies: [8]
+  - id: 10
+    content: "Add /workspace/[projectId]/scene/[sceneId] page route"
+    status: done
+    dependencies: [5]
+  - id: 11
+    content: "Write tests for autosave and repository"
+    status: done
+    dependencies: [8]
+---
+
+# Scene Editor (Markdown) — Retroactive Plan
+
+> This plan was written retroactively after the feature was merged (PR #3).
+
+**Goal:** Writers open a scene and write in a full-page Markdown textarea. Content autosaves every 800ms after the last keystroke. They can toggle the scene's status (draft/revise/final) and navigate between previous/next scenes.
+
+## Architecture
+
+Scenes are embedded in `WritingProject.scenes: Record<string, Scene>` — no separate storage key. `SceneEditorService` is the application layer; `useSceneEditor` + `useSceneEditorRuntime` are the React hooks.
+
+**Runtime refs isolation pattern:** mutable refs (debounce timer, content snapshot for dirty checking) live in `useSceneEditorRuntime` to prevent stale closures in the autosave callback. View state (content, status, wordCount, isDirty, isSaving, saveError, lastSavedAt) lives in `useSceneEditor`. This pattern was later reused for `useWritingSession`.
+
+## Files Changed
+
+| Action | Path |
+|--------|------|
+| Modify | `src/domain/project/project.ts` — add Scene type |
+| Modify | `src/domain/project/project-repository.ts` — add scene methods |
+| Modify | `src/data/project/local-project-repository.ts` — implement scene CRUD |
+| Create | `src/application/scene/scene-editor-service.ts` |
+| Create | `src/components/scene/scene-editor-shell.tsx` |
+| Create | `src/components/scene/scene-toolbar.tsx` |
+| Create | `src/components/scene/scene-status-badge.tsx` |
+| Create | `src/hooks/use-scene-editor.ts` |
+| Create | `src/hooks/use-scene-editor-runtime.ts` |
+| Create | `src/app/workspace/[projectId]/scene/[sceneId]/page.tsx` |
+| Modify | `src/app/workspace/[projectId]/page.tsx` |
+| Modify | `src/app/globals.css` |
+| Modify | `src/app/layout.tsx` |
+
+## Key Decisions
+
+- **800ms debounce** — long enough to not fire on every keystroke, short enough that writers never lose more than a second of work
+- **`useSceneEditorRuntime` separation** — isolating mutable refs from view state prevents the autosave interval from capturing stale state references; critical for correctness
+- **Scene max content: 1,000,000 characters** — enforced at the repository level to protect localStorage from extremely large payloads
+- **Markdown-only** — no WYSIWYG to keep the editor simple and portable; preview toggle was left for a future feature

--- a/docs/plans/2026-02-28-bible-dry-patterns.plan.md
+++ b/docs/plans/2026-02-28-bible-dry-patterns.plan.md
@@ -1,0 +1,50 @@
+---
+name: Bible DRY Patterns
+overview: Refactor the Story Bible module to remove duplication — extract shared helpers, consolidate state management, and simplify the page controller.
+status: done
+merged: "2026-02-28"
+pr: 5
+todos:
+  - id: 1
+    content: "Extract upsertRecord helper to consolidate bible repository upsert methods"
+    status: done
+    dependencies: []
+  - id: 2
+    content: "Extract resolveIdInList to deduplicate ID resolution across form states"
+    status: done
+    dependencies: []
+  - id: 3
+    content: "Extract withBibleAction and remove identity function in bible controller"
+    status: done
+    dependencies: []
+  - id: 4
+    content: "Remove dead component and deduplicate loading JSX"
+    status: done
+    dependencies: []
+---
+
+# Bible DRY Patterns — Retroactive Plan
+
+> This plan was written retroactively after the feature was merged (PR #5).
+
+**Goal:** The Story Bible module had grown organically with duplicated upsert patterns, repeated ID resolution logic, and a dead component. This refactor cleaned it up without changing any behavior.
+
+## Files Changed
+
+| Action | Path |
+|--------|------|
+| Refactor | `src/data/bible/local-bible-repository.ts` |
+| Refactor | `src/components/bible/bible-editor-utils.ts` |
+| Refactor | `src/components/bible/relationship-editor-state.ts` |
+| Refactor | `src/components/bible/scene-links-state.ts` |
+| Refactor | `src/components/bible/bible-page-controller.ts` |
+| Refactor | `src/components/bible/bible-page-client.tsx` |
+| Refactor | `src/components/scene/workspace-scene-list.tsx` |
+
+## What Was Done
+
+- **`upsertRecord`** helper extracted in `local-bible-repository.ts` — entities, relationships, and scene-links all had the same "find by id or append" pattern
+- **`resolveIdInList`** extracted — relationship editor and scene-links editor both resolved selected IDs from form state the same way
+- **`withBibleAction`** extracted in `bible-page-controller.ts` — error handling wrapper around all bible mutations was repeated for every action
+- Removed a dead component that was no longer rendered
+- Deduplicated loading JSX that appeared in multiple render paths of `bible-page-client.tsx`

--- a/docs/plans/2026-02-28-story-bible.plan.md
+++ b/docs/plans/2026-02-28-story-bible.plan.md
@@ -1,0 +1,117 @@
+---
+name: Story Bible
+overview: Build a full worldbuilding and continuity system — writers can create bible entities (characters, locations, factions, lore), define relationships between them with cycle detection, and link entities to specific scenes.
+status: done
+merged: "2026-02-28"
+pr: 4
+todos:
+  - id: 1
+    content: "Define BibleEntity, BibleRelationship, BibleSceneLink domain types and Zod schemas"
+    status: done
+    dependencies: []
+  - id: 2
+    content: "Define BibleRepository interface with entity, relationship, and scene-link operations"
+    status: done
+    dependencies: [1]
+  - id: 3
+    content: "Implement LocalBibleRepository persisting to localStorage"
+    status: done
+    dependencies: [2]
+  - id: 4
+    content: "Build BibleService with CRUD, cycle detection, tag limits, scope enforcement"
+    status: done
+    dependencies: [3]
+  - id: 5
+    content: "Build BiblePageController hook composing all bible state"
+    status: done
+    dependencies: [4]
+  - id: 6
+    content: "Build BibleList component with search and category filter"
+    status: done
+    dependencies: [5]
+  - id: 7
+    content: "Build BibleEditor component for entity create/edit"
+    status: done
+    dependencies: [5]
+  - id: 8
+    content: "Build RelationshipEditor component with cycle detection UI"
+    status: done
+    dependencies: [5]
+  - id: 9
+    content: "Build SceneLinks component for entity-scene linking"
+    status: done
+    dependencies: [5]
+  - id: 10
+    content: "Build BiblePageClient 4-column layout"
+    status: done
+    dependencies: [6, 7, 8, 9]
+  - id: 11
+    content: "Add /workspace/[projectId]/bible page route"
+    status: done
+    dependencies: [10]
+  - id: 12
+    content: "Add bible entry point to project detail page"
+    status: done
+    dependencies: [11]
+---
+
+# Story Bible — Retroactive Plan
+
+> This plan was written retroactively after the feature was merged (PR #4).
+
+**Goal:** Writers maintain a structured reference of their story world. They can define entities (characters, locations, factions, lore), draw relationships between them, and annotate which scenes each entity appears in.
+
+## Architecture
+
+Separate storage key per project: `ainkwell:projects:{id}:bible:v1`
+
+Stores: `{ entities: BibleEntity[], relationships: BibleRelationship[], sceneLinks: BibleSceneLink[], scenes: BibleScene[] }`
+
+`BiblePageController` is a hook that composes `BibleService` and manages all bible UI state in one place (selected entity, active editor mode, search query, category filter). This avoids prop-drilling across the 4-column layout.
+
+## Domain
+
+```ts
+type BibleEntity = {
+  id, projectId, category, name, summary, details, tags, createdAt, updatedAt
+}
+// category: 'character' | 'location' | 'faction' | 'lore'
+
+type BibleRelationship = {
+  id, projectId, type, fromEntityId, toEntityId, notes, createdAt, updatedAt
+}
+// 10 relationship types: ally_of, enemy_of, member_of, located_in,
+//   parent_of, sibling_of, mentor_of, rival_of, controls, knows
+
+type BibleSceneLink = {
+  id, projectId, sceneId, entityId, notes, createdAt, updatedAt
+}
+```
+
+## Files Changed
+
+| Action | Path |
+|--------|------|
+| Create | `src/domain/bible/types.ts` |
+| Create | `src/domain/bible/repository.ts` |
+| Create | `src/data/bible/local-bible-repository.ts` |
+| Create | `src/application/bible/bible-service.ts` |
+| Create | `src/components/bible/bible-page-controller.ts` |
+| Create | `src/components/bible/bible-page-client.tsx` |
+| Create | `src/components/bible/bible-list.tsx` |
+| Create | `src/components/bible/bible-editor.tsx` |
+| Create | `src/components/bible/relationship-editor.tsx` |
+| Create | `src/components/bible/relationship-editor-state.ts` |
+| Create | `src/components/bible/scene-links.tsx` |
+| Create | `src/components/bible/scene-links-state.ts` |
+| Create | `src/components/bible/bible-editor-utils.ts` |
+| Create | `src/app/workspace/[projectId]/bible/page.tsx` |
+| Modify | `src/app/workspace/[projectId]/page.tsx` |
+| Modify | `src/app/layout.tsx` |
+
+## Key Decisions
+
+- **Cycle detection in relationships** — `BibleService.saveRelationship` runs a BFS/DFS before persisting to prevent circular chains (A → B → A). This preserves graph integrity even though it's local-only
+- **Project scope enforcement** — every operation validates that the entity/relationship/link belongs to the current project, preventing cross-project data leaks
+- **`BiblePageController` as a single hook** — the bible page has 4 interactive columns; a single controller hook is cleaner than threading callbacks through 4 levels of components
+- **Separate storage key** — bible data is isolated from project data (`ainkwell:projects:{id}:bible:v1`) to keep individual localStorage entries small and avoid parsing the entire project on every bible operation

--- a/docs/plans/2026-02-28-tags-filtering.plan.md
+++ b/docs/plans/2026-02-28-tags-filtering.plan.md
@@ -1,0 +1,79 @@
+---
+name: Tags Filtering
+overview: Add multi-tag support to Bible entities — writers can tag characters/locations/etc. and filter the entity list by one or more tags.
+status: done
+merged: "2026-02-28"
+pr: 6
+todos:
+  - id: 1
+    content: "Add tags field to BibleEntity domain type (max 12 unique tags)"
+    status: done
+    dependencies: []
+  - id: 2
+    content: "Add listAllTags query and tag filtering to BibleRepository interface"
+    status: done
+    dependencies: [1]
+  - id: 3
+    content: "Implement tags persistence and filtering in LocalBibleRepository"
+    status: done
+    dependencies: [2]
+  - id: 4
+    content: "Update BibleService to expose listAllTags and pass tag filters"
+    status: done
+    dependencies: [3]
+  - id: 5
+    content: "Build TagsInput component for multi-tag entry in entity editor"
+    status: done
+    dependencies: []
+  - id: 6
+    content: "Build TagChip component for tag display"
+    status: done
+    dependencies: []
+  - id: 7
+    content: "Build TagFilterPanel for filtering entity list by tags"
+    status: done
+    dependencies: [6]
+  - id: 8
+    content: "Wire tag filtering into bible page controller, list, and editor"
+    status: done
+    dependencies: [4, 5, 7]
+  - id: 9
+    content: "Write tests for tag filtering in repository and page"
+    status: done
+    dependencies: [8]
+---
+
+# Tags Filtering — Retroactive Plan
+
+> This plan was written retroactively after the feature was merged (PR #6).
+
+**Goal:** Let writers label bible entities with tags (e.g. "protagonist", "chapter-1", "deceased") and filter the entity list by clicking tags.
+
+## Architecture
+
+`tags: string[]` added to `BibleEntity`. Max 12 unique tags per entity. Tags are lowercase strings, no spaces enforced at the UI level. `listAllTags(projectId)` returns all unique tags across entities for populating the filter panel.
+
+## Files Changed
+
+| Action | Path |
+|--------|------|
+| Modify | `src/domain/bible/types.ts` |
+| Modify | `src/domain/bible/repository.ts` |
+| Modify | `src/data/bible/local-bible-repository.ts` |
+| Modify | `src/application/bible/bible-service.ts` |
+| Create | `src/components/bible/tags-input.tsx` |
+| Create | `src/components/bible/tag-chip.tsx` |
+| Create | `src/components/bible/tag-filter-panel.tsx` |
+| Modify | `src/components/bible/bible-editor.tsx` |
+| Modify | `src/components/bible/bible-list.tsx` |
+| Modify | `src/components/bible/bible-page-client.tsx` |
+| Modify | `src/components/bible/bible-page-controller.ts` |
+| Modify | `src/test/bible/bible-page.test.tsx` |
+| Modify | `src/test/bible/local-bible-repository.test.ts` |
+
+## Key Decisions
+
+- Max 12 tags per entity to prevent abuse and keep the filter panel manageable
+- Tags stored as plain `string[]` in the entity — no separate tags collection
+- `TagFilterPanel` uses multi-select: clicking a tag toggles it, entity list shows entities that have ALL selected tags (AND logic)
+- `TagsInput` uses comma-separated entry with duplicate deduplication

--- a/docs/plans/2026-02-28-writing-goals-sessions.plan.md
+++ b/docs/plans/2026-02-28-writing-goals-sessions.plan.md
@@ -1,0 +1,93 @@
+---
+name: Writing Goals & Sessions
+overview: Track writing sessions with a live timer, set daily word count goals, visualize progress with streaks and a weekly chart, and integrate the session timer into the scene editor.
+status: done
+merged: "2026-02-28"
+pr: 7
+todos:
+  - id: 1
+    content: "Define WritingSession and DailyGoal domain types with Zod schemas"
+    status: done
+    dependencies: []
+  - id: 2
+    content: "Define WritingSessionRepository interface"
+    status: done
+    dependencies: [1]
+  - id: 3
+    content: "Implement LocalWritingSessionRepository persisting to localStorage"
+    status: done
+    dependencies: [2]
+  - id: 4
+    content: "Implement WritingSessionService with start/end session, goal, and dashboard logic"
+    status: done
+    dependencies: [3]
+  - id: 5
+    content: "Build useWritingSession hook with live timer and word delta tracking"
+    status: done
+    dependencies: [4]
+  - id: 6
+    content: "Build writing session UI components (timer, goal form, progress, chart, history)"
+    status: done
+    dependencies: [5]
+  - id: 7
+    content: "Add /workspace/[projectId]/goals page route"
+    status: done
+    dependencies: [6]
+  - id: 8
+    content: "Integrate session timer into scene editor shell"
+    status: done
+    dependencies: [5]
+  - id: 9
+    content: "Write tests for domain, service, repository, hook, and goals page"
+    status: done
+    dependencies: [7]
+---
+
+# Writing Goals & Sessions — Retroactive Plan
+
+> This plan was written retroactively after the feature was merged (PR #7).
+
+**Goal:** Writers can start/stop timed writing sessions, set a daily word count goal, and see their progress through streaks, a weekly chart, and session history — all persisted locally.
+
+## Architecture
+
+New vertical slice following the layered architecture:
+- `domain/writing-session/` — `WritingSession`, `DailyGoal`, `SessionsDashboard` types + `WritingSessionRepository` interface
+- `data/writing-session/local-writing-session-repository.ts` — localStorage at `ainkwell:projects:{id}:sessions:v1`
+- `application/writing-session/writing-session-service.ts` — business logic: streak calculation, weekly summary, dashboard aggregation
+- `hooks/use-writing-session.ts` + `use-writing-session-runtime.ts` — live timer with 1-second tick interval
+- `components/writing-session/` — UI components
+- `app/workspace/[projectId]/goals/page.tsx` — goals page
+
+## Files Changed
+
+| Action | Path |
+|--------|------|
+| Create | `src/domain/writing-session/` (types, repository interface) |
+| Create | `src/data/writing-session/local-writing-session-repository.ts` |
+| Create | `src/application/writing-session/writing-session-service.ts` |
+| Create | `src/hooks/use-writing-session.ts` |
+| Create | `src/hooks/use-writing-session-runtime.ts` |
+| Create | `src/components/writing-session/goals-page-client.tsx` |
+| Create | `src/components/writing-session/session-timer.tsx` |
+| Create | `src/components/writing-session/daily-goal-form.tsx` |
+| Create | `src/components/writing-session/daily-progress.tsx` |
+| Create | `src/components/writing-session/weekly-chart.tsx` |
+| Create | `src/components/writing-session/session-history.tsx` |
+| Create | `src/app/workspace/[projectId]/goals/page.tsx` |
+| Modify | `src/hooks/use-scene-editor.ts` |
+| Modify | `src/hooks/use-scene-editor-runtime.ts` |
+| Modify | `src/components/scene/scene-editor-shell.tsx` |
+| Modify | `src/app/workspace/[projectId]/page.tsx` |
+| Create | `src/test/writing-session/` (4 test files) |
+
+## Key Decisions
+
+- **Runtime refs isolation** (`use-writing-session-runtime.ts`): separates mutable refs (sessionId, intervalId, elapsed) from view state to prevent stale closure bugs in the tick interval — mirrors the pattern from `use-scene-editor-runtime.ts`
+- **Word delta tracking**: `onWordsSaved` callback added to `useSceneEditor`; when autosave fires, the word count delta is reported to the session hook
+- **Streak calculation**: consecutive days with at least 1 session, with gap detection — stored in `SessionsDashboard` returned by `WritingSessionService.getDashboard()`
+- **SSR safety**: repository uses a no-op storage fallback when `window` is undefined
+
+## Storage Key
+
+`ainkwell:projects:{projectId}:sessions:v1` — stores `{ sessions: WritingSession[], dailyGoal: number | null }`

--- a/docs/plans/2026-03-01-chapter-grouping.plan.md
+++ b/docs/plans/2026-03-01-chapter-grouping.plan.md
@@ -1,0 +1,99 @@
+---
+name: Chapter Grouping
+overview: Add a chapter layer between projects and scenes — writers can create chapters, assign scenes to chapters, reorder chapters, and move scenes between chapters.
+status: done
+merged: "2026-03-01"
+pr: 8
+todos:
+  - id: 1
+    content: "Add ProjectChapter domain type and embed chapters in WritingProject"
+    status: done
+    dependencies: []
+  - id: 2
+    content: "Add chapter CRUD and scene-move operations to ProjectRepository interface"
+    status: done
+    dependencies: [1]
+  - id: 3
+    content: "Implement chapter operations in LocalProjectRepository"
+    status: done
+    dependencies: [2]
+  - id: 4
+    content: "Create ChapterService in application layer"
+    status: done
+    dependencies: [3]
+  - id: 5
+    content: "Build ChapterForm component for creating chapters"
+    status: done
+    dependencies: []
+  - id: 6
+    content: "Build ChapterOutlinePanel with chapter/scene hierarchy, reorder, and move"
+    status: done
+    dependencies: [4, 5]
+  - id: 7
+    content: "Update project detail page to show chapter outline panel"
+    status: done
+    dependencies: [6]
+  - id: 8
+    content: "Wire writing session context across project layout via WritingSessionProvider"
+    status: done
+    dependencies: []
+  - id: 9
+    content: "Fix SSR crashes and stabilize useWritingSession hook deps"
+    status: done
+    dependencies: [8]
+---
+
+# Chapter Grouping — Retroactive Plan
+
+> This plan was written retroactively after the feature was merged (PR #8).
+
+**Goal:** Group scenes into chapters. Chapters are ordered within a project; scenes are ordered within a chapter. Writers can reorder chapters (up/down), move scenes between chapters, and see per-chapter word counts.
+
+## Architecture
+
+Chapters are embedded in `WritingProject` (no separate storage key):
+
+```ts
+type ProjectChapter = {
+  id: string;
+  projectId: string;
+  title: string;
+  sceneOrder: string[];   // ordered scene IDs
+  wordCount: number;      // derived, recalculated on mutation
+  createdAt: string;
+};
+
+type WritingProject = {
+  // ... existing fields
+  chapterOrder: string[];                      // ordered chapter IDs
+  chapters: Record<string, ProjectChapter>;
+};
+```
+
+New `ChapterService` in `src/application/project/chapter-service.ts` handles: `listChapters`, `createChapter`, `renameChapter`, `deleteChapter`, `reorderChapter`, `moveSceneToChapter`.
+
+## Files Changed
+
+| Action | Path |
+|--------|------|
+| Modify | `src/domain/project/project.ts` |
+| Modify | `src/domain/project/project-repository.ts` |
+| Modify | `src/data/project/local-project-repository.ts` |
+| Create | `src/application/project/chapter-service.ts` |
+| Create | `src/components/workspace/chapter-form.tsx` |
+| Create | `src/components/workspace/chapter-outline-panel.tsx` |
+| Modify | `src/app/workspace/[projectId]/page.tsx` |
+| Create | `src/app/workspace/[projectId]/layout.tsx` |
+| Create | `src/context/writing-session-context.tsx` |
+| Create | `src/components/writing-session/writing-session-provider-client.tsx` |
+| Modify | `src/hooks/use-writing-session.ts` |
+| Modify | `src/data/writing-session/local-writing-session-repository.ts` |
+| Modify | `src/components/scene/scene-editor-shell.tsx` |
+| Modify | `src/test/writing-session/use-writing-session.test.ts` |
+
+## Key Decisions
+
+- **Chapters embedded in project**: no new storage key, chapters live inside `ainkwell.projects.v1` alongside scenes. Keeps the data model simple and avoids cross-key consistency issues
+- **`chapterOrder` + `sceneOrder`**: explicit ordering arrays instead of sort fields — matches the existing `scenes` pattern and makes reordering O(1)
+- **`WritingSessionProvider` moved to layout**: the session context was previously instantiated per-page; moving it to `[projectId]/layout.tsx` makes it available across scene editor, goals page, and project detail without prop drilling
+- **SSR safety fixes**: `WritingSessionProvider` wrapped in a client-only dynamic import to prevent localStorage access during SSR; `useCallback` deps stabilized to prevent session auto-stop on re-render


### PR DESCRIPTION
## Summary

- Add retroactive `docs/plans/` entries for all 8 merged feature PRs (#1–#8)
- Plans document architecture decisions, files changed, key decisions, and domain design for each feature
- All todos marked `status: done` — these are historical records, not work items

## Plans Added

| Plan | PR | Feature |
|------|----|---------|
| `2026-02-25-oss-local-first-no-firebase.plan.md` | #1 | Drop Firebase, local-first baseline |
| `2026-02-27-project-workspace.plan.md` | #2 | Project CRUD, LocalProjectRepository, workspace UI |
| `2026-02-27-scene-editor-markdown.plan.md` | #3 | Markdown editor, 800ms autosave, useSceneEditor hook |
| `2026-02-28-story-bible.plan.md` | #4 | Entities, relationships (cycle detection), scene links |
| `2026-02-28-bible-dry-patterns.plan.md` | #5 | upsertRecord, resolveIdInList, withBibleAction refactors |
| `2026-02-28-tags-filtering.plan.md` | #6 | Multi-tag support and filtering for bible entities |
| `2026-02-28-writing-goals-sessions.plan.md` | #7 | Session timer, daily goals, streaks, weekly chart |
| `2026-03-01-chapter-grouping.plan.md` | #8 | Chapter layer with reorder and scene-move |

## Test plan

- [ ] Verify all 8 plan files are present in `docs/plans/`
- [ ] Verify no source code was modified (docs-only PR)