### PR TITLE
✨ feat: add JSON backup export/import and Markdown export

### DIFF
--- a/docs/plans/export-import.plan.md
+++ b/docs/plans/export-import.plan.md
@@ -1,0 +1,414 @@
+---
+name: Export & Import
+overview: Allow writers to export their projects as JSON (backup/restore) and as Markdown (portability), and import from JSON backup.
+todos:
+  - id: 1
+    content: "Define ExportService in application layer with exportProjectJson, importProjectJson, exportProjectMarkdown"
+    status: pending
+    dependencies: []
+  - id: 2
+    content: "Add exportProject/importProject methods to ProjectRepository interface"
+    status: pending
+    dependencies: []
+  - id: 3
+    content: "Implement export/import in LocalProjectRepository"
+    status: pending
+    dependencies: [1, 2]
+  - id: 4
+    content: "Build ExportImportPanel component"
+    status: pending
+    dependencies: [3]
+  - id: 5
+    content: "Integrate panel into workspace project detail page"
+    status: pending
+    dependencies: [4]
+  - id: 6
+    content: "Write tests for ExportService"
+    status: pending
+    dependencies: [1]
+---
+
+# Export & Import — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let writers download their project as a JSON backup or Markdown manuscript, and restore from a JSON file.
+
+**Architecture:** New `ExportService` in `src/application/export/`. Repository interface gets `exportProject` and `importProject`. UI panel added to project detail page. No new storage keys.
+
+**Tech Stack:** Next.js 15, TypeScript, Zod, localStorage, browser File API (download via `<a>` blob, upload via `<input type="file">`)
+
+---
+
+## Overview
+
+Writers using a local-first app need two safety nets:
+1. **JSON backup/restore** — full fidelity, includes scenes, chapters, bible, sessions
+2. **Markdown export** — human-readable, portable, chapters as headings + scene content
+
+Import validates the JSON with Zod before writing to storage to prevent corruption.
+
+---
+
+## Architecture / Data Model
+
+No new domain entities. New operations only.
+
+**Export format (JSON):**
+```ts
+{
+  version: 1,
+  exportedAt: ISO string,
+  project: WritingProject,          // from ainkwell.projects.v1
+  bible: BibleData,                 // from ainkwell:projects:{id}:bible:v1
+  sessions: WritingSessionData,     // from ainkwell:projects:{id}:sessions:v1
+}
+```
+
+**Markdown format:**
+```markdown
+# Project Title
+
+## Chapter 1: Chapter Name
+
+### Scene Title
+
+Scene content here...
+
+---
+
+### Scene Title 2
+
+...
+```
+
+---
+
+## Implementation Steps
+
+### Task 1: ProjectRepository interface — add export/import methods
+
+**Files:**
+- Modify: `src/domain/project/project-repository.ts`
+
+**Step 1: Read the file**
+Read `src/domain/project/project-repository.ts` to understand the current interface.
+
+**Step 2: Write the failing test**
+
+File: `src/test/export/export-service.test.ts`
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ExportService } from '@/application/export/export-service';
+import type { ProjectRepository } from '@/domain/project/project-repository';
+
+describe('ExportService', () => {
+  let mockRepository: ProjectRepository;
+
+  beforeEach(() => {
+    mockRepository = {
+      exportProject: vi.fn(),
+      importProject: vi.fn(),
+    } as unknown as ProjectRepository;
+  });
+
+  it('calls exportProject with project id', async () => {
+    vi.mocked(mockRepository.exportProject).mockResolvedValue({
+      version: 1,
+      exportedAt: '2026-01-01T00:00:00.000Z',
+      project: { id: 'p1', title: 'My Novel' } as any,
+      bible: null,
+      sessions: null,
+    });
+
+    const service = new ExportService(mockRepository);
+    const result = await service.exportProjectJson('p1');
+    expect(mockRepository.exportProject).toHaveBeenCalledWith('p1');
+    expect(result.project.id).toBe('p1');
+  });
+});
+```
+
+**Step 3: Run test — expect FAIL** (`ExportService` does not exist yet)
+```bash
+npx vitest run src/test/export/export-service.test.ts
+```
+
+**Step 4: Add ProjectExport type and methods to ProjectRepository interface**
+
+In `src/domain/project/project-repository.ts`, add:
+```ts
+export type ProjectExport = {
+  version: 1;
+  exportedAt: string;
+  project: WritingProject;
+  bible: unknown | null;
+  sessions: unknown | null;
+};
+
+// Add to ProjectRepository interface:
+exportProject(projectId: string): Promise<ProjectExport>;
+importProject(data: ProjectExport): Promise<void>;
+```
+
+**Step 5: Create ExportService**
+
+File: `src/application/export/export-service.ts`
+```ts
+import type { ProjectRepository, ProjectExport } from '@/domain/project/project-repository';
+import type { WritingProject } from '@/domain/project/project';
+
+export class ExportService {
+  constructor(private readonly repository: ProjectRepository) {}
+
+  async exportProjectJson(projectId: string): Promise<ProjectExport> {
+    return this.repository.exportProject(projectId);
+  }
+
+  async importProjectJson(data: ProjectExport): Promise<void> {
+    return this.repository.importProject(data);
+  }
+
+  async exportProjectMarkdown(projectId: string): Promise<string> {
+    const exported = await this.repository.exportProject(projectId);
+    return buildMarkdown(exported.project);
+  }
+}
+
+function buildMarkdown(project: WritingProject): string {
+  const lines: string[] = [`# ${project.title}`, ''];
+
+  for (const chapterId of project.chapterOrder) {
+    const chapter = project.chapters[chapterId];
+    if (!chapter) continue;
+    lines.push(`## ${chapter.title}`, '');
+
+    for (const sceneId of chapter.sceneOrder) {
+      const scene = project.scenes[sceneId];
+      if (!scene) continue;
+      lines.push(`### ${scene.title}`, '', scene.content.trim(), '', '---', '');
+    }
+  }
+
+  return lines.join('\n');
+}
+```
+
+**Step 6: Run test — expect PASS**
+```bash
+npx vitest run src/test/export/export-service.test.ts
+```
+
+**Step 7: Commit**
+```bash
+git add src/domain/project/project-repository.ts src/application/export/export-service.ts src/test/export/export-service.test.ts
+git commit -m "✨ feat: add ExportService and ProjectExport type to domain"
+```
+
+---
+
+### Task 2: Implement export/import in LocalProjectRepository
+
+**Files:**
+- Modify: `src/data/project/local-project-repository.ts`
+
+**Step 1: Read current implementation**
+Read `src/data/project/local-project-repository.ts`.
+
+**Step 2: Add exportProject implementation**
+
+```ts
+async exportProject(projectId: string): Promise<ProjectExport> {
+  const projects = this.readProjects();
+  const project = projects[projectId];
+  if (!project) throw new Error(`Project ${projectId} not found`);
+
+  const bibleKey = `ainkwell:projects:${projectId}:bible:v1`;
+  const sessionsKey = `ainkwell:projects:${projectId}:sessions:v1`;
+
+  const bibleRaw = this.storage.getItem(bibleKey);
+  const sessionsRaw = this.storage.getItem(sessionsKey);
+
+  return {
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    project,
+    bible: bibleRaw ? JSON.parse(bibleRaw) : null,
+    sessions: sessionsRaw ? JSON.parse(sessionsRaw) : null,
+  };
+}
+
+async importProject(data: ProjectExport): Promise<void> {
+  const parsed = projectExportSchema.parse(data);
+  const projects = this.readProjects();
+
+  const newId = crypto.randomUUID();
+  const importedProject = {
+    ...parsed.project,
+    id: newId,
+    title: `${parsed.project.title} (imported)`,
+  };
+
+  projects[newId] = importedProject;
+  this.writeProjects(projects);
+
+  if (parsed.bible) {
+    this.storage.setItem(`ainkwell:projects:${newId}:bible:v1`, JSON.stringify(parsed.bible));
+  }
+  if (parsed.sessions) {
+    this.storage.setItem(`ainkwell:projects:${newId}:sessions:v1`, JSON.stringify(parsed.sessions));
+  }
+}
+```
+
+Add Zod validation schema in domain:
+```ts
+export const projectExportSchema = z.object({
+  version: z.literal(1),
+  exportedAt: z.string(),
+  project: writingProjectSchema,
+  bible: z.unknown().nullable(),
+  sessions: z.unknown().nullable(),
+});
+```
+
+**Step 3: Run full tests**
+```bash
+npm run test:ci
+```
+
+**Step 4: Commit**
+```bash
+git add src/data/project/local-project-repository.ts src/domain/project/project-repository.ts
+git commit -m "✨ feat: implement exportProject and importProject in LocalProjectRepository"
+```
+
+---
+
+### Task 3: Build ExportImportPanel component
+
+**Files:**
+- Create: `src/components/workspace/export-import-panel.tsx`
+- Modify: `src/app/workspace/[projectId]/page.tsx`
+
+**Step 1: Read the project detail page**
+Read `src/app/workspace/[projectId]/page.tsx` to find where to add the panel.
+
+**Step 2: Write the component**
+
+```tsx
+'use client';
+import { useRef, useState } from 'react';
+import type { ReactElement } from 'react';
+import { ExportService } from '@/application/export/export-service';
+import { LocalProjectRepository } from '@/data/project/local-project-repository';
+import type { ProjectExport } from '@/domain/project/project-repository';
+
+type Props = { projectId: string; projectTitle: string };
+
+export function ExportImportPanel({ projectId, projectTitle }: Props): ReactElement {
+  const [importing, setImporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const service = new ExportService(new LocalProjectRepository());
+
+  async function handleExportJson(): Promise<void> {
+    const data = await service.exportProjectJson(projectId);
+    downloadFile(JSON.stringify(data, null, 2), `${slugify(projectTitle)}-backup.json`, 'application/json');
+  }
+
+  async function handleExportMarkdown(): Promise<void> {
+    const markdown = await service.exportProjectMarkdown(projectId);
+    downloadFile(markdown, `${slugify(projectTitle)}.md`, 'text/markdown');
+  }
+
+  async function handleImport(event: React.ChangeEvent<HTMLInputElement>): Promise<void> {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    setImporting(true);
+    setError(null);
+    try {
+      const text = await file.text();
+      const data: ProjectExport = JSON.parse(text);
+      await service.importProjectJson(data);
+      window.location.reload();
+    } catch {
+      setError('Invalid backup file. Make sure it is a valid Ainkwell JSON export.');
+    } finally {
+      setImporting(false);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm font-medium text-foreground">Export & Import</p>
+      <div className="flex flex-wrap gap-2">
+        <button className="rounded border border-border px-3 py-1.5 text-xs hover:bg-muted" onClick={handleExportJson} type="button">
+          Export JSON backup
+        </button>
+        <button className="rounded border border-border px-3 py-1.5 text-xs hover:bg-muted" onClick={handleExportMarkdown} type="button">
+          Export Markdown
+        </button>
+        <button className="rounded border border-border px-3 py-1.5 text-xs hover:bg-muted" onClick={() => fileInputRef.current?.click()} type="button">
+          {importing ? 'Importing…' : 'Import JSON backup'}
+        </button>
+        <input accept=".json" className="hidden" onChange={handleImport} ref={fileInputRef} type="file" />
+      </div>
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}
+
+function downloadFile(content: string, filename: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+function slugify(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+```
+
+**Step 3: Add to project detail page**
+Import and place `<ExportImportPanel projectId={projectId} projectTitle={project.title} />` below the project stats section.
+
+**Step 4: Run tests**
+```bash
+npm run test:ci
+```
+
+**Step 5: Commit**
+```bash
+git add src/components/workspace/export-import-panel.tsx src/app/workspace/[projectId]/page.tsx
+git commit -m "✨ feat: add ExportImportPanel to project detail page"
+```
+
+---
+
+## Files Summary
+
+| Action | Path |
+|--------|------|
+| Modify | `src/domain/project/project-repository.ts` |
+| Create | `src/application/export/export-service.ts` |
+| Modify | `src/data/project/local-project-repository.ts` |
+| Create | `src/components/workspace/export-import-panel.tsx` |
+| Modify | `src/app/workspace/[projectId]/page.tsx` |
+| Create | `src/test/export/export-service.test.ts` |
+
+---
+
+## Testing
+
+- Unit: `ExportService.exportProjectJson` calls repository correctly
+- Unit: `ExportService.exportProjectMarkdown` produces correct Markdown structure
+- Unit: `importProject` validates schema and rejects invalid data
+- Manual: export JSON, clear project, import JSON, verify data restored
+- Manual: export Markdown, verify chapter/scene structure

--- a/docs/test-fixtures/invalid-import.json
+++ b/docs/test-fixtures/invalid-import.json
@@ -1,0 +1,8 @@
+{
+  "version": 2,
+  "exportedAt": "2026-03-01T10:00:00.000Z",
+  "project": {
+    "title": "Fichier corrompu",
+    "scenes": "pas un objet"
+  }
+}

--- a/docs/test-fixtures/valid-import.json
+++ b/docs/test-fixtures/valid-import.json
@@ -1,0 +1,84 @@
+{
+  "version": 1,
+  "exportedAt": "2026-03-01T10:00:00.000Z",
+  "project": {
+    "id": "550e8400-e29b-4d4a-a716-446655440000",
+    "title": "Les Ombres de Valcourt",
+    "description": "Un roman policier historique se déroulant dans la France du XIXe siècle.",
+    "createdAt": "2026-01-15T08:00:00.000Z",
+    "updatedAt": "2026-02-28T18:30:00.000Z",
+    "stats": {
+      "wordCount": 1247,
+      "sceneCount": 4,
+      "chapterCount": 2
+    },
+    "settings": {
+      "language": "fr",
+      "targetWordCount": 80000
+    },
+    "chapterOrder": [
+      "chap-0001-0000-0000-000000000001",
+      "chap-0002-0000-0000-000000000002"
+    ],
+    "chapters": {
+      "chap-0001-0000-0000-000000000001": {
+        "id": "chap-0001-0000-0000-000000000001",
+        "projectId": "550e8400-e29b-4d4a-a716-446655440000",
+        "title": "L'Arrivée à Valcourt",
+        "sceneOrder": [
+          "scen-0001-0000-0000-000000000001",
+          "scen-0002-0000-0000-000000000002"
+        ],
+        "wordCount": 723,
+        "createdAt": "2026-01-15T08:00:00.000Z"
+      },
+      "chap-0002-0000-0000-000000000002": {
+        "id": "chap-0002-0000-0000-000000000002",
+        "projectId": "550e8400-e29b-4d4a-a716-446655440000",
+        "title": "Le Manoir Maudit",
+        "sceneOrder": [
+          "scen-0003-0000-0000-000000000003",
+          "scen-0004-0000-0000-000000000004"
+        ],
+        "wordCount": 524,
+        "createdAt": "2026-01-20T09:00:00.000Z"
+      }
+    },
+    "scenes": {
+      "scen-0001-0000-0000-000000000001": {
+        "id": "scen-0001-0000-0000-000000000001",
+        "projectId": "550e8400-e29b-4d4a-a716-446655440000",
+        "title": "La diligence",
+        "content": "La diligence cahota sur les pavés disjoints à l'entrée de Valcourt. Inspecteur Renaud écarta le rideau de cuir usé et observa la place du marché, déserte à cette heure matinale. Une brume grise s'accrochait aux toits d'ardoise, effaçant les contours des maisons comme une mauvaise conscience.\n\n— Valcourt, annonça le cocher depuis son perchoir. Terminus.\n\nRenaud descendit le premier, sa mallette de cuir noir sous le bras. Il n'était pas venu dans ce bourg depuis l'affaire Moreau, dix ans plus tôt. Rien n'avait changé, ou presque. La fontaine au centre de la place crachait toujours son filet d'eau rouillée. L'enseigne de l'auberge du Cerf d'Or se balançait dans le vent d'est.",
+        "status": "final",
+        "updatedAt": "2026-02-10T14:00:00.000Z"
+      },
+      "scen-0002-0000-0000-000000000002": {
+        "id": "scen-0002-0000-0000-000000000002",
+        "projectId": "550e8400-e29b-4d4a-a716-446655440000",
+        "title": "L'auberge du Cerf d'Or",
+        "content": "L'aubergiste, un homme trapu aux favoris poivre et sel, posa ses deux poings sur le comptoir de chêne.\n\n— On n'a pas eu de visiteurs depuis la mort du comte, dit-il à voix basse, comme si les murs pouvaient entendre.\n\nRenaud commanda un verre de cidre et attendit. Il avait appris depuis longtemps que le silence était souvent plus efficace qu'une question. L'aubergiste finit par remplir le verre, les yeux baissés.\n\n— Le château est fermé. Madame la comtesse refuse de recevoir quiconque. Ils disent qu'elle est folle de chagrin. Moi je dis qu'elle a peur.\n\n— Peur de quoi ?\n\nL'homme haussa les épaules et s'éloigna vers l'autre bout du bar, soudainement passionné par le polissage de ses chopes en étain.",
+        "status": "revise",
+        "updatedAt": "2026-02-15T16:30:00.000Z"
+      },
+      "scen-0003-0000-0000-000000000003": {
+        "id": "scen-0003-0000-0000-000000000003",
+        "projectId": "550e8400-e29b-4d4a-a716-446655440000",
+        "title": "Les grilles du château",
+        "content": "Le château de Valcourt se dressait au sommet de la colline boisée, ses tourelles pointant vers un ciel couleur d'ardoise. Renaud avait marché une heure depuis le bourg, suivant un chemin de terre que les pluies de février avaient transformé en ruisseau de boue.\n\nLes grilles en fer forgé étaient cadenassées. Rouillées, aussi, sauf là où quelqu'un les avait frottées récemment — les barreaux du bas brillaient d'un éclat suspect. Renaud s'accroupit et examina la terre à ses pieds. Des empreintes de bottes, larges, profondes. Plusieurs passages, dans les deux sens.",
+        "status": "draft",
+        "updatedAt": "2026-02-20T11:00:00.000Z"
+      },
+      "scen-0004-0000-0000-000000000004": {
+        "id": "scen-0004-0000-0000-000000000004",
+        "projectId": "550e8400-e29b-4d4a-a716-446655440000",
+        "title": "La comtesse",
+        "content": "Elle l'attendait dans le grand salon, assise dans un fauteuil face à la cheminée éteinte. Une femme d'une cinquantaine d'années, le dos droit malgré tout, les mains croisées sur les genoux dans une attitude qui ressemblait à de la dignité mais que Renaud reconnut pour ce qu'elle était : de la terreur maîtrisée.\n\n— Inspecteur, dit-elle sans se retourner. Je savais qu'on vous enverrait.\n\n— Madame la comtesse. Mon supérieur pense que la mort de votre mari mérite qu'on y regarde de plus près.\n\nUn silence. Le bois craqua quelque part dans la maison. Elle ne bougea pas.\n\n— Mon mari est tombé dans l'escalier. C'est un accident. Il n'y a rien à examiner.",
+        "status": "draft",
+        "updatedAt": "2026-02-28T18:30:00.000Z"
+      }
+    }
+  },
+  "bible": null,
+  "sessions": null
+}

--- a/src/app/workspace/[projectId]/page.tsx
+++ b/src/app/workspace/[projectId]/page.tsx
@@ -11,6 +11,7 @@ import type { ProjectService } from '@/application/project/project-service';
 import { SceneEditorService } from '@/application/scene/scene-editor-service';
 import { ChapterOutlinePanel } from '@/components/workspace/chapter-outline-panel';
 import { ChapterForm } from '@/components/workspace/chapter-form';
+import { ExportImportPanel } from '@/components/workspace/export-import-panel';
 import { LocalProjectRepository } from '@/data/project/local-project-repository';
 import { projectIdSchema } from '@/domain/project/schemas';
 import type { ChapterSummary, WritingProject } from '@/domain/project/types';
@@ -453,6 +454,7 @@ function ProjectDetailView({
       <ChaptersSection projectId={projectId} project={project} chapterActions={chapterActions} />
       <ProjectStoryBibleSection projectId={projectId} />
       <ProjectWritingGoalsSection projectId={projectId} />
+      <ExportImportPanel projectId={projectId} projectTitle={project.title} />
       <Link className="text-sm font-medium text-primary underline" href="/workspace">
         Back to workspace
       </Link>

--- a/src/app/workspace/[projectId]/page.tsx
+++ b/src/app/workspace/[projectId]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'next/navigation';
 import type { Dispatch, ReactElement, SetStateAction } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { ExportService } from '@/application/export/export-service';
 import { createChapterService } from '@/application/project/chapter-service';
 import { createProjectService } from '@/application/project/project-service';
 import type { ProjectService } from '@/application/project/project-service';
@@ -435,10 +436,12 @@ function ProjectDetailView({
   project,
   projectId,
   chapterActions,
+  exportService,
 }: {
   project: WritingProject;
   projectId: string;
   chapterActions: ChapterActions;
+  exportService: ExportService;
 }): ReactElement {
   return (
     <main className="mx-auto flex min-h-screen w-full max-w-4xl flex-col gap-6 px-4 py-10">
@@ -454,7 +457,7 @@ function ProjectDetailView({
       <ChaptersSection projectId={projectId} project={project} chapterActions={chapterActions} />
       <ProjectStoryBibleSection projectId={projectId} />
       <ProjectWritingGoalsSection projectId={projectId} />
-      <ExportImportPanel projectId={projectId} projectTitle={project.title} />
+      <ExportImportPanel exportService={exportService} projectId={projectId} projectTitle={project.title} />
       <Link className="text-sm font-medium text-primary underline" href="/workspace">
         Back to workspace
       </Link>
@@ -466,10 +469,12 @@ function ProjectPageState({
   projectId,
   detail,
   chapterActions,
+  exportService,
 }: {
   projectId: string | null;
   detail: ProjectDetailResult;
   chapterActions: ChapterActions;
+  exportService: ExportService;
 }): ReactElement {
   if (!projectId) {
     return renderInvalidProjectIdState();
@@ -496,6 +501,7 @@ function ProjectPageState({
       project={detail.project}
       projectId={projectId}
       chapterActions={chapterActions}
+      exportService={exportService}
     />
   );
 }
@@ -548,6 +554,7 @@ export default function WorkspaceProjectPage(): ReactElement {
   const projectId = useProjectIdParam();
   const repository = useMemo(() => new LocalProjectRepository(), []);
   const projectService = useMemo(() => createProjectService(repository), [repository]);
+  const exportService = useMemo(() => new ExportService(repository), [repository]);
 
   const detail = useProjectDetail(projectId, projectService);
   const chapterActions = useChapterActions(projectId, detail.project, repository, detail.reload);
@@ -557,6 +564,7 @@ export default function WorkspaceProjectPage(): ReactElement {
       projectId={projectId}
       detail={detail}
       chapterActions={chapterActions}
+      exportService={exportService}
     />
   );
 }

--- a/src/app/workspace/page.tsx
+++ b/src/app/workspace/page.tsx
@@ -205,6 +205,9 @@ export default function WorkspacePage(): ReactElement {
         workspaceState.setEditingProjectId(null);
       }}
       onCreateProject={workspaceState.createProject}
+      onImportProject={() => {
+        void loadProjects();
+      }}
       onDeleteProject={(projectId: string) => {
         void workspaceState.deleteProject(projectId);
       }}

--- a/src/application/export/export-service.ts
+++ b/src/application/export/export-service.ts
@@ -1,0 +1,37 @@
+import type { ProjectRepository } from '@/domain/project/repository';
+import type { ProjectExport, WritingProject } from '@/domain/project/types';
+
+export class ExportService {
+  constructor(private readonly repository: ProjectRepository) {}
+
+  async exportProjectJson(projectId: string): Promise<ProjectExport> {
+    return this.repository.exportProject(projectId);
+  }
+
+  async importProjectJson(data: ProjectExport): Promise<void> {
+    return this.repository.importProject(data);
+  }
+
+  async exportProjectMarkdown(projectId: string): Promise<string> {
+    const exported = await this.repository.exportProject(projectId);
+    return buildMarkdown(exported.project);
+  }
+}
+
+function buildMarkdown(project: WritingProject): string {
+  const lines: string[] = [`# ${project.title}`, ''];
+
+  for (const chapterId of project.chapterOrder) {
+    const chapter = project.chapters[chapterId];
+    if (!chapter) continue;
+    lines.push(`## ${chapter.title}`, '');
+
+    for (const sceneId of chapter.sceneOrder) {
+      const scene = project.scenes[sceneId];
+      if (!scene) continue;
+      lines.push(`### ${scene.title}`, '', scene.content.trim(), '', '---', '');
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/src/application/export/export-service.ts
+++ b/src/application/export/export-service.ts
@@ -1,19 +1,23 @@
 import type { ProjectRepository } from '@/domain/project/repository';
+import { projectExportSchema, projectIdSchema } from '@/domain/project/schemas';
 import type { ProjectExport, WritingProject } from '@/domain/project/types';
 
 export class ExportService {
   constructor(private readonly repository: ProjectRepository) {}
 
   async exportProjectJson(projectId: string): Promise<ProjectExport> {
-    return this.repository.exportProject(projectId);
+    const validProjectId = projectIdSchema.parse(projectId);
+    return this.repository.exportProject(validProjectId);
   }
 
   async importProjectJson(data: ProjectExport): Promise<void> {
+    projectExportSchema.parse(data);
     return this.repository.importProject(data);
   }
 
   async exportProjectMarkdown(projectId: string): Promise<string> {
-    const exported = await this.repository.exportProject(projectId);
+    const validProjectId = projectIdSchema.parse(projectId);
+    const exported = await this.repository.exportProject(validProjectId);
     return buildMarkdown(exported.project);
   }
 }

--- a/src/components/workspace/export-import-panel.tsx
+++ b/src/components/workspace/export-import-panel.tsx
@@ -1,0 +1,92 @@
+'use client';
+import { useRef, useState } from 'react';
+import type { ReactElement } from 'react';
+
+import { ExportService } from '@/application/export/export-service';
+import { LocalProjectRepository } from '@/data/project/local-project-repository';
+import type { ProjectExport } from '@/domain/project/types';
+
+type Props = { projectId: string; projectTitle: string };
+
+export function ExportImportPanel({ projectId, projectTitle }: Props): ReactElement {
+  const [importing, setImporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const service = new ExportService(new LocalProjectRepository());
+
+  async function handleExportJson(): Promise<void> {
+    const data = await service.exportProjectJson(projectId);
+    downloadFile(JSON.stringify(data, null, 2), `${slugify(projectTitle)}-backup.json`, 'application/json');
+  }
+
+  async function handleExportMarkdown(): Promise<void> {
+    const markdown = await service.exportProjectMarkdown(projectId);
+    downloadFile(markdown, `${slugify(projectTitle)}.md`, 'text/markdown');
+  }
+
+  async function handleImport(event: React.ChangeEvent<HTMLInputElement>): Promise<void> {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    setImporting(true);
+    setError(null);
+    try {
+      const text = await file.text();
+      const data: ProjectExport = JSON.parse(text);
+      await service.importProjectJson(data);
+      window.location.reload();
+    } catch {
+      setError('Invalid backup file. Make sure it is a valid Ainkwell JSON export.');
+    } finally {
+      setImporting(false);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    }
+  }
+
+  return (
+    <section className="rounded-lg border p-4 space-y-3">
+      <h2 className="text-2xl font-headline font-semibold">Export & Import</h2>
+      <p className="text-sm text-muted-foreground">
+        Download a full JSON backup or a Markdown manuscript, or restore a project from a previous backup.
+      </p>
+      <div className="flex flex-wrap gap-2">
+        <button
+          className="rounded border border-border px-3 py-1.5 text-xs hover:bg-muted"
+          onClick={handleExportJson}
+          type="button"
+        >
+          Export JSON backup
+        </button>
+        <button
+          className="rounded border border-border px-3 py-1.5 text-xs hover:bg-muted"
+          onClick={handleExportMarkdown}
+          type="button"
+        >
+          Export Markdown
+        </button>
+        <button
+          className="rounded border border-border px-3 py-1.5 text-xs hover:bg-muted"
+          onClick={() => fileInputRef.current?.click()}
+          type="button"
+        >
+          {importing ? 'Importing…' : 'Import JSON backup'}
+        </button>
+        <input accept=".json" className="hidden" onChange={handleImport} ref={fileInputRef} type="file" />
+      </div>
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </section>
+  );
+}
+
+function downloadFile(content: string, filename: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+function slugify(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}

--- a/src/components/workspace/export-import-panel.tsx
+++ b/src/components/workspace/export-import-panel.tsx
@@ -1,17 +1,12 @@
 'use client';
-import { useRef, useState } from 'react';
 import type { ReactElement } from 'react';
 
 import { ExportService } from '@/application/export/export-service';
 import { LocalProjectRepository } from '@/data/project/local-project-repository';
-import type { ProjectExport } from '@/domain/project/types';
 
 type Props = { projectId: string; projectTitle: string };
 
 export function ExportImportPanel({ projectId, projectTitle }: Props): ReactElement {
-  const [importing, setImporting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const service = new ExportService(new LocalProjectRepository());
 
   async function handleExportJson(): Promise<void> {
@@ -24,29 +19,11 @@ export function ExportImportPanel({ projectId, projectTitle }: Props): ReactElem
     downloadFile(markdown, `${slugify(projectTitle)}.md`, 'text/markdown');
   }
 
-  async function handleImport(event: React.ChangeEvent<HTMLInputElement>): Promise<void> {
-    const file = event.target.files?.[0];
-    if (!file) return;
-    setImporting(true);
-    setError(null);
-    try {
-      const text = await file.text();
-      const data: ProjectExport = JSON.parse(text);
-      await service.importProjectJson(data);
-      window.location.reload();
-    } catch {
-      setError('Invalid backup file. Make sure it is a valid Ainkwell JSON export.');
-    } finally {
-      setImporting(false);
-      if (fileInputRef.current) fileInputRef.current.value = '';
-    }
-  }
-
   return (
     <section className="rounded-lg border p-4 space-y-3">
-      <h2 className="text-2xl font-headline font-semibold">Export & Import</h2>
+      <h2 className="text-2xl font-headline font-semibold">Export</h2>
       <p className="text-sm text-muted-foreground">
-        Download a full JSON backup or a Markdown manuscript, or restore a project from a previous backup.
+        Download a full JSON backup or a Markdown manuscript of this project.
       </p>
       <div className="flex flex-wrap gap-2">
         <button
@@ -63,16 +40,7 @@ export function ExportImportPanel({ projectId, projectTitle }: Props): ReactElem
         >
           Export Markdown
         </button>
-        <button
-          className="rounded border border-border px-3 py-1.5 text-xs hover:bg-muted"
-          onClick={() => fileInputRef.current?.click()}
-          type="button"
-        >
-          {importing ? 'Importing…' : 'Import JSON backup'}
-        </button>
-        <input accept=".json" className="hidden" onChange={handleImport} ref={fileInputRef} type="file" />
       </div>
-      {error && <p className="text-xs text-destructive">{error}</p>}
     </section>
   );
 }

--- a/src/components/workspace/export-import-panel.tsx
+++ b/src/components/workspace/export-import-panel.tsx
@@ -1,22 +1,32 @@
 'use client';
+import { useState } from 'react';
 import type { ReactElement } from 'react';
 
-import { ExportService } from '@/application/export/export-service';
-import { LocalProjectRepository } from '@/data/project/local-project-repository';
+import type { ExportService } from '@/application/export/export-service';
 
-type Props = { projectId: string; projectTitle: string };
+type Props = { exportService: ExportService; projectId: string; projectTitle: string };
 
-export function ExportImportPanel({ projectId, projectTitle }: Props): ReactElement {
-  const service = new ExportService(new LocalProjectRepository());
+export function ExportImportPanel({ exportService, projectId, projectTitle }: Props): ReactElement {
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   async function handleExportJson(): Promise<void> {
-    const data = await service.exportProjectJson(projectId);
-    downloadFile(JSON.stringify(data, null, 2), `${slugify(projectTitle)}-backup.json`, 'application/json');
+    setErrorMessage(null);
+    try {
+      const data = await exportService.exportProjectJson(projectId);
+      downloadFile(JSON.stringify(data, null, 2), `${slugify(projectTitle)}-backup.json`, 'application/json');
+    } catch {
+      setErrorMessage('Unable to export JSON backup.');
+    }
   }
 
   async function handleExportMarkdown(): Promise<void> {
-    const markdown = await service.exportProjectMarkdown(projectId);
-    downloadFile(markdown, `${slugify(projectTitle)}.md`, 'text/markdown');
+    setErrorMessage(null);
+    try {
+      const markdown = await exportService.exportProjectMarkdown(projectId);
+      downloadFile(markdown, `${slugify(projectTitle)}.md`, 'text/markdown');
+    } catch {
+      setErrorMessage('Unable to export Markdown.');
+    }
   }
 
   return (
@@ -41,6 +51,11 @@ export function ExportImportPanel({ projectId, projectTitle }: Props): ReactElem
           Export Markdown
         </button>
       </div>
+      {errorMessage ? (
+        <p aria-live="polite" className="text-xs text-destructive" role="alert">
+          {errorMessage}
+        </p>
+      ) : null}
     </section>
   );
 }

--- a/src/components/workspace/workspace-page-content.tsx
+++ b/src/components/workspace/workspace-page-content.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useRef, useState } from 'react';
+import { type ChangeEvent, useRef, useState } from 'react';
 import type { ReactElement } from 'react';
 
 import { ExportService } from '@/application/export/export-service';
@@ -30,7 +30,7 @@ function ImportProjectButton({ onSuccess }: { onSuccess: () => void }): ReactEle
   const fileInputRef = useRef<HTMLInputElement>(null);
   const service = new ExportService(new LocalProjectRepository());
 
-  async function handleImport(event: React.ChangeEvent<HTMLInputElement>): Promise<void> {
+  async function handleImport(event: ChangeEvent<HTMLInputElement>): Promise<void> {
     const file = event.target.files?.[0];
     if (!file) return;
     setImporting(true);
@@ -40,7 +40,8 @@ function ImportProjectButton({ onSuccess }: { onSuccess: () => void }): ReactEle
       const data: ProjectExport = JSON.parse(text);
       await service.importProjectJson(data);
       onSuccess();
-    } catch {
+    } catch (error: unknown) {
+      console.error('Project import failed.', error);
       setError('Invalid backup file. Make sure it is a valid Ainkwell JSON export.');
     } finally {
       setImporting(false);
@@ -58,7 +59,11 @@ function ImportProjectButton({ onSuccess }: { onSuccess: () => void }): ReactEle
         {importing ? 'Importing…' : 'Import JSON backup'}
       </button>
       <input accept=".json" className="hidden" onChange={handleImport} ref={fileInputRef} type="file" />
-      {error && <p className="text-xs text-destructive">{error}</p>}
+      {error ? (
+        <p aria-live="polite" className="text-xs text-destructive" role="alert">
+          {error}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/src/components/workspace/workspace-page-content.tsx
+++ b/src/components/workspace/workspace-page-content.tsx
@@ -1,4 +1,10 @@
+'use client';
+import { useRef, useState } from 'react';
 import type { ReactElement } from 'react';
+
+import { ExportService } from '@/application/export/export-service';
+import { LocalProjectRepository } from '@/data/project/local-project-repository';
+import type { ProjectExport } from '@/domain/project/types';
 import { ProjectCard } from '@/components/workspace/project-card';
 import { ProjectForm, type ProjectFormValues } from '@/components/workspace/project-form';
 import type { WritingProject } from '@/domain/project/types';
@@ -11,11 +17,51 @@ type WorkspacePageContentProps = {
   submitting: boolean;
   onRetry: () => void;
   onCreateProject: (values: ProjectFormValues) => Promise<void>;
+  onImportProject: () => void;
   onEditProject: (projectId: string) => void;
   onCancelEdit: () => void;
   onUpdateProject: (projectId: string, values: ProjectFormValues) => Promise<void>;
   onDeleteProject: (projectId: string) => void;
 };
+
+function ImportProjectButton({ onSuccess }: { onSuccess: () => void }): ReactElement {
+  const [importing, setImporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const service = new ExportService(new LocalProjectRepository());
+
+  async function handleImport(event: React.ChangeEvent<HTMLInputElement>): Promise<void> {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    setImporting(true);
+    setError(null);
+    try {
+      const text = await file.text();
+      const data: ProjectExport = JSON.parse(text);
+      await service.importProjectJson(data);
+      onSuccess();
+    } catch {
+      setError('Invalid backup file. Make sure it is a valid Ainkwell JSON export.');
+    } finally {
+      setImporting(false);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    }
+  }
+
+  return (
+    <div className="space-y-1">
+      <button
+        className="rounded border border-border px-3 py-1.5 text-xs hover:bg-muted"
+        onClick={() => fileInputRef.current?.click()}
+        type="button"
+      >
+        {importing ? 'Importing…' : 'Import JSON backup'}
+      </button>
+      <input accept=".json" className="hidden" onChange={handleImport} ref={fileInputRef} type="file" />
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}
 
 function WorkspaceHeader(): ReactElement {
   return (
@@ -141,7 +187,7 @@ function WorkspaceProjectList({
   onCancelEdit,
   onUpdateProject,
   onDeleteProject,
-}: Omit<WorkspacePageContentProps, 'errorMessage' | 'onRetry' | 'onCreateProject'>): ReactElement {
+}: Omit<WorkspacePageContentProps, 'errorMessage' | 'onRetry' | 'onCreateProject' | 'onImportProject'>): ReactElement {
   if (loading) {
     return <p data-testid="workspace-loading">Loading projects...</p>;
   }
@@ -175,6 +221,7 @@ export function WorkspacePageContent({
   submitting,
   onRetry,
   onCreateProject,
+  onImportProject,
   onEditProject,
   onCancelEdit,
   onUpdateProject,
@@ -186,7 +233,10 @@ export function WorkspacePageContent({
       {errorMessage ? <WorkspaceErrorBanner errorMessage={errorMessage} onRetry={onRetry} /> : null}
       <ProjectForm isSubmitting={submitting} mode="create" onSubmit={onCreateProject} />
       <section className="space-y-3">
-        <h2 className="text-2xl font-headline font-semibold">Projects</h2>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h2 className="text-2xl font-headline font-semibold">Projects</h2>
+          <ImportProjectButton onSuccess={onImportProject} />
+        </div>
         <WorkspaceProjectList
           editingProjectId={editingProjectId}
           loading={loading}

--- a/src/data/project/local-project-repository.ts
+++ b/src/data/project/local-project-repository.ts
@@ -486,7 +486,7 @@ export class LocalProjectRepository implements ProjectRepository {
       throw new Error(browserOnlyRepositoryMessage);
     }
 
-    const newId = crypto.randomUUID();
+    const newId = generateProjectId();
     const importedProject = writingProjectSchema.parse({
       ...parsed.project,
       id: newId,

--- a/src/data/project/local-project-repository.ts
+++ b/src/data/project/local-project-repository.ts
@@ -21,8 +21,10 @@ import type {
   UpdateProjectInput,
   WritingProject,
 } from '@/domain/project/types';
+import { bibleStorageSchema } from '@/domain/bible/schemas';
 import { saveSceneInputSchema, sceneSchema, sceneSummarySchema } from '@/domain/scene/schemas';
 import type { Scene, SceneSummary } from '@/domain/scene/types';
+import { projectSessionDataSchema } from '@/domain/writing-session/schemas';
 import { generateProjectId } from '@/lib/utils';
 
 import {
@@ -458,16 +460,17 @@ export class LocalProjectRepository implements ProjectRepository {
   }
 
   public async exportProject(projectId: string): Promise<ProjectExport> {
+    const validProjectId = projectIdSchema.parse(projectId);
     const storage = getStorage();
     const projects = this.readProjects();
-    const project = projects.find((p) => p.id === projectId);
+    const project = projects.find((projectItem) => projectItem.id === validProjectId);
 
     if (!project) {
       throw new Error(projectNotFoundCode);
     }
 
-    const bibleRaw = storage?.getItem(`ainkwell:projects:${projectId}:bible:v1`) ?? null;
-    const sessionsRaw = storage?.getItem(`ainkwell:projects:${projectId}:sessions:v1`) ?? null;
+    const bibleRaw = storage?.getItem(`ainkwell:projects:${validProjectId}:bible:v1`) ?? null;
+    const sessionsRaw = storage?.getItem(`ainkwell:projects:${validProjectId}:sessions:v1`) ?? null;
 
     return {
       version: 1,
@@ -486,11 +489,18 @@ export class LocalProjectRepository implements ProjectRepository {
       throw new Error(browserOnlyRepositoryMessage);
     }
 
+    const importedTitleSuffix = ' (imported)';
+    const maxProjectTitleLength = 120;
+    const importedTitle =
+      parsed.project.title.length + importedTitleSuffix.length <= maxProjectTitleLength
+        ? `${parsed.project.title}${importedTitleSuffix}`
+        : `${parsed.project.title.slice(0, maxProjectTitleLength - importedTitleSuffix.length).trimEnd()}${importedTitleSuffix}`;
+
     const newId = generateProjectId();
     const importedProject = writingProjectSchema.parse({
       ...parsed.project,
       id: newId,
-      title: `${parsed.project.title} (imported)`,
+      title: importedTitle,
       scenes: Object.fromEntries(
         Object.entries(parsed.project.scenes).map(([, scene]) => [
           scene.id,
@@ -512,10 +522,12 @@ export class LocalProjectRepository implements ProjectRepository {
     });
 
     if (parsed.bible) {
-      storage.setItem(`ainkwell:projects:${newId}:bible:v1`, JSON.stringify(parsed.bible));
+      const validatedBible = bibleStorageSchema.parse(parsed.bible);
+      storage.setItem(`ainkwell:projects:${newId}:bible:v1`, JSON.stringify(validatedBible));
     }
     if (parsed.sessions) {
-      storage.setItem(`ainkwell:projects:${newId}:sessions:v1`, JSON.stringify(parsed.sessions));
+      const validatedSessions = projectSessionDataSchema.parse(parsed.sessions);
+      storage.setItem(`ainkwell:projects:${newId}:sessions:v1`, JSON.stringify(validatedSessions));
     }
   }
 

--- a/src/data/project/local-project-repository.ts
+++ b/src/data/project/local-project-repository.ts
@@ -4,6 +4,7 @@ import type { ProjectRepository } from '@/domain/project/repository';
 import {
   createChapterInputSchema,
   createProjectInputSchema,
+  projectExportSchema,
   projectIdSchema,
   projectStorageSchema,
   updateProjectInputSchema,
@@ -16,6 +17,7 @@ import type {
   CreateProjectInput,
   MoveSceneToChapterInput,
   ProjectChapter,
+  ProjectExport,
   UpdateProjectInput,
   WritingProject,
 } from '@/domain/project/types';
@@ -453,6 +455,68 @@ export class LocalProjectRepository implements ProjectRepository {
         currentProject.id === input.projectId ? updatedProject : currentProject,
       ),
     );
+  }
+
+  public async exportProject(projectId: string): Promise<ProjectExport> {
+    const storage = getStorage();
+    const projects = this.readProjects();
+    const project = projects.find((p) => p.id === projectId);
+
+    if (!project) {
+      throw new Error(projectNotFoundCode);
+    }
+
+    const bibleRaw = storage?.getItem(`ainkwell:projects:${projectId}:bible:v1`) ?? null;
+    const sessionsRaw = storage?.getItem(`ainkwell:projects:${projectId}:sessions:v1`) ?? null;
+
+    return {
+      version: 1,
+      exportedAt: new Date().toISOString(),
+      project,
+      bible: bibleRaw ? JSON.parse(bibleRaw) : null,
+      sessions: sessionsRaw ? JSON.parse(sessionsRaw) : null,
+    };
+  }
+
+  public async importProject(data: ProjectExport): Promise<void> {
+    const parsed = projectExportSchema.parse(data);
+    const storage = getStorage();
+
+    if (!storage) {
+      throw new Error(browserOnlyRepositoryMessage);
+    }
+
+    const newId = crypto.randomUUID();
+    const importedProject = writingProjectSchema.parse({
+      ...parsed.project,
+      id: newId,
+      title: `${parsed.project.title} (imported)`,
+      scenes: Object.fromEntries(
+        Object.entries(parsed.project.scenes).map(([, scene]) => [
+          scene.id,
+          { ...scene, projectId: newId },
+        ]),
+      ),
+      chapters: Object.fromEntries(
+        Object.entries(parsed.project.chapters).map(([id, chapter]) => [
+          id,
+          { ...chapter, projectId: newId },
+        ]),
+      ),
+    });
+
+    const projectStorage = this.readProjectStorage();
+    this.writeProjectStorage({
+      version: PROJECT_STORAGE_VERSION,
+      projects: sortProjectsByUpdatedAt([importedProject, ...projectStorage.projects]),
+    });
+
+    if (parsed.bible) {
+      storage.setItem(`ainkwell:projects:${newId}:bible:v1`, JSON.stringify(parsed.bible));
+    }
+    if (parsed.sessions) {
+      storage.setItem(`ainkwell:projects:${newId}:sessions:v1`, JSON.stringify(parsed.sessions));
+    }
   }
 
   public async moveSceneToChapter(input: MoveSceneToChapterInput): Promise<void> {

--- a/src/domain/project/repository.ts
+++ b/src/domain/project/repository.ts
@@ -4,6 +4,7 @@ import type {
   CreateProjectInput,
   MoveSceneToChapterInput,
   ProjectChapter,
+  ProjectExport,
   UpdateProjectInput,
   WritingProject,
 } from '@/domain/project/types';
@@ -35,4 +36,6 @@ export interface ProjectRepository {
     direction: 'up' | 'down';
   }): Promise<void>;
   moveSceneToChapter(input: MoveSceneToChapterInput): Promise<void>;
+  exportProject(projectId: string): Promise<ProjectExport>;
+  importProject(data: ProjectExport): Promise<void>;
 }

--- a/src/domain/project/schemas.ts
+++ b/src/domain/project/schemas.ts
@@ -244,7 +244,7 @@ export const projectStorageSchema = z.object({
 
 export const projectExportSchema = z.object({
   version: z.literal(1),
-  exportedAt: z.string(),
+  exportedAt: z.string().datetime({ offset: true }),
   project: writingProjectSchema,
   bible: z.unknown().nullable(),
   sessions: z.unknown().nullable(),

--- a/src/domain/project/schemas.ts
+++ b/src/domain/project/schemas.ts
@@ -242,6 +242,14 @@ export const projectStorageSchema = z.object({
   projects: z.array(writingProjectSchema),
 });
 
+export const projectExportSchema = z.object({
+  version: z.literal(1),
+  exportedAt: z.string(),
+  project: writingProjectSchema,
+  bible: z.unknown().nullable(),
+  sessions: z.unknown().nullable(),
+});
+
 export type LegacyProjectStorage = z.infer<typeof legacyProjectStorageSchema>;
 export type V2ProjectStorage = z.infer<typeof v2ProjectStorageSchema>;
 export type ProjectStorage = z.infer<typeof projectStorageSchema>;

--- a/src/domain/project/types.ts
+++ b/src/domain/project/types.ts
@@ -77,3 +77,11 @@ export type UpdateProjectInput = {
   settings?: Partial<ProjectSettings>;
   stats?: Partial<ProjectStats>;
 };
+
+export type ProjectExport = {
+  version: 1;
+  exportedAt: string;
+  project: WritingProject;
+  bible: unknown | null;
+  sessions: unknown | null;
+};

--- a/src/test/export/export-service.test.ts
+++ b/src/test/export/export-service.test.ts
@@ -3,6 +3,27 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ExportService } from '@/application/export/export-service';
 import type { ProjectRepository } from '@/domain/project/repository';
 
+const validProjectId = '550e8400-e29b-4d4a-a716-446655440000';
+
+const validExportData = {
+  version: 1 as const,
+  exportedAt: '2026-01-01T00:00:00.000Z',
+  project: {
+    id: validProjectId,
+    title: 'My Novel',
+    description: '',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    settings: { language: 'en', targetWordCount: null },
+    stats: { wordCount: 0, sceneCount: 0, chapterCount: 0 },
+    chapterOrder: [],
+    chapters: {},
+    scenes: {},
+  },
+  bible: null,
+  sessions: null,
+};
+
 describe('ExportService', () => {
   let mockRepository: ProjectRepository;
 
@@ -14,57 +35,57 @@ describe('ExportService', () => {
   });
 
   it('calls exportProject with project id', async () => {
-    vi.mocked(mockRepository.exportProject).mockResolvedValue({
-      version: 1,
-      exportedAt: '2026-01-01T00:00:00.000Z',
-      project: { id: 'p1', title: 'My Novel' } as any,
-      bible: null,
-      sessions: null,
-    });
+    vi.mocked(mockRepository.exportProject).mockResolvedValue(validExportData);
 
     const service = new ExportService(mockRepository);
-    const result = await service.exportProjectJson('p1');
-    expect(mockRepository.exportProject).toHaveBeenCalledWith('p1');
-    expect(result.project.id).toBe('p1');
+    const result = await service.exportProjectJson(validProjectId);
+    expect(mockRepository.exportProject).toHaveBeenCalledWith(validProjectId);
+    expect(result.project.id).toBe(validProjectId);
   });
 
   it('calls importProject with parsed data', async () => {
     vi.mocked(mockRepository.importProject).mockResolvedValue(undefined);
 
-    const data = {
-      version: 1 as const,
-      exportedAt: '2026-01-01T00:00:00.000Z',
-      project: { id: 'p1', title: 'My Novel' } as any,
-      bible: null,
-      sessions: null,
-    };
-
     const service = new ExportService(mockRepository);
-    await service.importProjectJson(data);
-    expect(mockRepository.importProject).toHaveBeenCalledWith(data);
+    await service.importProjectJson(validExportData);
+    expect(mockRepository.importProject).toHaveBeenCalledWith(validExportData);
   });
 
   it('exportProjectMarkdown calls exportProject and returns markdown string', async () => {
+    const chapterId = 'aaaaaaaa-0000-4000-8000-000000000001';
+    const sceneId = 'aaaaaaaa-0000-4000-8000-000000000002';
+
     vi.mocked(mockRepository.exportProject).mockResolvedValue({
-      version: 1,
-      exportedAt: '2026-01-01T00:00:00.000Z',
+      ...validExportData,
       project: {
-        id: 'p1',
-        title: 'My Novel',
-        chapterOrder: ['ch1'],
+        ...validExportData.project,
+        chapterOrder: [chapterId],
         chapters: {
-          ch1: { id: 'ch1', title: 'Chapter One', sceneOrder: ['sc1'] },
+          [chapterId]: {
+            id: chapterId,
+            projectId: validProjectId,
+            title: 'Chapter One',
+            sceneOrder: [sceneId],
+          },
         },
         scenes: {
-          sc1: { id: 'sc1', title: 'Scene One', content: 'Once upon a time.' },
+          [sceneId]: {
+            id: sceneId,
+            projectId: validProjectId,
+            chapterId,
+            title: 'Scene One',
+            content: 'Once upon a time.',
+            status: 'draft' as const,
+            wordCount: 4,
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+          },
         },
-      } as any,
-      bible: null,
-      sessions: null,
+      },
     });
 
     const service = new ExportService(mockRepository);
-    const markdown = await service.exportProjectMarkdown('p1');
+    const markdown = await service.exportProjectMarkdown(validProjectId);
     expect(markdown).toContain('# My Novel');
     expect(markdown).toContain('## Chapter One');
     expect(markdown).toContain('### Scene One');

--- a/src/test/export/export-service.test.ts
+++ b/src/test/export/export-service.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { ExportService } from '@/application/export/export-service';
+import type { ProjectRepository } from '@/domain/project/repository';
+
+describe('ExportService', () => {
+  let mockRepository: ProjectRepository;
+
+  beforeEach(() => {
+    mockRepository = {
+      exportProject: vi.fn(),
+      importProject: vi.fn(),
+    } as unknown as ProjectRepository;
+  });
+
+  it('calls exportProject with project id', async () => {
+    vi.mocked(mockRepository.exportProject).mockResolvedValue({
+      version: 1,
+      exportedAt: '2026-01-01T00:00:00.000Z',
+      project: { id: 'p1', title: 'My Novel' } as any,
+      bible: null,
+      sessions: null,
+    });
+
+    const service = new ExportService(mockRepository);
+    const result = await service.exportProjectJson('p1');
+    expect(mockRepository.exportProject).toHaveBeenCalledWith('p1');
+    expect(result.project.id).toBe('p1');
+  });
+
+  it('calls importProject with parsed data', async () => {
+    vi.mocked(mockRepository.importProject).mockResolvedValue(undefined);
+
+    const data = {
+      version: 1 as const,
+      exportedAt: '2026-01-01T00:00:00.000Z',
+      project: { id: 'p1', title: 'My Novel' } as any,
+      bible: null,
+      sessions: null,
+    };
+
+    const service = new ExportService(mockRepository);
+    await service.importProjectJson(data);
+    expect(mockRepository.importProject).toHaveBeenCalledWith(data);
+  });
+
+  it('exportProjectMarkdown calls exportProject and returns markdown string', async () => {
+    vi.mocked(mockRepository.exportProject).mockResolvedValue({
+      version: 1,
+      exportedAt: '2026-01-01T00:00:00.000Z',
+      project: {
+        id: 'p1',
+        title: 'My Novel',
+        chapterOrder: ['ch1'],
+        chapters: {
+          ch1: { id: 'ch1', title: 'Chapter One', sceneOrder: ['sc1'] },
+        },
+        scenes: {
+          sc1: { id: 'sc1', title: 'Scene One', content: 'Once upon a time.' },
+        },
+      } as any,
+      bible: null,
+      sessions: null,
+    });
+
+    const service = new ExportService(mockRepository);
+    const markdown = await service.exportProjectMarkdown('p1');
+    expect(markdown).toContain('# My Novel');
+    expect(markdown).toContain('## Chapter One');
+    expect(markdown).toContain('### Scene One');
+    expect(markdown).toContain('Once upon a time.');
+  });
+});

--- a/src/test/export/validate-fixture.test.ts
+++ b/src/test/export/validate-fixture.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { describe, it, expect } from 'vitest';
+
+import { projectExportSchema } from '@/domain/project/schemas';
+
+describe('valid-import.json fixture', () => {
+  it('passes projectExportSchema validation', () => {
+    const raw = readFileSync(resolve('docs/test-fixtures/valid-import.json'), 'utf-8');
+    const data = JSON.parse(raw);
+    const result = projectExportSchema.safeParse(data);
+    if (!result.success) {
+      console.error(JSON.stringify(result.error.issues, null, 2));
+    }
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `ProjectExport` domain type and `projectExportSchema` (Zod) for validated JSON backup format
- Implements `exportProject` / `importProject` on `LocalProjectRepository` with full bible + session data round-trip
- Adds `ExportService` orchestrating JSON export, JSON import, and Markdown manuscript generation
- Adds `ExportImportPanel` component on the project detail page (export JSON + export Markdown)
- Adds `ImportProjectButton` to the workspace page header (import JSON backup → creates new project)
- Adds test fixtures: `docs/test-fixtures/valid-import.json` and `invalid-import.json`

## Test Plan

- [ ] All 111 unit tests pass (`npm run test:ci`)
- [ ] `Export JSON backup` button on project detail page downloads `<slug>-backup.json`
- [ ] `Export Markdown` button downloads `<slug>.md` with chapter/scene structure
- [ ] `Import JSON backup` button on workspace page imports the downloaded JSON as a new project
- [ ] Importing `invalid-import.json` shows error message in the UI
- [ ] Workspace project list refreshes automatically after a successful import

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes: JSON Backup Export/Import and Markdown Export

### Key Features Added
- **JSON Backup Export/Import**: Full project round-trip serialization including project data, optional Bible data, and sessions
- **Markdown Export**: Generate manuscript-ready Markdown output with project structure (chapters and scenes)
- **Import from Backup**: New workspace header button to import JSON backup files and create new projects

### Improvements
- **ExportService**: New service layer orchestrating JSON export, JSON import, and Markdown generation
- **ProjectExport Type & Schema**: Standardized export format with Zod validation (version 1, exportedAt timestamp)
- **Enhanced ProjectRepository**: Added `exportProject()` and `importProject()` methods with automatic UUID reassignment on import
- **UI Components**: 
  - `ExportImportPanel` on project detail page (JSON and Markdown export buttons)
  - `ImportProjectButton` in workspace header for importing backups
- **Auto-refresh**: Workspace project list automatically refreshes after successful import

### Affected Areas
- **Frontend**: New export/import UI components and actions
- **Data Layer**: LocalProjectRepository extended with export/import capabilities
- **Domain**: New ProjectExport type and validation schema
- **Testing**: Added test fixtures (valid-import.json, invalid-import.json) and comprehensive test coverage for ExportService and validation

### Breaking Changes
None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->