### PR TITLE
✨ feat: add scene beat planner (synopsis + beats)

### DIFF
--- a/docs/plans/scene-beat-planner.plan.md
+++ b/docs/plans/scene-beat-planner.plan.md
@@ -1,0 +1,380 @@
+---
+name: Scene Beat Planner
+overview: Add a synopsis field and beat cards per scene so writers can plan scenes before writing them — the structured data foundation for future AI assistance.
+todos:
+  - id: 1
+    content: "Extend Scene domain type with synopsis and beats fields"
+    status: pending
+    dependencies: []
+  - id: 2
+    content: "Update LocalProjectRepository to persist synopsis/beats"
+    status: pending
+    dependencies: [1]
+  - id: 3
+    content: "Update SceneEditorService to pass through synopsis/beats"
+    status: pending
+    dependencies: [2]
+  - id: 4
+    content: "Build SceneBeatPanel component for scene editor"
+    status: pending
+    dependencies: [3]
+  - id: 5
+    content: "Add inline synopsis to chapter outline panel"
+    status: pending
+    dependencies: [3]
+---
+
+# Scene Beat Planner — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Each scene gets a `synopsis` (short sentence: what happens) and `beats` (ordered list of story beats: setup, conflict, resolution, etc.). Writers plan before they write. AI will fill these fields in a future feature.
+
+**Architecture:** Extend `Scene` domain type. Repository persists new fields transparently (optional fields, backward compatible). `SceneEditorService` passes them through. New `SceneBeatPanel` in scene editor. Inline synopsis in chapter outline.
+
+**Tech Stack:** Next.js 15, TypeScript, Zod, React, Tailwind CSS
+
+---
+
+## Architecture / Data Model
+
+```ts
+export type BeatType = 'setup' | 'conflict' | 'resolution' | 'action' | 'dialogue' | 'revelation';
+
+export type SceneBeat = {
+  id: string;
+  content: string;    // max 200 chars
+  type: BeatType;
+};
+
+// Extend existing Scene:
+export type Scene = {
+  // ... existing fields unchanged
+  synopsis?: string;    // max 300 chars
+  beats?: SceneBeat[];  // max 20 beats
+};
+```
+
+No new storage keys. `synopsis` and `beats` stored inside the existing `WritingProject` in `ainkwell.projects.v1`. Backward compatible — existing scenes without these fields work fine.
+
+---
+
+## Implementation Steps
+
+### Task 1: Extend Scene domain type
+
+**Files:**
+- Modify: `src/domain/project/project.ts`
+
+**Step 1: Read the file**
+Read `src/domain/project/project.ts` to find the Scene type and its Zod schema.
+
+**Step 2: Write the failing test**
+
+File: `src/test/scene/scene-beat.test.ts`
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { sceneBeatSchema, sceneSchema } from '@/domain/project/project';
+
+describe('Scene beat schema', () => {
+  it('validates a beat with valid type', () => {
+    const beat = { id: 'b1', content: 'Hero enters the room', type: 'setup' };
+    expect(() => sceneBeatSchema.parse(beat)).not.toThrow();
+  });
+
+  it('rejects beat with invalid type', () => {
+    const beat = { id: 'b1', content: 'Hero enters the room', type: 'invalid' };
+    expect(() => sceneBeatSchema.parse(beat)).toThrow();
+  });
+
+  it('accepts scene without synopsis or beats (backward compat)', () => {
+    const scene = {
+      id: 's1', projectId: 'p1', title: 'Opening Scene',
+      content: '', status: 'draft', updatedAt: new Date().toISOString(),
+    };
+    expect(() => sceneSchema.parse(scene)).not.toThrow();
+  });
+
+  it('accepts scene with synopsis and beats', () => {
+    const scene = {
+      id: 's1', projectId: 'p1', title: 'Opening Scene',
+      content: '', status: 'draft', updatedAt: new Date().toISOString(),
+      synopsis: 'Aria discovers the letter is missing.',
+      beats: [
+        { id: 'b1', content: 'Aria opens the drawer', type: 'setup' },
+        { id: 'b2', content: 'Aria realizes the letter is gone', type: 'revelation' },
+      ],
+    };
+    expect(() => sceneSchema.parse(scene)).not.toThrow();
+  });
+});
+```
+
+**Step 3: Run test — expect FAIL** (`sceneBeatSchema` doesn't exist yet)
+```bash
+npx vitest run src/test/scene/scene-beat.test.ts
+```
+
+**Step 4: Add types and schemas**
+
+In `src/domain/project/project.ts`, add:
+```ts
+export const beatTypeSchema = z.enum([
+  'setup', 'conflict', 'resolution', 'action', 'dialogue', 'revelation',
+]);
+export type BeatType = z.infer<typeof beatTypeSchema>;
+
+export const sceneBeatSchema = z.object({
+  id: z.string(),
+  content: z.string().max(200),
+  type: beatTypeSchema,
+});
+export type SceneBeat = z.infer<typeof sceneBeatSchema>;
+```
+
+Then extend the existing `sceneSchema` with:
+```ts
+synopsis: z.string().max(300).optional(),
+beats: z.array(sceneBeatSchema).max(20).optional(),
+```
+
+**Step 5: Run test — expect PASS**
+```bash
+npx vitest run src/test/scene/scene-beat.test.ts
+```
+
+**Step 6: Commit**
+```bash
+git add src/domain/project/project.ts src/test/scene/scene-beat.test.ts
+git commit -m "✨ feat: add SceneBeat type and synopsis/beats fields to Scene domain schema"
+```
+
+---
+
+### Task 2: Update repository and service
+
+**Files:**
+- Modify: `src/domain/project/project-repository.ts`
+- Modify: `src/data/project/local-project-repository.ts`
+- Modify: `src/application/scene/scene-editor-service.ts`
+
+**Step 1: Read the files**
+Read `src/domain/project/project-repository.ts` and `src/application/scene/scene-editor-service.ts`.
+
+**Step 2: Update SaveSceneInput in project-repository.ts**
+```ts
+export type SaveSceneInput = {
+  // ... existing fields
+  synopsis?: string;
+  beats?: SceneBeat[];
+};
+```
+
+**Step 3: Update saveScene in LocalProjectRepository**
+When writing the scene object, include:
+```ts
+const updatedScene: Scene = {
+  ...existingScene,
+  content: input.content,
+  status: input.status,
+  updatedAt: input.updatedAt,
+  synopsis: input.synopsis,
+  beats: input.beats,
+};
+```
+
+**Step 4: Update SceneEditorService.saveScene signature**
+Add `synopsis?: string` and `beats?: SceneBeat[]` to the input type and forward them to the repository.
+
+**Step 5: Run full tests**
+```bash
+npm run test:ci
+```
+
+**Step 6: Commit**
+```bash
+git add src/domain/project/project-repository.ts src/data/project/local-project-repository.ts src/application/scene/scene-editor-service.ts
+git commit -m "✨ feat: persist synopsis and beats through repository and service layers"
+```
+
+---
+
+### Task 3: SceneBeatPanel component + scene editor integration
+
+**Files:**
+- Create: `src/components/scene/scene-beat-panel.tsx`
+- Modify: `src/components/scene/scene-editor-shell.tsx`
+
+**Step 1: Read scene-editor-shell.tsx**
+Read `src/components/scene/scene-editor-shell.tsx`.
+
+**Step 2: Build SceneBeatPanel**
+
+```tsx
+'use client';
+import { useState } from 'react';
+import type { ReactElement } from 'react';
+import type { SceneBeat, BeatType } from '@/domain/project/project';
+
+type Props = {
+  synopsis: string;
+  beats: SceneBeat[];
+  onSynopsisChange: (value: string) => void;
+  onBeatsChange: (beats: SceneBeat[]) => void;
+};
+
+const BEAT_LABELS: Record<BeatType, string> = {
+  setup: 'Setup', conflict: 'Conflict', resolution: 'Resolution',
+  action: 'Action', dialogue: 'Dialogue', revelation: 'Revelation',
+};
+
+export function SceneBeatPanel({ synopsis, beats, onSynopsisChange, onBeatsChange }: Props): ReactElement {
+  const [isOpen, setIsOpen] = useState(false);
+
+  function addBeat(): void {
+    onBeatsChange([...beats, { id: crypto.randomUUID(), content: '', type: 'setup' }]);
+  }
+
+  function updateBeat(id: string, changes: Partial<SceneBeat>): void {
+    onBeatsChange(beats.map((b) => (b.id === id ? { ...b, ...changes } : b)));
+  }
+
+  function removeBeat(id: string): void {
+    onBeatsChange(beats.filter((b) => b.id !== id));
+  }
+
+  return (
+    <div className="border-b border-border bg-card">
+      <button
+        className="flex w-full items-center justify-between px-4 py-2 text-sm text-muted-foreground hover:text-foreground"
+        onClick={() => setIsOpen((v) => !v)}
+        type="button"
+      >
+        <span>Scene Plan</span>
+        <span>{isOpen ? '▲' : '▼'}</span>
+      </button>
+      {isOpen && (
+        <div className="space-y-3 px-4 pb-4">
+          <div>
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">Synopsis</label>
+            <input
+              className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+              maxLength={300}
+              onChange={(e) => onSynopsisChange(e.target.value)}
+              placeholder="What happens in this scene?"
+              type="text"
+              value={synopsis}
+            />
+          </div>
+          <div>
+            <div className="mb-1 flex items-center justify-between">
+              <label className="text-xs font-medium text-muted-foreground">Beats</label>
+              <button className="text-xs text-primary hover:underline" onClick={addBeat} type="button">
+                + Add beat
+              </button>
+            </div>
+            <ol className="space-y-2">
+              {beats.map((beat) => (
+                <li className="flex items-start gap-2" key={beat.id}>
+                  <select
+                    className="rounded border border-border bg-background px-1 py-1 text-xs"
+                    onChange={(e) => updateBeat(beat.id, { type: e.target.value as BeatType })}
+                    value={beat.type}
+                  >
+                    {Object.entries(BEAT_LABELS).map(([value, label]) => (
+                      <option key={value} value={value}>{label}</option>
+                    ))}
+                  </select>
+                  <input
+                    className="flex-1 rounded border border-border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+                    maxLength={200}
+                    onChange={(e) => updateBeat(beat.id, { content: e.target.value })}
+                    placeholder="Describe this beat…"
+                    type="text"
+                    value={beat.content}
+                  />
+                  <button
+                    className="text-xs text-muted-foreground hover:text-destructive"
+                    onClick={() => removeBeat(beat.id)}
+                    type="button"
+                  >
+                    ✕
+                  </button>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+**Step 3: Integrate in scene-editor-shell.tsx**
+Add `<SceneBeatPanel>` between the toolbar and textarea. Wire synopsis and beats from scene state; save with same debounce as content (800ms).
+
+**Step 4: Run tests**
+```bash
+npm run test:ci
+```
+
+**Step 5: Commit**
+```bash
+git add src/components/scene/scene-beat-panel.tsx src/components/scene/scene-editor-shell.tsx
+git commit -m "✨ feat: add SceneBeatPanel to scene editor"
+```
+
+---
+
+### Task 4: Inline synopsis in chapter outline
+
+**Files:**
+- Modify: `src/components/workspace/chapter-outline-panel.tsx`
+
+**Step 1: Read the file**
+
+**Step 2: Show synopsis below scene title if present**
+```tsx
+<div className="flex flex-col">
+  <span className="text-sm">{scene.title}</span>
+  {scene.synopsis && (
+    <span className="text-xs text-muted-foreground line-clamp-1">{scene.synopsis}</span>
+  )}
+</div>
+```
+
+**Step 3: Run tests**
+```bash
+npm run test:ci
+```
+
+**Step 4: Commit**
+```bash
+git add src/components/workspace/chapter-outline-panel.tsx
+git commit -m "✨ feat: show scene synopsis inline in chapter outline"
+```
+
+---
+
+## Files Summary
+
+| Action | Path |
+|--------|------|
+| Modify | `src/domain/project/project.ts` |
+| Modify | `src/domain/project/project-repository.ts` |
+| Modify | `src/data/project/local-project-repository.ts` |
+| Modify | `src/application/scene/scene-editor-service.ts` |
+| Create | `src/components/scene/scene-beat-panel.tsx` |
+| Modify | `src/components/scene/scene-editor-shell.tsx` |
+| Modify | `src/components/workspace/chapter-outline-panel.tsx` |
+| Create | `src/test/scene/scene-beat.test.ts` |
+
+---
+
+## AI Readiness
+
+- `synopsis` = AI instruction: "write a scene that does X"
+- `beats` = AI outline: "write a scene with these micro-moments in order"
+- Future AI Writing Assistant will read these as prompts to generate scene content

--- a/src/application/export/export-service.ts
+++ b/src/application/export/export-service.ts
@@ -33,7 +33,8 @@ function buildMarkdown(project: WritingProject): string {
     for (const sceneId of chapter.sceneOrder) {
       const scene = project.scenes[sceneId];
       if (!scene) continue;
-      lines.push(`### ${scene.title}`, '', scene.content.trim(), '', '---', '');
+      const synopsisLine = scene.synopsis ? `*${scene.synopsis}*\n` : '';
+      lines.push(`### ${scene.title}`, '', synopsisLine + scene.content.trim(), '', '---', '');
     }
   }
 

--- a/src/application/scene/scene-editor-service.ts
+++ b/src/application/scene/scene-editor-service.ts
@@ -2,6 +2,7 @@ import { ZodError } from 'zod';
 
 import { projectNotFoundCode, sceneNotFoundCode } from '@/data/project/local-project-repository';
 import type { ProjectRepository } from '@/domain/project/repository';
+import type { SceneBeat } from '@/domain/scene/schemas';
 import { maxSceneContentLength } from '@/domain/scene/schemas';
 import type { Scene, SceneStatus, SceneSummary } from '@/domain/scene/types';
 
@@ -16,6 +17,8 @@ type SaveSceneInput = {
   content: string;
   status: SceneStatus;
   updatedAt: string;
+  synopsis?: string;
+  beats?: SceneBeat[];
 };
 
 type CreateSceneInput = {

--- a/src/components/scene/scene-beat-panel.tsx
+++ b/src/components/scene/scene-beat-panel.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState } from 'react';
+import type { ReactElement } from 'react';
+
+import type { BeatType, SceneBeat } from '@/domain/scene/schemas';
+
+type Props = {
+  synopsis: string;
+  beats: SceneBeat[];
+  onSynopsisChange: (value: string) => void;
+  onBeatsChange: (beats: SceneBeat[]) => void;
+};
+
+const BEAT_LABELS: Record<BeatType, string> = {
+  setup: 'Setup',
+  conflict: 'Conflict',
+  resolution: 'Resolution',
+  action: 'Action',
+  dialogue: 'Dialogue',
+  revelation: 'Revelation',
+};
+
+export function SceneBeatPanel({ synopsis, beats, onSynopsisChange, onBeatsChange }: Props): ReactElement {
+  const [isOpen, setIsOpen] = useState(false);
+
+  function addBeat(): void {
+    onBeatsChange([...beats, { id: crypto.randomUUID(), content: '', type: 'setup' }]);
+  }
+
+  function updateBeat(id: string, changes: Partial<SceneBeat>): void {
+    onBeatsChange(beats.map((beat) => (beat.id === id ? { ...beat, ...changes } : beat)));
+  }
+
+  function removeBeat(id: string): void {
+    onBeatsChange(beats.filter((beat) => beat.id !== id));
+  }
+
+  return (
+    <div className="border-b border-border bg-card">
+      <button
+        className="flex w-full items-center justify-between px-4 py-2 text-sm text-muted-foreground hover:text-foreground"
+        onClick={() => setIsOpen((open) => !open)}
+        type="button"
+      >
+        <span>Scene Plan</span>
+        <span>{isOpen ? '▲' : '▼'}</span>
+      </button>
+      {isOpen && (
+        <div className="space-y-3 px-4 pb-4">
+          <div>
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">Synopsis</label>
+            <input
+              className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+              maxLength={300}
+              onChange={(event) => onSynopsisChange(event.target.value)}
+              placeholder="What happens in this scene?"
+              type="text"
+              value={synopsis}
+            />
+          </div>
+          <div>
+            <div className="mb-1 flex items-center justify-between">
+              <label className="text-xs font-medium text-muted-foreground">Beats</label>
+              <button className="text-xs text-primary hover:underline" onClick={addBeat} type="button">
+                + Add beat
+              </button>
+            </div>
+            <ol className="space-y-2">
+              {beats.map((beat) => (
+                <li className="flex items-start gap-2" key={beat.id}>
+                  <select
+                    className="rounded border border-border bg-background px-1 py-1 text-xs"
+                    onChange={(event) => updateBeat(beat.id, { type: event.target.value as BeatType })}
+                    value={beat.type}
+                  >
+                    {Object.entries(BEAT_LABELS).map(([value, label]) => (
+                      <option key={value} value={value}>{label}</option>
+                    ))}
+                  </select>
+                  <input
+                    className="flex-1 rounded border border-border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+                    maxLength={200}
+                    onChange={(event) => updateBeat(beat.id, { content: event.target.value })}
+                    placeholder="Describe this beat…"
+                    type="text"
+                    value={beat.content}
+                  />
+                  <button
+                    className="text-xs text-muted-foreground hover:text-destructive"
+                    onClick={() => removeBeat(beat.id)}
+                    type="button"
+                  >
+                    ✕
+                  </button>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/scene/scene-beat-panel.tsx
+++ b/src/components/scene/scene-beat-panel.tsx
@@ -12,6 +12,8 @@ type Props = {
   onBeatsChange: (beats: SceneBeat[]) => void;
 };
 
+const maxBeatsPerScene = 20;
+
 const BEAT_LABELS: Record<BeatType, string> = {
   setup: 'Setup',
   conflict: 'Conflict',
@@ -25,6 +27,7 @@ export function SceneBeatPanel({ synopsis, beats, onSynopsisChange, onBeatsChang
   const [isOpen, setIsOpen] = useState(false);
 
   function addBeat(): void {
+    if (beats.length >= maxBeatsPerScene) return;
     onBeatsChange([...beats, { id: `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`, content: '', type: 'setup' }]);
   }
 
@@ -39,15 +42,17 @@ export function SceneBeatPanel({ synopsis, beats, onSynopsisChange, onBeatsChang
   return (
     <div className="border-b border-border bg-card">
       <button
+        aria-controls="scene-plan-panel"
+        aria-expanded={isOpen}
         className="flex w-full items-center justify-between px-4 py-2 text-sm text-muted-foreground hover:text-foreground"
         onClick={() => setIsOpen((open) => !open)}
         type="button"
       >
         <span>Scene Plan</span>
-        <span>{isOpen ? '▲' : '▼'}</span>
+        <span aria-hidden>{isOpen ? '▲' : '▼'}</span>
       </button>
       {isOpen && (
-        <div className="space-y-3 px-4 pb-4">
+        <div className="space-y-3 px-4 pb-4" id="scene-plan-panel">
           <div>
             <label className="mb-1 block text-xs font-medium text-muted-foreground">Synopsis</label>
             <input
@@ -62,14 +67,20 @@ export function SceneBeatPanel({ synopsis, beats, onSynopsisChange, onBeatsChang
           <div>
             <div className="mb-1 flex items-center justify-between">
               <label className="text-xs font-medium text-muted-foreground">Beats</label>
-              <button className="text-xs text-primary hover:underline" onClick={addBeat} type="button">
+              <button
+                className="text-xs text-primary hover:underline disabled:opacity-50"
+                disabled={beats.length >= maxBeatsPerScene}
+                onClick={addBeat}
+                type="button"
+              >
                 + Add beat
               </button>
             </div>
             <ol className="space-y-2">
-              {beats.map((beat) => (
+              {beats.map((beat, index) => (
                 <li className="flex items-start gap-2" key={beat.id}>
                   <select
+                    aria-label={`Beat ${index + 1} type`}
                     className="rounded border border-border bg-background px-1 py-1 text-xs"
                     onChange={(event) => updateBeat(beat.id, { type: event.target.value as BeatType })}
                     value={beat.type}
@@ -79,6 +90,7 @@ export function SceneBeatPanel({ synopsis, beats, onSynopsisChange, onBeatsChang
                     ))}
                   </select>
                   <input
+                    aria-label={`Beat ${index + 1} content`}
                     className="flex-1 rounded border border-border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
                     maxLength={200}
                     onChange={(event) => updateBeat(beat.id, { content: event.target.value })}
@@ -87,6 +99,7 @@ export function SceneBeatPanel({ synopsis, beats, onSynopsisChange, onBeatsChang
                     value={beat.content}
                   />
                   <button
+                    aria-label={`Remove beat ${index + 1}`}
                     className="text-xs text-muted-foreground hover:text-destructive"
                     onClick={() => removeBeat(beat.id)}
                     type="button"

--- a/src/components/scene/scene-beat-panel.tsx
+++ b/src/components/scene/scene-beat-panel.tsx
@@ -25,7 +25,7 @@ export function SceneBeatPanel({ synopsis, beats, onSynopsisChange, onBeatsChang
   const [isOpen, setIsOpen] = useState(false);
 
   function addBeat(): void {
-    onBeatsChange([...beats, { id: crypto.randomUUID(), content: '', type: 'setup' }]);
+    onBeatsChange([...beats, { id: `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`, content: '', type: 'setup' }]);
   }
 
   function updateBeat(id: string, changes: Partial<SceneBeat>): void {

--- a/src/components/scene/scene-editor-shell.tsx
+++ b/src/components/scene/scene-editor-shell.tsx
@@ -9,6 +9,7 @@ import {
   type SceneEditorServicePort,
 } from '@/application/scene/scene-editor-service';
 import { WritingSessionService } from '@/application/writing-session/writing-session-service';
+import { SceneBeatPanel } from '@/components/scene/scene-beat-panel';
 import { SceneToolbar } from '@/components/scene/scene-toolbar';
 import { SessionTimer } from '@/components/writing-session/session-timer';
 import { WritingSessionContext } from '@/context/writing-session-context';
@@ -192,17 +193,25 @@ function SceneEditorLoadedView(props: SceneEditorLoadedViewProps): ReactElement 
         onStop={props.onSessionStop}
       />
 
-      <section className="flex-1 rounded-xl border bg-card p-4 text-card-foreground">
-        <label htmlFor="scene-content" className="mb-2 block text-sm font-medium">
-          Markdown content
-        </label>
-        <textarea
-          id="scene-content"
-          value={props.sceneEditor.content}
-          onChange={(event) => props.sceneEditor.setContent(event.target.value)}
-          className="min-h-[60vh] w-full resize-y rounded-md border bg-background p-3 font-mono text-sm"
+      <div className="flex-1 rounded-xl border overflow-hidden">
+        <SceneBeatPanel
+          synopsis={props.sceneEditor.synopsis}
+          beats={props.sceneEditor.beats}
+          onSynopsisChange={props.sceneEditor.setSynopsis}
+          onBeatsChange={props.sceneEditor.setBeats}
         />
-      </section>
+        <section className="bg-card p-4 text-card-foreground">
+          <label htmlFor="scene-content" className="mb-2 block text-sm font-medium">
+            Markdown content
+          </label>
+          <textarea
+            id="scene-content"
+            value={props.sceneEditor.content}
+            onChange={(event) => props.sceneEditor.setContent(event.target.value)}
+            className="min-h-[60vh] w-full resize-y rounded-md border bg-background p-3 font-mono text-sm"
+          />
+        </section>
+      </div>
 
       <SceneEditorNavigation
         projectId={props.projectId}

--- a/src/components/workspace/chapter-outline-panel.tsx
+++ b/src/components/workspace/chapter-outline-panel.tsx
@@ -49,7 +49,7 @@ function SceneRow({
   chapters,
   actions,
 }: {
-  scene: { id: string; title: string; status: SceneStatus; updatedAt: string };
+  scene: { id: string; title: string; status: SceneStatus; updatedAt: string; synopsis?: string };
   chapterId: string;
   projectId: string;
   chapters: ChapterSummary[];
@@ -57,7 +57,12 @@ function SceneRow({
 }): ReactElement {
   return (
     <div className="flex items-center gap-3 py-1.5 pl-4 text-sm">
-      <span className="flex-1 truncate text-muted-foreground">{scene.title}</span>
+      <span className="flex flex-col flex-1 min-w-0">
+        <span className="truncate text-muted-foreground">{scene.title}</span>
+        {scene.synopsis ? (
+          <span className="truncate text-xs text-muted-foreground/60">{scene.synopsis}</span>
+        ) : null}
+      </span>
       <span className="text-xs text-muted-foreground">{formatProjectDate(scene.updatedAt)}</span>
       <span className="text-xs text-muted-foreground">{statusLabel[scene.status]}</span>
       {chapters.length > 1 ? (

--- a/src/data/project/local-project-repository.ts
+++ b/src/data/project/local-project-repository.ts
@@ -247,6 +247,8 @@ export class LocalProjectRepository implements ProjectRepository {
     content: string;
     status: Scene['status'];
     updatedAt: string;
+    synopsis?: string;
+    beats?: Scene['beats'];
   }): Promise<Scene> {
     const parsedInput = saveSceneInputSchema.parse(input);
     const projectStorage = this.readProjectStorage();
@@ -262,6 +264,8 @@ export class LocalProjectRepository implements ProjectRepository {
       content: parsedInput.content,
       status: parsedInput.status,
       updatedAt: parsedInput.updatedAt,
+      synopsis: parsedInput.synopsis,
+      beats: parsedInput.beats,
     });
 
     const updatedProject = withRecalculatedStats(

--- a/src/data/project/local-project-repository.ts
+++ b/src/data/project/local-project-repository.ts
@@ -268,8 +268,8 @@ export class LocalProjectRepository implements ProjectRepository {
       content: parsedInput.content,
       status: parsedInput.status,
       updatedAt: parsedInput.updatedAt,
-      synopsis: parsedInput.synopsis,
-      beats: parsedInput.beats,
+      ...(parsedInput.synopsis !== undefined ? { synopsis: parsedInput.synopsis } : {}),
+      ...(parsedInput.beats !== undefined ? { beats: parsedInput.beats } : {}),
     });
 
     const updatedProject = withRecalculatedStats(

--- a/src/domain/project/repository.ts
+++ b/src/domain/project/repository.ts
@@ -1,3 +1,4 @@
+import type { SceneBeat } from '@/domain/scene/schemas';
 import type {
   ChapterSummary,
   CreateChapterInput,
@@ -24,6 +25,8 @@ export interface ProjectRepository {
     content: string;
     status: SceneStatus;
     updatedAt: string;
+    synopsis?: string;
+    beats?: SceneBeat[];
   }): Promise<Scene>;
   listChapters(input: { projectId: string }): Promise<ChapterSummary[]>;
   createChapter(input: CreateChapterInput): Promise<ProjectChapter>;

--- a/src/domain/project/schemas.ts
+++ b/src/domain/project/schemas.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { maxSceneContentLength, sceneStatusSchema } from '@/domain/scene/schemas';
+import { maxSceneContentLength, sceneBeatSchema, sceneStatusSchema } from '@/domain/scene/schemas';
 
 const uuidV4Regex =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -69,6 +69,8 @@ export const projectSceneSchema = z.object({
   content: sceneContentSchema,
   status: sceneStatusSchema,
   updatedAt: z.string().datetime({ offset: true }),
+  synopsis: z.string().max(300).optional(),
+  beats: z.array(sceneBeatSchema).max(20).optional(),
 });
 
 export const projectChapterSchema = z.object({

--- a/src/domain/project/types.ts
+++ b/src/domain/project/types.ts
@@ -1,3 +1,4 @@
+import type { SceneBeat } from '@/domain/scene/schemas';
 import type { SceneStatus } from '@/domain/scene/types';
 
 export type ProjectStats = {
@@ -18,6 +19,8 @@ export type ProjectScene = {
   content: string;
   status: SceneStatus;
   updatedAt: string;
+  synopsis?: string;
+  beats?: SceneBeat[];
 };
 
 export type ProjectChapter = {

--- a/src/domain/scene/schemas.ts
+++ b/src/domain/scene/schemas.ts
@@ -26,7 +26,7 @@ export const beatTypeSchema = z.enum([
 export type BeatType = z.infer<typeof beatTypeSchema>;
 
 export const sceneBeatSchema = z.object({
-  id: z.string(),
+  id: z.string().min(1),
   content: z.string().max(200),
   type: beatTypeSchema,
 });

--- a/src/domain/scene/schemas.ts
+++ b/src/domain/scene/schemas.ts
@@ -15,6 +15,23 @@ const updatedAtSchema = z.string().datetime({ offset: true });
 
 export const sceneStatusSchema = z.enum(['draft', 'revise', 'final']);
 
+export const beatTypeSchema = z.enum([
+  'setup',
+  'conflict',
+  'resolution',
+  'action',
+  'dialogue',
+  'revelation',
+]);
+export type BeatType = z.infer<typeof beatTypeSchema>;
+
+export const sceneBeatSchema = z.object({
+  id: z.string(),
+  content: z.string().max(200),
+  type: beatTypeSchema,
+});
+export type SceneBeat = z.infer<typeof sceneBeatSchema>;
+
 export const sceneSchema = z.object({
   id: sceneIdSchema,
   projectId: projectIdSchema,
@@ -22,6 +39,8 @@ export const sceneSchema = z.object({
   content: sceneContentSchema,
   status: sceneStatusSchema,
   updatedAt: updatedAtSchema,
+  synopsis: z.string().max(300).optional(),
+  beats: z.array(sceneBeatSchema).max(20).optional(),
 });
 
 export const sceneSummarySchema = sceneSchema.pick({

--- a/src/domain/scene/schemas.ts
+++ b/src/domain/scene/schemas.ts
@@ -57,6 +57,8 @@ export const saveSceneInputSchema = z.object({
   content: sceneContentSchema,
   status: sceneStatusSchema,
   updatedAt: updatedAtSchema,
+  synopsis: z.string().max(300).optional(),
+  beats: z.array(sceneBeatSchema).max(20).optional(),
 });
 
 const legacySceneSchema = z.object({

--- a/src/domain/scene/types.ts
+++ b/src/domain/scene/types.ts
@@ -1,3 +1,5 @@
+import type { SceneBeat } from '@/domain/scene/schemas';
+
 export type SceneStatus = 'draft' | 'revise' | 'final';
 
 export interface Scene {
@@ -7,6 +9,8 @@ export interface Scene {
   content: string;
   status: SceneStatus;
   updatedAt: string;
+  synopsis?: string;
+  beats?: SceneBeat[];
 }
 
 export interface SceneSummary {

--- a/src/hooks/use-scene-editor-runtime.ts
+++ b/src/hooks/use-scene-editor-runtime.ts
@@ -216,7 +216,7 @@ export const applySaveSuccess = (input: SaveSuccessInput): void => {
     runtimeRefs.contentRef.current === payload.content &&
     runtimeRefs.statusRef.current === payload.status &&
     (runtimeRefs.synopsisRef.current || undefined) === payload.synopsis &&
-    runtimeRefs.beatsRef.current === payload.beats;
+    JSON.stringify(runtimeRefs.beatsRef.current) === JSON.stringify(payload.beats ?? []);
 
   if (!payloadStillCurrent) {
     return;

--- a/src/hooks/use-scene-editor-runtime.ts
+++ b/src/hooks/use-scene-editor-runtime.ts
@@ -1,6 +1,7 @@
 import type { MutableRefObject } from 'react';
 
 import type { SceneEditorServicePort } from '@/application/scene/scene-editor-service';
+import type { SceneBeat } from '@/domain/scene/schemas';
 import type { Scene, SceneStatus } from '@/domain/scene/types';
 
 export type SceneEditorLoadState =
@@ -14,6 +15,8 @@ export type SceneViewState = {
   scene: Scene | null;
   content: string;
   status: SceneStatus;
+  synopsis: string;
+  beats: SceneBeat[];
   isDirty: boolean;
   isSaving: boolean;
   saveError: string | null;
@@ -27,6 +30,8 @@ export type SceneRuntimeRefs = {
   sceneRef: MutableRefObject<Scene | null>;
   contentRef: MutableRefObject<string>;
   statusRef: MutableRefObject<SceneStatus>;
+  synopsisRef: MutableRefObject<string>;
+  beatsRef: MutableRefObject<SceneBeat[]>;
   isDirtyRef: MutableRefObject<boolean>;
   latestRequestRef: MutableRefObject<number>;
   latestAppliedRequestRef: MutableRefObject<number>;
@@ -44,6 +49,8 @@ export type SavePayload = {
   content: string;
   status: SceneStatus;
   updatedAt: string;
+  synopsis?: string;
+  beats?: SceneBeat[];
 };
 
 type SaveSuccessInput = {
@@ -76,6 +83,8 @@ export const initialViewState: SceneViewState = {
   scene: null,
   content: '',
   status: 'draft',
+  synopsis: '',
+  beats: [],
   isDirty: false,
   isSaving: false,
   saveError: null,
@@ -114,6 +123,8 @@ export const resetRuntimeRefs = (runtimeRefs: SceneRuntimeRefs): void => {
   assignRef(runtimeRefs.sceneRef, null);
   assignRef(runtimeRefs.contentRef, '');
   assignRef(runtimeRefs.statusRef, 'draft');
+  assignRef(runtimeRefs.synopsisRef, '');
+  assignRef(runtimeRefs.beatsRef, []);
   assignRef(runtimeRefs.isDirtyRef, false);
   assignRef(runtimeRefs.latestRequestRef, 0);
   assignRef(runtimeRefs.latestAppliedRequestRef, 0);
@@ -147,6 +158,8 @@ export const applyLoadedScene = (input: ApplyLoadedInput): void => {
   assignRef(runtimeRefs.sceneRef, scene);
   assignRef(runtimeRefs.contentRef, scene.content);
   assignRef(runtimeRefs.statusRef, scene.status);
+  assignRef(runtimeRefs.synopsisRef, scene.synopsis ?? '');
+  assignRef(runtimeRefs.beatsRef, scene.beats ?? []);
   assignRef(runtimeRefs.isDirtyRef, false);
   assignRef(runtimeRefs.latestRequestRef, 0);
   assignRef(runtimeRefs.latestAppliedRequestRef, 0);
@@ -156,6 +169,8 @@ export const applyLoadedScene = (input: ApplyLoadedInput): void => {
     scene,
     content: scene.content,
     status: scene.status,
+    synopsis: scene.synopsis ?? '',
+    beats: scene.beats ?? [],
     isDirty: false,
     isSaving: false,
     saveError: null,
@@ -176,6 +191,8 @@ export const createSavePayload = (runtimeRefs: SceneRuntimeRefs): SavePayload | 
     sceneId: runtimeRefs.sceneRef.current.id,
     content: runtimeRefs.contentRef.current,
     status: runtimeRefs.statusRef.current,
+    synopsis: runtimeRefs.synopsisRef.current || undefined,
+    beats: runtimeRefs.beatsRef.current,
     updatedAt: new Date().toISOString(),
   };
 };
@@ -196,7 +213,10 @@ export const applySaveSuccess = (input: SaveSuccessInput): void => {
   patchViewState({ scene: savedScene, lastSavedAt: savedScene.updatedAt });
 
   const payloadStillCurrent =
-    runtimeRefs.contentRef.current === payload.content && runtimeRefs.statusRef.current === payload.status;
+    runtimeRefs.contentRef.current === payload.content &&
+    runtimeRefs.statusRef.current === payload.status &&
+    (runtimeRefs.synopsisRef.current || undefined) === payload.synopsis &&
+    runtimeRefs.beatsRef.current === payload.beats;
 
   if (!payloadStillCurrent) {
     return;

--- a/src/hooks/use-scene-editor.ts
+++ b/src/hooks/use-scene-editor.ts
@@ -7,6 +7,7 @@ import {
 } from 'react';
 
 import type { SceneEditorServicePort } from '@/application/scene/scene-editor-service';
+import type { SceneBeat } from '@/domain/scene/schemas';
 import type { Scene, SceneStatus } from '@/domain/scene/types';
 
 import {
@@ -39,6 +40,8 @@ export type UseSceneEditorResult = {
   scene: Scene | null;
   content: string;
   status: SceneStatus;
+  synopsis: string;
+  beats: SceneBeat[];
   wordCount: number;
   isDirty: boolean;
   isSaving: boolean;
@@ -49,6 +52,8 @@ export type UseSceneEditorResult = {
   loadState: SceneEditorLoadState;
   setContent: (value: string) => void;
   setStatus: (value: SceneStatus) => void;
+  setSynopsis: (value: string) => void;
+  setBeats: (beats: SceneBeat[]) => void;
   retrySave: () => Promise<void>;
 };
 
@@ -76,6 +81,8 @@ function useRuntimeRefs(): SceneRuntimeRefs {
   const sceneRef = useRef<Scene | null>(null);
   const contentRef = useRef<string>('');
   const statusRef = useRef<SceneStatus>('draft');
+  const synopsisRef = useRef<string>('');
+  const beatsRef = useRef<SceneBeat[]>([]);
   const isDirtyRef = useRef<boolean>(false);
   const latestRequestRef = useRef<number>(0);
   const latestAppliedRequestRef = useRef<number>(0);
@@ -88,6 +95,8 @@ function useRuntimeRefs(): SceneRuntimeRefs {
       sceneRef,
       contentRef,
       statusRef,
+      synopsisRef,
+      beatsRef,
       isDirtyRef,
       latestRequestRef,
       latestAppliedRequestRef,
@@ -236,10 +245,12 @@ function useAutosave(
   }, [
     runSaveCycle,
     runtimeRefs,
+    viewState.beats,
     viewState.content,
     viewState.isDirty,
     viewState.loadState,
     viewState.status,
+    viewState.synopsis,
   ]);
 }
 
@@ -247,7 +258,7 @@ function useEditorMutators(
   runtimeRefs: SceneRuntimeRefs,
   patchViewState: ViewStateSetter,
   runSaveCycle: () => Promise<void>,
-): Pick<UseSceneEditorResult, 'setContent' | 'setStatus' | 'retrySave'> {
+): Pick<UseSceneEditorResult, 'setContent' | 'setStatus' | 'setSynopsis' | 'setBeats' | 'retrySave'> {
   const setContent = useCallback(
     (value: string): void => {
       assignRef(runtimeRefs.contentRef, value);
@@ -266,12 +277,30 @@ function useEditorMutators(
     [patchViewState, runtimeRefs],
   );
 
+  const setSynopsis = useCallback(
+    (value: string): void => {
+      assignRef(runtimeRefs.synopsisRef, value);
+      patchViewState({ synopsis: value, saveError: null });
+      markDirty(runtimeRefs, patchViewState);
+    },
+    [patchViewState, runtimeRefs],
+  );
+
+  const setBeats = useCallback(
+    (beats: SceneBeat[]): void => {
+      assignRef(runtimeRefs.beatsRef, beats);
+      patchViewState({ beats, saveError: null });
+      markDirty(runtimeRefs, patchViewState);
+    },
+    [patchViewState, runtimeRefs],
+  );
+
   const retrySave = useCallback(async (): Promise<void> => {
     patchViewState({ saveError: null });
     await runSaveCycle();
   }, [patchViewState, runSaveCycle]);
 
-  return { setContent, setStatus, retrySave };
+  return { setContent, setStatus, setSynopsis, setBeats, retrySave };
 }
 
 export function useSceneEditor(input: UseSceneEditorInput): UseSceneEditorResult {
@@ -283,7 +312,7 @@ export function useSceneEditor(input: UseSceneEditorInput): UseSceneEditorResult
   useLoadScene(input, runtimeRefs, patchViewState, replaceViewState);
   useAutosave(runtimeRefs, viewState, runSaveCycle);
 
-  const { setContent, setStatus, retrySave } = useEditorMutators(
+  const { setContent, setStatus, setSynopsis, setBeats, retrySave } = useEditorMutators(
     runtimeRefs,
     patchViewState,
     runSaveCycle,
@@ -298,6 +327,8 @@ export function useSceneEditor(input: UseSceneEditorInput): UseSceneEditorResult
     scene: viewState.scene,
     content: viewState.content,
     status: viewState.status,
+    synopsis: viewState.synopsis,
+    beats: viewState.beats,
     wordCount,
     isDirty: viewState.isDirty,
     isSaving: viewState.isSaving,
@@ -308,6 +339,8 @@ export function useSceneEditor(input: UseSceneEditorInput): UseSceneEditorResult
     loadState: viewState.loadState,
     setContent,
     setStatus,
+    setSynopsis,
+    setBeats,
     retrySave,
   };
 }

--- a/src/test/scene/scene-beat.test.ts
+++ b/src/test/scene/scene-beat.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { sceneBeatSchema, sceneSchema } from '@/domain/scene/schemas';
+
+const validProjectId = '11111111-1111-4111-8111-111111111111';
+
+describe('Scene beat schema', () => {
+  it('validates a beat with valid type', () => {
+    const beat = { id: 'b1', content: 'Hero enters the room', type: 'setup' };
+    expect(() => sceneBeatSchema.parse(beat)).not.toThrow();
+  });
+
+  it('rejects beat with invalid type', () => {
+    const beat = { id: 'b1', content: 'Hero enters the room', type: 'invalid' };
+    expect(() => sceneBeatSchema.parse(beat)).toThrow();
+  });
+
+  it('accepts scene without synopsis or beats (backward compat)', () => {
+    const scene = {
+      id: 's1',
+      projectId: validProjectId,
+      title: 'Opening Scene',
+      content: '',
+      status: 'draft' as const,
+      updatedAt: '2026-02-27T00:00:00.000Z',
+    };
+    expect(() => sceneSchema.parse(scene)).not.toThrow();
+  });
+
+  it('accepts scene with synopsis and beats', () => {
+    const scene = {
+      id: 's1',
+      projectId: validProjectId,
+      title: 'Opening Scene',
+      content: '',
+      status: 'draft' as const,
+      updatedAt: '2026-02-27T00:00:00.000Z',
+      synopsis: 'Aria discovers the letter is missing.',
+      beats: [
+        { id: 'b1', content: 'Aria opens the drawer', type: 'setup' },
+        { id: 'b2', content: 'Aria realizes the letter is gone', type: 'revelation' },
+      ],
+    };
+    expect(() => sceneSchema.parse(scene)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Add `synopsis` (short sentence) and `beats` (ordered story beat list) as optional fields on each scene for pre-writing planning
- New collapsible **Scene Plan** panel in the scene editor above the textarea
- Synopsis displayed inline below scene title in the chapter outline
- Full autosave integration (800ms debounce) through domain → data stack
- Backward-compatible: existing scenes without these fields load and save without errors

## Commits

- `✨ feat: add SceneBeat type and synopsis/beats fields to Scene domain schema`
- `✨ feat: persist synopsis and beats through repository and service layers`
- `✨ feat: add SceneBeatPanel to scene editor with autosave integration`
- `✨ feat: show scene synopsis inline in chapter outline`
- `🐛 fix: replace crypto.randomUUID with non-secure-context-safe ID generation`

## Checklist

- [x] `npm run test:ci` passes (111/111 tests, lint clean, typecheck clean)
- [x] Scene Plan panel renders and toggles open/closed
- [x] Synopsis autosaves to localStorage
- [x] Beats add, edit type, edit content, delete — all autosave
- [x] Synopsis appears inline in chapter outline
- [x] No console errors
- [ ] Visual check: panel styling, beat row alignment, synopsis truncation
- [ ] Edge: 20 beats max, 300 char synopsis max, 200 char beat max
- [ ] Regression: status dropdown, word count, session timer, chapter actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Scene Beat Planner Feature — Release Notes

### Key Changes

**Frontend**
- Added collapsible "Scene Plan" panel in scene editor with synopsis input (max 300 characters) and beat management (add/edit/remove, max 20 beats at 200 characters each)
- Synopsis now displays inline below scene titles in the chapter outline (truncated to single line)
- Beat type selector with predefined categories (setup, conflict, resolution, action, dialogue, revelation)

**Domain & Architecture**
- Introduced `BeatType` enum and `SceneBeat` type with id, content, and type fields
- Extended `Scene` interface with optional `synopsis` (string) and `beats` (SceneBeat[]) fields
- Updated schemas (`sceneSchema`, `projectSceneSchema`, `saveSceneInputSchema`) to validate synopsis (max 300 chars) and beats (max 20, 200 chars each)

**Persistence & Autosave**
- Full autosave integration (800ms debounce) across domain → data stack
- Updated `ProjectRepository`, `LocalProjectRepository`, and `scene-editor-service` to persist synopsis and beats
- Runtime refs and mutators added for synopsis and beats via `use-scene-editor` hook
- Autosave triggers on synopsis or beats changes in addition to content and status

**Markdown Export**
- Updated export service to include synopsis in markdown output when present (prepended to scene content)

**Backward Compatibility**
- Existing scenes without synopsis/beats fields load and save without errors
- Optional fields gracefully omit from output when unset

**Bug Fix**
- Replaced `crypto.randomUUID` with Date.now + Math.random for beat ID generation (eliminates secure-context-only requirement)

### Testing
- All tests passing (111/111)
- Added `scene-beat.test.ts` covering beat schema validation and backward compatibility scenarios

### Affected Areas
- **Frontend**: Scene editor UI, chapter outline panel, component integration
- **Backend/Domain**: Type definitions, validation schemas, repository contracts
- **Data Layer**: Local persistence, autosave mechanism
- **Export**: Markdown generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->