### PR TITLE
✨ feat: add Codex Context System

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,10 +29,10 @@ domain/ → application/ → data/ → components/ → app/
 ```
 
 - **`src/domain/`** — Pure types, interfaces, and Zod schemas. No implementation. Defines `ProjectRepository` and `BibleRepository` interfaces.
-- **`src/application/`** — Business logic services (`ProjectService`, `ChapterService`, `BibleService`, `SceneEditorService`, `WritingSessionService`). Validated via Zod schemas. Depend only on domain interfaces.
+- **`src/application/`** — Business logic services (`ProjectService`, `ChapterService`, `BibleService`, `SceneEditorService`, `WritingSessionService`, `ExportService`). Validated via Zod schemas. Depend only on domain interfaces.
 - **`src/data/`** — Concrete repository implementations (`LocalProjectRepository`, `LocalBibleRepository`, `LocalWritingSessionRepository`). All persist exclusively to `window.localStorage`. No cloud/server dependency.
 - **`src/components/`** — React components organized by feature (`bible/`, `scene/`, `workspace/`, `writing-session/`). Page-level controllers (e.g. `bible-page-controller.ts`) are hooks that compose services and manage state.
-- **`src/hooks/`** — Shared hooks. `use-scene-editor.ts` (autosave, 800ms debounce) and `use-writing-session.ts` (live timer, word delta). Both isolate mutable refs in a companion `*-runtime.ts` hook to prevent stale closures.
+- **`src/hooks/`** — Shared hooks. `use-scene-editor.ts` (autosave, 800ms debounce) and `use-writing-session.ts` (live timer, word delta) isolate mutable refs in a companion `*-runtime.ts` hook to prevent stale closures. `use-codex-context.ts` scans scene content for story bible entity mentions (debounced 800ms, whole-word case-insensitive, max 10 results).
 - **`src/app/`** — Next.js App Router pages. All pages are client components (`'use client'`) due to localStorage dependency.
 
 ## Local Storage Keys
@@ -44,6 +44,8 @@ domain/ → application/ → data/ → components/ → app/
 | `ainkwell:projects:{id}:scenes:v1` | Bible's own scene list per project |
 | `ainkwell:projects:{id}:sessions:v1` | Writing sessions + daily goal per project |
 | `ainkwell:workspace:v1` | Legacy key — migrated automatically on first read |
+
+> **SSR gotcha:** `LocalBibleRepository` and `LocalWritingSessionRepository` fall back to `noOpStorage` when `typeof window === 'undefined'` (SSR). `LocalProjectRepository` uses `getStorage()` which returns `null` on the server — always guard writes with a null check.
 
 ## Code Conventions
 

--- a/docs/plans/2026-03-02-codex-context-system.plan.md
+++ b/docs/plans/2026-03-02-codex-context-system.plan.md
@@ -1,18 +1,20 @@
 ---
 name: Codex Context System
 overview: When a scene is open in the editor, automatically detect which story bible entities are mentioned in the content and surface their summaries — the context injection infrastructure for future AI assistance.
+status: in-progress
+pr: 13
 todos:
   - id: 1
     content: "Build useCodexContext hook: scans scene content for entity name matches"
-    status: pending
+    status: done
     dependencies: []
   - id: 2
     content: "Build CodexContextPanel component to display matched entities"
-    status: pending
+    status: done
     dependencies: [1]
   - id: 3
     content: "Integrate panel into scene editor shell"
-    status: pending
+    status: done
     dependencies: [2]
 ---
 

--- a/docs/plans/2026-03-02-export-import.plan.md
+++ b/docs/plans/2026-03-02-export-import.plan.md
@@ -1,30 +1,33 @@
 ---
 name: Export & Import
 overview: Allow writers to export their projects as JSON (backup/restore) and as Markdown (portability), and import from JSON backup.
+status: done
+merged: "2026-03-02"
+pr: 11
 todos:
   - id: 1
     content: "Define ExportService in application layer with exportProjectJson, importProjectJson, exportProjectMarkdown"
-    status: pending
+    status: done
     dependencies: []
   - id: 2
     content: "Add exportProject/importProject methods to ProjectRepository interface"
-    status: pending
+    status: done
     dependencies: []
   - id: 3
     content: "Implement export/import in LocalProjectRepository"
-    status: pending
+    status: done
     dependencies: [1, 2]
   - id: 4
     content: "Build ExportImportPanel component"
-    status: pending
+    status: done
     dependencies: [3]
   - id: 5
     content: "Integrate panel into workspace project detail page"
-    status: pending
+    status: done
     dependencies: [4]
   - id: 6
     content: "Write tests for ExportService"
-    status: pending
+    status: done
     dependencies: [1]
 ---
 

--- a/docs/plans/2026-03-02-scene-beat-planner.plan.md
+++ b/docs/plans/2026-03-02-scene-beat-planner.plan.md
@@ -1,26 +1,29 @@
 ---
 name: Scene Beat Planner
 overview: Add a synopsis field and beat cards per scene so writers can plan scenes before writing them — the structured data foundation for future AI assistance.
+status: done
+merged: "2026-03-02"
+pr: 12
 todos:
   - id: 1
     content: "Extend Scene domain type with synopsis and beats fields"
-    status: pending
+    status: done
     dependencies: []
   - id: 2
     content: "Update LocalProjectRepository to persist synopsis/beats"
-    status: pending
+    status: done
     dependencies: [1]
   - id: 3
     content: "Update SceneEditorService to pass through synopsis/beats"
-    status: pending
+    status: done
     dependencies: [2]
   - id: 4
     content: "Build SceneBeatPanel component for scene editor"
-    status: pending
+    status: done
     dependencies: [3]
   - id: 5
     content: "Add inline synopsis to chapter outline panel"
-    status: pending
+    status: done
     dependencies: [3]
 ---
 

--- a/docs/plans/codex-context-system.plan.md
+++ b/docs/plans/codex-context-system.plan.md
@@ -1,0 +1,363 @@
+---
+name: Codex Context System
+overview: When a scene is open in the editor, automatically detect which story bible entities are mentioned in the content and surface their summaries — the context injection infrastructure for future AI assistance.
+todos:
+  - id: 1
+    content: "Build useCodexContext hook: scans scene content for entity name matches"
+    status: pending
+    dependencies: []
+  - id: 2
+    content: "Build CodexContextPanel component to display matched entities"
+    status: pending
+    dependencies: [1]
+  - id: 3
+    content: "Integrate panel into scene editor shell"
+    status: pending
+    dependencies: [2]
+---
+
+# Codex Context System — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** As a writer types in the scene editor, the app scans the content for story bible entity names and surfaces their summaries in a side panel — no manual linking required. Becomes the context injection layer when Claude API is added.
+
+**Architecture:** New `useCodexContext` hook (debounced 800ms, reads from `BibleService`). New `CodexContextPanel` renders matched entities. No new storage. Integrates into scene editor shell as a collapsible right panel.
+
+**Tech Stack:** Next.js 15, TypeScript, React, Tailwind CSS, existing `BibleService`
+
+---
+
+## Overview
+
+Example: Writer types "Aria stepped into the Hollow Tower". The Codex panel shows:
+- **Aria** (Character) — "The protagonist, a former archivist haunted by a lost manuscript"
+- **Hollow Tower** (Location) — "An ancient lighthouse at the edge of the Dead Meridian"
+
+### Matching Strategy
+
+- Case-insensitive, whole-word matching (avoids "Ark" matching inside "darkness")
+- Sorted by order of first mention in text
+- Max 10 entities shown
+- Debounced 800ms after last keystroke (same interval as autosave)
+
+---
+
+## Implementation Steps
+
+### Task 1: useCodexContext hook
+
+**Files:**
+- Create: `src/hooks/use-codex-context.ts`
+- Create: `src/test/hooks/use-codex-context.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useCodexContext } from '@/hooks/use-codex-context';
+import type { BibleService } from '@/application/bible/bible-service';
+import type { BibleEntity } from '@/domain/bible/bible';
+
+describe('useCodexContext', () => {
+  const makeEntity = (name: string): BibleEntity => ({
+    id: `e-${name}`, projectId: 'p1', category: 'character', name,
+    summary: `Summary of ${name}`, details: '', tags: [],
+    createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+  });
+
+  it('returns empty array when content is empty', async () => {
+    const mockService = {
+      listEntities: vi.fn().mockResolvedValue([makeEntity('Aria')]),
+    } as unknown as BibleService;
+
+    const { result } = renderHook(() =>
+      useCodexContext({ projectId: 'p1', content: '', service: mockService }),
+    );
+    expect(result.current.matchedEntities).toEqual([]);
+  });
+
+  it('detects entity name mentions in content', async () => {
+    vi.useFakeTimers();
+    const aria = makeEntity('Aria');
+    const marcus = makeEntity('Marcus');
+    const mockService = {
+      listEntities: vi.fn().mockResolvedValue([aria, marcus]),
+    } as unknown as BibleService;
+
+    const { result } = renderHook(() =>
+      useCodexContext({ projectId: 'p1', content: 'Aria walked toward Marcus.', service: mockService }),
+    );
+
+    await act(async () => { vi.advanceTimersByTime(800); });
+
+    expect(result.current.matchedEntities).toHaveLength(2);
+    vi.useRealTimers();
+  });
+
+  it('is case-insensitive', async () => {
+    vi.useFakeTimers();
+    const aria = makeEntity('Aria');
+    const mockService = {
+      listEntities: vi.fn().mockResolvedValue([aria]),
+    } as unknown as BibleService;
+
+    const { result } = renderHook(() =>
+      useCodexContext({ projectId: 'p1', content: 'ARIA entered the room.', service: mockService }),
+    );
+
+    await act(async () => { vi.advanceTimersByTime(800); });
+    expect(result.current.matchedEntities).toHaveLength(1);
+    vi.useRealTimers();
+  });
+
+  it('does not match substrings (whole-word only)', async () => {
+    vi.useFakeTimers();
+    const ark = makeEntity('Ark');
+    const mockService = {
+      listEntities: vi.fn().mockResolvedValue([ark]),
+    } as unknown as BibleService;
+
+    const { result } = renderHook(() =>
+      useCodexContext({ projectId: 'p1', content: 'darkness fell', service: mockService }),
+    );
+
+    await act(async () => { vi.advanceTimersByTime(800); });
+    expect(result.current.matchedEntities).toHaveLength(0);
+    vi.useRealTimers();
+  });
+});
+```
+
+**Step 2: Run test — expect FAIL**
+```bash
+npx vitest run src/test/hooks/use-codex-context.test.ts
+```
+
+**Step 3: Implement the hook**
+
+```ts
+import { useEffect, useRef, useState } from 'react';
+import type { BibleEntity } from '@/domain/bible/bible';
+import type { BibleService } from '@/application/bible/bible-service';
+
+const DEBOUNCE_MS = 800;
+const MAX_MATCHES = 10;
+
+type UseCodexContextInput = {
+  projectId: string;
+  content: string;
+  service: BibleService;
+};
+
+type UseCodexContextResult = {
+  matchedEntities: BibleEntity[];
+};
+
+export function useCodexContext({ projectId, content, service }: UseCodexContextInput): UseCodexContextResult {
+  const [matchedEntities, setMatchedEntities] = useState<BibleEntity[]>([]);
+  const allEntitiesRef = useRef<BibleEntity[]>([]);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    service.listEntities(projectId).then((entities) => {
+      allEntitiesRef.current = entities;
+    });
+  }, [projectId, service]);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    debounceRef.current = setTimeout(() => {
+      const matches = findMentionedEntities(content, allEntitiesRef.current);
+      setMatchedEntities(matches.slice(0, MAX_MATCHES));
+    }, DEBOUNCE_MS);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [content]);
+
+  return { matchedEntities };
+}
+
+function findMentionedEntities(content: string, entities: BibleEntity[]): BibleEntity[] {
+  if (!content.trim()) return [];
+  const mentioned: BibleEntity[] = [];
+  const seenIds = new Set<string>();
+
+  for (const entity of entities) {
+    if (seenIds.has(entity.id)) continue;
+    const pattern = new RegExp(`\\b${escapeRegex(entity.name)}\\b`, 'i');
+    if (pattern.test(content)) {
+      mentioned.push(entity);
+      seenIds.add(entity.id);
+    }
+  }
+  return mentioned;
+}
+
+function escapeRegex(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+```
+
+**Step 4: Run test — expect PASS**
+```bash
+npx vitest run src/test/hooks/use-codex-context.test.ts
+```
+
+**Step 5: Commit**
+```bash
+git add src/hooks/use-codex-context.ts src/test/hooks/use-codex-context.test.ts
+git commit -m "✨ feat: add useCodexContext hook for entity mention detection"
+```
+
+---
+
+### Task 2: CodexContextPanel component
+
+**Files:**
+- Create: `src/components/scene/codex-context-panel.tsx`
+
+**Step 1: Build the component**
+
+```tsx
+'use client';
+import type { ReactElement } from 'react';
+import { useState } from 'react';
+import type { BibleEntity } from '@/domain/bible/bible';
+
+const CATEGORY_LABELS: Record<BibleEntity['category'], string> = {
+  character: 'Character', location: 'Location', faction: 'Faction', lore: 'Lore',
+};
+
+const CATEGORY_COLORS: Record<BibleEntity['category'], string> = {
+  character: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+  location: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+  faction: 'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300',
+  lore: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300',
+};
+
+type Props = { entities: BibleEntity[] };
+
+export function CodexContextPanel({ entities }: Props): ReactElement {
+  const [isOpen, setIsOpen] = useState(true);
+
+  if (entities.length === 0) return <></>;
+
+  return (
+    <div className="w-64 shrink-0 border-l border-border bg-card">
+      <button
+        className="flex w-full items-center justify-between px-4 py-2 text-sm font-medium text-foreground"
+        onClick={() => setIsOpen((v) => !v)}
+        type="button"
+      >
+        <span>Codex ({entities.length})</span>
+        <span className="text-muted-foreground">{isOpen ? '▶' : '◀'}</span>
+      </button>
+      {isOpen && (
+        <div className="space-y-2 overflow-y-auto px-3 pb-4" style={{ maxHeight: 'calc(100vh - 120px)' }}>
+          {entities.map((entity) => (
+            <div className="rounded-md border border-border bg-background p-2" key={entity.id}>
+              <div className="mb-1 flex items-center gap-2">
+                <span className={`rounded px-1.5 py-0.5 text-xs font-medium ${CATEGORY_COLORS[entity.category]}`}>
+                  {CATEGORY_LABELS[entity.category]}
+                </span>
+                <span className="text-sm font-medium text-foreground">{entity.name}</span>
+              </div>
+              {entity.summary && (
+                <p className="text-xs text-muted-foreground line-clamp-3">{entity.summary}</p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+**Step 2: Commit**
+```bash
+git add src/components/scene/codex-context-panel.tsx
+git commit -m "✨ feat: add CodexContextPanel component"
+```
+
+---
+
+### Task 3: Integrate into scene editor shell
+
+**Files:**
+- Modify: `src/components/scene/scene-editor-shell.tsx`
+
+**Step 1: Read the file**
+Read `src/components/scene/scene-editor-shell.tsx`.
+
+**Step 2: Wire up the hook and panel**
+
+Add imports at top:
+```ts
+import { useMemo } from 'react';
+import { useCodexContext } from '@/hooks/use-codex-context';
+import { CodexContextPanel } from './codex-context-panel';
+import { BibleService } from '@/application/bible/bible-service';
+import { LocalBibleRepository } from '@/data/bible/local-bible-repository';
+```
+
+Inside the component:
+```ts
+const bibleService = useMemo(() => new BibleService(new LocalBibleRepository()), []);
+const { matchedEntities } = useCodexContext({
+  projectId,
+  content: viewState.content,
+  service: bibleService,
+});
+```
+
+Update the JSX layout to add the panel to the right of the textarea:
+```tsx
+<div className="flex flex-1 overflow-hidden">
+  <textarea className="flex-1 resize-none ..." />
+  <CodexContextPanel entities={matchedEntities} />
+</div>
+```
+
+**Step 3: Run full test suite**
+```bash
+npm run test:ci
+```
+
+**Step 4: Commit**
+```bash
+git add src/components/scene/scene-editor-shell.tsx
+git commit -m "✨ feat: integrate CodexContextPanel into scene editor shell"
+```
+
+---
+
+## Files Summary
+
+| Action | Path |
+|--------|------|
+| Create | `src/hooks/use-codex-context.ts` |
+| Create | `src/components/scene/codex-context-panel.tsx` |
+| Modify | `src/components/scene/scene-editor-shell.tsx` |
+| Create | `src/test/hooks/use-codex-context.test.ts` |
+
+---
+
+## AI Readiness
+
+When the AI Writing Assistant is added, `matchedEntities` becomes the context payload:
+
+```ts
+// Future usage:
+const systemPrompt = [
+  'You are a writing assistant. Here is the story context:',
+  ...matchedEntities.map((e) => `- ${e.name} (${e.category}): ${e.summary}`),
+].join('\n');
+```
+
+This is exactly how NovelCrafter injects Codex entries into its AI context window.

--- a/src/application/bible/create-bible-service.ts
+++ b/src/application/bible/create-bible-service.ts
@@ -1,0 +1,7 @@
+import { LocalBibleRepository } from '@/data/bible/local-bible-repository';
+
+import { BibleService } from './bible-service';
+
+export function createBibleService(): BibleService {
+  return new BibleService(new LocalBibleRepository());
+}

--- a/src/components/scene/codex-context-panel.tsx
+++ b/src/components/scene/codex-context-panel.tsx
@@ -1,7 +1,7 @@
 'use client';
 import type { ReactElement } from 'react';
 import { useState } from 'react';
-import type { BibleEntity } from '@/domain/bible/bible';
+import type { BibleEntity } from '@/domain/bible/types';
 
 const CATEGORY_LABELS: Record<BibleEntity['category'], string> = {
   character: 'Character', location: 'Location', faction: 'Faction', lore: 'Lore',

--- a/src/components/scene/codex-context-panel.tsx
+++ b/src/components/scene/codex-context-panel.tsx
@@ -1,0 +1,53 @@
+'use client';
+import type { ReactElement } from 'react';
+import { useState } from 'react';
+import type { BibleEntity } from '@/domain/bible/bible';
+
+const CATEGORY_LABELS: Record<BibleEntity['category'], string> = {
+  character: 'Character', location: 'Location', faction: 'Faction', lore: 'Lore',
+};
+
+const CATEGORY_COLORS: Record<BibleEntity['category'], string> = {
+  character: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+  location: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+  faction: 'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300',
+  lore: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300',
+};
+
+type Props = { entities: BibleEntity[] };
+
+export function CodexContextPanel({ entities }: Props): ReactElement {
+  const [isOpen, setIsOpen] = useState(true);
+
+  if (entities.length === 0) return <></>;
+
+  return (
+    <div className="w-64 shrink-0 border-l border-border bg-card">
+      <button
+        className="flex w-full items-center justify-between px-4 py-2 text-sm font-medium text-foreground"
+        onClick={() => setIsOpen((v) => !v)}
+        type="button"
+      >
+        <span>Codex ({entities.length})</span>
+        <span className="text-muted-foreground">{isOpen ? '▶' : '◀'}</span>
+      </button>
+      {isOpen && (
+        <div className="space-y-2 overflow-y-auto px-3 pb-4" style={{ maxHeight: 'calc(100vh - 120px)' }}>
+          {entities.map((entity) => (
+            <div className="rounded-md border border-border bg-background p-2" key={entity.id}>
+              <div className="mb-1 flex items-center gap-2">
+                <span className={`rounded px-1.5 py-0.5 text-xs font-medium ${CATEGORY_COLORS[entity.category]}`}>
+                  {CATEGORY_LABELS[entity.category]}
+                </span>
+                <span className="text-sm font-medium text-foreground">{entity.name}</span>
+              </div>
+              {entity.summary && (
+                <p className="text-xs text-muted-foreground line-clamp-3">{entity.summary}</p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/scene/codex-context-panel.tsx
+++ b/src/components/scene/codex-context-panel.tsx
@@ -24,15 +24,17 @@ export function CodexContextPanel({ entities }: Props): ReactElement {
   return (
     <div className="w-64 shrink-0 border-l border-border bg-card">
       <button
+        aria-controls="codex-panel-content"
+        aria-expanded={isOpen}
         className="flex w-full items-center justify-between px-4 py-2 text-sm font-medium text-foreground"
         onClick={() => setIsOpen((v) => !v)}
         type="button"
       >
         <span>Codex ({entities.length})</span>
-        <span className="text-muted-foreground">{isOpen ? '▶' : '◀'}</span>
+        <span aria-hidden="true" className="text-muted-foreground">{isOpen ? '▶' : '◀'}</span>
       </button>
       {isOpen && (
-        <div className="space-y-2 overflow-y-auto px-3 pb-4" style={{ maxHeight: 'calc(100vh - 120px)' }}>
+        <div className="space-y-2 overflow-y-auto px-3 pb-4" id="codex-panel-content" style={{ maxHeight: 'calc(100vh - 120px)' }}>
           {entities.map((entity) => (
             <div className="rounded-md border border-border bg-background p-2" key={entity.id}>
               <div className="mb-1 flex items-center gap-2">

--- a/src/components/scene/scene-editor-shell.tsx
+++ b/src/components/scene/scene-editor-shell.tsx
@@ -5,6 +5,7 @@ import type { ReactElement } from 'react';
 import { useCallback, useContext, useMemo } from 'react';
 
 import { BibleService } from '@/application/bible/bible-service';
+import { createBibleService as createDefaultBibleService } from '@/application/bible/create-bible-service';
 import {
   SceneEditorService,
   type SceneEditorServicePort,
@@ -15,7 +16,7 @@ import { SceneBeatPanel } from '@/components/scene/scene-beat-panel';
 import { SceneToolbar } from '@/components/scene/scene-toolbar';
 import { SessionTimer } from '@/components/writing-session/session-timer';
 import { WritingSessionContext } from '@/context/writing-session-context';
-import { LocalBibleRepository } from '@/data/bible/local-bible-repository';
+
 import { LocalProjectRepository } from '@/data/project/local-project-repository';
 import { LocalWritingSessionRepository } from '@/data/writing-session/local-writing-session-repository';
 import type { BibleEntity } from '@/domain/bible/types';
@@ -37,8 +38,7 @@ const createSceneEditorService = (): SceneEditorServicePort =>
 const createWritingSessionService = (): WritingSessionService =>
   new WritingSessionService(new LocalWritingSessionRepository());
 
-const createBibleService = (): BibleService =>
-  new BibleService(new LocalBibleRepository());
+const createBibleService = (): BibleService => createDefaultBibleService();
 
 function useShellServices(props: Pick<SceneEditorShellProps, 'service' | 'writingService' | 'bibleService'>) {
   const service = useMemo(() => props.service ?? createSceneEditorService(), [props.service]);
@@ -189,7 +189,15 @@ type SceneContentSectionProps = {
   onBeatsChange: (beats: import('@/domain/scene/schemas').SceneBeat[]) => void;
 };
 
-function SceneContentSection({ content, onContentChange, matchedEntities, synopsis, beats, onSynopsisChange, onBeatsChange }: SceneContentSectionProps): ReactElement {
+function SceneContentSection({
+  content,
+  onContentChange,
+  matchedEntities,
+  synopsis,
+  beats,
+  onSynopsisChange,
+  onBeatsChange,
+}: SceneContentSectionProps): ReactElement {
   return (
     <section className="flex flex-1 flex-col overflow-hidden rounded-xl border bg-card text-card-foreground">
       <SceneBeatPanel

--- a/src/components/scene/scene-editor-shell.tsx
+++ b/src/components/scene/scene-editor-shell.tsx
@@ -8,12 +8,16 @@ import {
   SceneEditorService,
   type SceneEditorServicePort,
 } from '@/application/scene/scene-editor-service';
+import { BibleService } from '@/application/bible/bible-service';
 import { WritingSessionService } from '@/application/writing-session/writing-session-service';
+import { CodexContextPanel } from '@/components/scene/codex-context-panel';
 import { SceneToolbar } from '@/components/scene/scene-toolbar';
 import { SessionTimer } from '@/components/writing-session/session-timer';
 import { WritingSessionContext } from '@/context/writing-session-context';
+import { LocalBibleRepository } from '@/data/bible/local-bible-repository';
 import { LocalProjectRepository } from '@/data/project/local-project-repository';
 import { LocalWritingSessionRepository } from '@/data/writing-session/local-writing-session-repository';
+import { useCodexContext } from '@/hooks/use-codex-context';
 import { useSceneEditor, type UseSceneEditorResult } from '@/hooks/use-scene-editor';
 import { useWritingSession } from '@/hooks/use-writing-session';
 
@@ -22,6 +26,7 @@ type SceneEditorShellProps = {
   sceneId: string;
   service?: SceneEditorServicePort;
   writingService?: WritingSessionService;
+  bibleService?: BibleService;
 };
 
 const createSceneEditorService = (): SceneEditorServicePort =>
@@ -29,6 +34,9 @@ const createSceneEditorService = (): SceneEditorServicePort =>
 
 const createWritingSessionService = (): WritingSessionService =>
   new WritingSessionService(new LocalWritingSessionRepository());
+
+const createBibleService = (): BibleService =>
+  new BibleService(new LocalBibleRepository());
 
 type SceneStateViewProps = {
   projectId: string;
@@ -160,9 +168,16 @@ type SceneEditorLoadedViewProps = {
   sessionElapsedSeconds: number;
   onSessionStart: () => void;
   onSessionStop: () => Promise<void>;
+  bibleService: BibleService;
 };
 
 function SceneEditorLoadedView(props: SceneEditorLoadedViewProps): ReactElement {
+  const { matchedEntities } = useCodexContext({
+    projectId: props.projectId,
+    content: props.sceneEditor.content,
+    service: props.bibleService,
+  });
+
   if (!props.sceneEditor.scene) {
     return (
       <main className="mx-auto flex min-h-screen w-full max-w-5xl items-center justify-center px-4 py-8">
@@ -192,16 +207,19 @@ function SceneEditorLoadedView(props: SceneEditorLoadedViewProps): ReactElement 
         onStop={props.onSessionStop}
       />
 
-      <section className="flex-1 rounded-xl border bg-card p-4 text-card-foreground">
-        <label htmlFor="scene-content" className="mb-2 block text-sm font-medium">
-          Markdown content
-        </label>
-        <textarea
-          id="scene-content"
-          value={props.sceneEditor.content}
-          onChange={(event) => props.sceneEditor.setContent(event.target.value)}
-          className="min-h-[60vh] w-full resize-y rounded-md border bg-background p-3 font-mono text-sm"
-        />
+      <section className="flex flex-1 overflow-hidden rounded-xl border bg-card text-card-foreground">
+        <div className="flex flex-1 flex-col p-4">
+          <label htmlFor="scene-content" className="mb-2 block text-sm font-medium">
+            Markdown content
+          </label>
+          <textarea
+            id="scene-content"
+            value={props.sceneEditor.content}
+            onChange={(event) => props.sceneEditor.setContent(event.target.value)}
+            className="min-h-[60vh] flex-1 w-full resize-y rounded-md border bg-background p-3 font-mono text-sm"
+          />
+        </div>
+        <CodexContextPanel entities={matchedEntities} />
       </section>
 
       <SceneEditorNavigation
@@ -222,6 +240,11 @@ export function SceneEditorShell(props: SceneEditorShellProps): ReactElement {
   const writingService = useMemo<WritingSessionService>(
     () => props.writingService ?? createWritingSessionService(),
     [props.writingService],
+  );
+
+  const bibleService = useMemo<BibleService>(
+    () => props.bibleService ?? createBibleService(),
+    [props.bibleService],
   );
 
   const contextSession = useContext(WritingSessionContext);
@@ -257,6 +280,7 @@ export function SceneEditorShell(props: SceneEditorShellProps): ReactElement {
       sessionElapsedSeconds={writingSession.elapsedSeconds}
       onSessionStart={writingSession.startSession}
       onSessionStop={handleSessionStop}
+      bibleService={bibleService}
     />
   );
 }

--- a/src/components/scene/scene-editor-shell.tsx
+++ b/src/components/scene/scene-editor-shell.tsx
@@ -4,11 +4,11 @@ import Link from 'next/link';
 import type { ReactElement } from 'react';
 import { useCallback, useContext, useMemo } from 'react';
 
+import { BibleService } from '@/application/bible/bible-service';
 import {
   SceneEditorService,
   type SceneEditorServicePort,
 } from '@/application/scene/scene-editor-service';
-import { BibleService } from '@/application/bible/bible-service';
 import { WritingSessionService } from '@/application/writing-session/writing-session-service';
 import { CodexContextPanel } from '@/components/scene/codex-context-panel';
 import { SceneToolbar } from '@/components/scene/scene-toolbar';
@@ -17,6 +17,7 @@ import { WritingSessionContext } from '@/context/writing-session-context';
 import { LocalBibleRepository } from '@/data/bible/local-bible-repository';
 import { LocalProjectRepository } from '@/data/project/local-project-repository';
 import { LocalWritingSessionRepository } from '@/data/writing-session/local-writing-session-repository';
+import type { BibleEntity } from '@/domain/bible/types';
 import { useCodexContext } from '@/hooks/use-codex-context';
 import { useSceneEditor, type UseSceneEditorResult } from '@/hooks/use-scene-editor';
 import { useWritingSession } from '@/hooks/use-writing-session';
@@ -37,6 +38,16 @@ const createWritingSessionService = (): WritingSessionService =>
 
 const createBibleService = (): BibleService =>
   new BibleService(new LocalBibleRepository());
+
+function useShellServices(props: Pick<SceneEditorShellProps, 'service' | 'writingService' | 'bibleService'>) {
+  const service = useMemo(() => props.service ?? createSceneEditorService(), [props.service]);
+  const writingService = useMemo(
+    () => props.writingService ?? createWritingSessionService(),
+    [props.writingService],
+  );
+  const bibleService = useMemo(() => props.bibleService ?? createBibleService(), [props.bibleService]);
+  return { service, writingService, bibleService };
+}
 
 type SceneStateViewProps = {
   projectId: string;
@@ -96,6 +107,12 @@ const getSceneLoadErrorView = (
         Back to workspace
       </Link>
     </div>
+  </main>
+);
+
+const getSceneNotLoadedView = (): ReactElement => (
+  <main className="mx-auto flex min-h-screen w-full max-w-5xl items-center justify-center px-4 py-8">
+    <p className="text-muted-foreground">Scene not found</p>
   </main>
 );
 
@@ -161,6 +178,31 @@ function SceneEditorNavigation(props: SceneEditorNavigationProps): ReactElement 
   );
 }
 
+type SceneContentSectionProps = {
+  content: string;
+  onContentChange: (value: string) => void;
+  matchedEntities: BibleEntity[];
+};
+
+function SceneContentSection({ content, onContentChange, matchedEntities }: SceneContentSectionProps): ReactElement {
+  return (
+    <section className="flex flex-1 overflow-hidden rounded-xl border bg-card text-card-foreground">
+      <div className="flex flex-1 flex-col p-4">
+        <label htmlFor="scene-content" className="mb-2 block text-sm font-medium">
+          Markdown content
+        </label>
+        <textarea
+          id="scene-content"
+          value={content}
+          onChange={(event) => onContentChange(event.target.value)}
+          className="min-h-[60vh] flex-1 w-full resize-y rounded-md border bg-background p-3 font-mono text-sm"
+        />
+      </div>
+      <CodexContextPanel entities={matchedEntities} />
+    </section>
+  );
+}
+
 type SceneEditorLoadedViewProps = {
   projectId: string;
   sceneEditor: UseSceneEditorResult;
@@ -178,13 +220,7 @@ function SceneEditorLoadedView(props: SceneEditorLoadedViewProps): ReactElement 
     service: props.bibleService,
   });
 
-  if (!props.sceneEditor.scene) {
-    return (
-      <main className="mx-auto flex min-h-screen w-full max-w-5xl items-center justify-center px-4 py-8">
-        <p className="text-muted-foreground">Scene not found</p>
-      </main>
-    );
-  }
+  if (!props.sceneEditor.scene) return getSceneNotLoadedView();
 
   return (
     <main className="mx-auto flex min-h-screen w-full max-w-5xl flex-col gap-4 px-4 py-8">
@@ -207,20 +243,11 @@ function SceneEditorLoadedView(props: SceneEditorLoadedViewProps): ReactElement 
         onStop={props.onSessionStop}
       />
 
-      <section className="flex flex-1 overflow-hidden rounded-xl border bg-card text-card-foreground">
-        <div className="flex flex-1 flex-col p-4">
-          <label htmlFor="scene-content" className="mb-2 block text-sm font-medium">
-            Markdown content
-          </label>
-          <textarea
-            id="scene-content"
-            value={props.sceneEditor.content}
-            onChange={(event) => props.sceneEditor.setContent(event.target.value)}
-            className="min-h-[60vh] flex-1 w-full resize-y rounded-md border bg-background p-3 font-mono text-sm"
-          />
-        </div>
-        <CodexContextPanel entities={matchedEntities} />
-      </section>
+      <SceneContentSection
+        content={props.sceneEditor.content}
+        onContentChange={props.sceneEditor.setContent}
+        matchedEntities={matchedEntities}
+      />
 
       <SceneEditorNavigation
         projectId={props.projectId}
@@ -232,21 +259,7 @@ function SceneEditorLoadedView(props: SceneEditorLoadedViewProps): ReactElement 
 }
 
 export function SceneEditorShell(props: SceneEditorShellProps): ReactElement {
-  const service = useMemo<SceneEditorServicePort>(
-    () => props.service ?? createSceneEditorService(),
-    [props.service],
-  );
-
-  const writingService = useMemo<WritingSessionService>(
-    () => props.writingService ?? createWritingSessionService(),
-    [props.writingService],
-  );
-
-  const bibleService = useMemo<BibleService>(
-    () => props.bibleService ?? createBibleService(),
-    [props.bibleService],
-  );
-
+  const { service, writingService, bibleService } = useShellServices(props);
   const contextSession = useContext(WritingSessionContext);
   const localSession = useWritingSession({ projectId: props.projectId, service: writingService });
   const writingSession = contextSession ?? localSession;

--- a/src/data/bible/local-bible-repository.ts
+++ b/src/data/bible/local-bible-repository.ts
@@ -57,6 +57,24 @@ function upsertRecord<T extends { id: string }>(records: T[], record: T): void {
   }
 }
 
+const noOpStorage: Storage = {
+  getItem: () => null,
+  setItem: () => undefined,
+  removeItem: () => undefined,
+  clear: () => undefined,
+  key: () => null,
+  length: 0,
+};
+
+const unavailableStorage: Storage = {
+  getItem: () => null,
+  setItem: () => { throw new Error('Storage backend is unavailable'); },
+  removeItem: () => { throw new Error('Storage backend is unavailable'); },
+  clear: () => { throw new Error('Storage backend is unavailable'); },
+  key: () => null,
+  length: 0,
+};
+
 export class LocalBibleRepository implements BibleRepository {
   private readonly storage: Storage;
 
@@ -71,7 +89,7 @@ export class LocalBibleRepository implements BibleRepository {
       return;
     }
 
-    throw new Error('Storage backend is unavailable');
+    this.storage = typeof window === 'undefined' ? noOpStorage : unavailableStorage;
   }
 
   public listEntities(projectId: string, filters?: BibleEntityFilters): BibleEntity[] {

--- a/src/hooks/use-codex-context.ts
+++ b/src/hooks/use-codex-context.ts
@@ -5,6 +5,7 @@ import type { BibleEntity } from '@/domain/bible/types';
 
 const DEBOUNCE_MS = 800;
 const MAX_MATCHES = 10;
+const MAX_ENTITY_NAME_LENGTH = 100;
 
 type UseCodexContextInput = {
   projectId: string;
@@ -44,6 +45,7 @@ function findMentionedEntities(content: string, entities: BibleEntity[]): BibleE
 
   for (const entity of entities) {
     if (seenIds.has(entity.id)) continue;
+    if (entity.name.length > MAX_ENTITY_NAME_LENGTH) continue;
     const pattern = new RegExp(`\\b${escapeRegex(entity.name)}\\b`, 'i');
     if (pattern.test(content)) {
       mentioned.push(entity);

--- a/src/hooks/use-codex-context.ts
+++ b/src/hooks/use-codex-context.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 
-import type { BibleEntity } from '@/domain/bible/types';
 import type { BibleService } from '@/application/bible/bible-service';
+import type { BibleEntity } from '@/domain/bible/types';
 
 const DEBOUNCE_MS = 800;
 const MAX_MATCHES = 10;

--- a/src/hooks/use-codex-context.ts
+++ b/src/hooks/use-codex-context.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
-import type { BibleEntity } from '@/domain/bible/bible';
+import type { BibleEntity } from '@/domain/bible/types';
 import type { BibleService } from '@/application/bible/bible-service';
 
 const DEBOUNCE_MS = 800;
@@ -24,10 +24,9 @@ export function useCodexContext({ projectId, content, service }: UseCodexContext
     if (debounceRef.current) clearTimeout(debounceRef.current);
 
     debounceRef.current = setTimeout(() => {
-      service.listEntities(projectId).then((entities) => {
-        const matches = findMentionedEntities(content, entities);
-        setMatchedEntities(matches.slice(0, MAX_MATCHES));
-      });
+      const entities = service.listEntities(projectId);
+      const matches = findMentionedEntities(content, entities);
+      setMatchedEntities(matches.slice(0, MAX_MATCHES));
     }, DEBOUNCE_MS);
 
     return () => {

--- a/src/hooks/use-codex-context.ts
+++ b/src/hooks/use-codex-context.ts
@@ -1,0 +1,59 @@
+import { useEffect, useRef, useState } from 'react';
+
+import type { BibleEntity } from '@/domain/bible/bible';
+import type { BibleService } from '@/application/bible/bible-service';
+
+const DEBOUNCE_MS = 800;
+const MAX_MATCHES = 10;
+
+type UseCodexContextInput = {
+  projectId: string;
+  content: string;
+  service: BibleService;
+};
+
+type UseCodexContextResult = {
+  matchedEntities: BibleEntity[];
+};
+
+export function useCodexContext({ projectId, content, service }: UseCodexContextInput): UseCodexContextResult {
+  const [matchedEntities, setMatchedEntities] = useState<BibleEntity[]>([]);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    debounceRef.current = setTimeout(() => {
+      service.listEntities(projectId).then((entities) => {
+        const matches = findMentionedEntities(content, entities);
+        setMatchedEntities(matches.slice(0, MAX_MATCHES));
+      });
+    }, DEBOUNCE_MS);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [content, projectId, service]);
+
+  return { matchedEntities };
+}
+
+function findMentionedEntities(content: string, entities: BibleEntity[]): BibleEntity[] {
+  if (!content.trim()) return [];
+  const mentioned: BibleEntity[] = [];
+  const seenIds = new Set<string>();
+
+  for (const entity of entities) {
+    if (seenIds.has(entity.id)) continue;
+    const pattern = new RegExp(`\\b${escapeRegex(entity.name)}\\b`, 'i');
+    if (pattern.test(content)) {
+      mentioned.push(entity);
+      seenIds.add(entity.id);
+    }
+  }
+  return mentioned;
+}
+
+function escapeRegex(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/test/hooks/use-codex-context.test.ts
+++ b/src/test/hooks/use-codex-context.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useCodexContext } from '@/hooks/use-codex-context';
+import type { BibleService } from '@/application/bible/bible-service';
+import type { BibleEntity } from '@/domain/bible/bible';
+
+describe('useCodexContext', () => {
+  const makeEntity = (name: string): BibleEntity => ({
+    id: `e-${name}`, projectId: 'p1', category: 'character', name,
+    summary: `Summary of ${name}`, details: '', tags: [],
+    createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+  });
+
+  it('returns empty array when content is empty', async () => {
+    const mockService = {
+      listEntities: vi.fn().mockResolvedValue([makeEntity('Aria')]),
+    } as unknown as BibleService;
+
+    const { result } = renderHook(() =>
+      useCodexContext({ projectId: 'p1', content: '', service: mockService }),
+    );
+    expect(result.current.matchedEntities).toEqual([]);
+  });
+
+  it('detects entity name mentions in content', async () => {
+    vi.useFakeTimers();
+    const aria = makeEntity('Aria');
+    const marcus = makeEntity('Marcus');
+    const mockService = {
+      listEntities: vi.fn().mockResolvedValue([aria, marcus]),
+    } as unknown as BibleService;
+
+    const { result } = renderHook(() =>
+      useCodexContext({ projectId: 'p1', content: 'Aria walked toward Marcus.', service: mockService }),
+    );
+
+    await act(async () => { vi.advanceTimersByTime(800); });
+
+    expect(result.current.matchedEntities).toHaveLength(2);
+    vi.useRealTimers();
+  });
+
+  it('is case-insensitive', async () => {
+    vi.useFakeTimers();
+    const aria = makeEntity('Aria');
+    const mockService = {
+      listEntities: vi.fn().mockResolvedValue([aria]),
+    } as unknown as BibleService;
+
+    const { result } = renderHook(() =>
+      useCodexContext({ projectId: 'p1', content: 'ARIA entered the room.', service: mockService }),
+    );
+
+    await act(async () => { vi.advanceTimersByTime(800); });
+    expect(result.current.matchedEntities).toHaveLength(1);
+    vi.useRealTimers();
+  });
+
+  it('does not match substrings (whole-word only)', async () => {
+    vi.useFakeTimers();
+    const ark = makeEntity('Ark');
+    const mockService = {
+      listEntities: vi.fn().mockResolvedValue([ark]),
+    } as unknown as BibleService;
+
+    const { result } = renderHook(() =>
+      useCodexContext({ projectId: 'p1', content: 'darkness fell', service: mockService }),
+    );
+
+    await act(async () => { vi.advanceTimersByTime(800); });
+    expect(result.current.matchedEntities).toHaveLength(0);
+    vi.useRealTimers();
+  });
+});

--- a/src/test/hooks/use-codex-context.test.ts
+++ b/src/test/hooks/use-codex-context.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useCodexContext } from '@/hooks/use-codex-context';
 import type { BibleService } from '@/application/bible/bible-service';
-import type { BibleEntity } from '@/domain/bible/bible';
+import type { BibleEntity } from '@/domain/bible/types';
 
 describe('useCodexContext', () => {
   const makeEntity = (name: string): BibleEntity => ({
@@ -13,7 +13,7 @@ describe('useCodexContext', () => {
 
   it('returns empty array when content is empty', async () => {
     const mockService = {
-      listEntities: vi.fn().mockResolvedValue([makeEntity('Aria')]),
+      listEntities: vi.fn().mockReturnValue([makeEntity('Aria')]),
     } as unknown as BibleService;
 
     const { result } = renderHook(() =>
@@ -27,7 +27,7 @@ describe('useCodexContext', () => {
     const aria = makeEntity('Aria');
     const marcus = makeEntity('Marcus');
     const mockService = {
-      listEntities: vi.fn().mockResolvedValue([aria, marcus]),
+      listEntities: vi.fn().mockReturnValue([aria, marcus]),
     } as unknown as BibleService;
 
     const { result } = renderHook(() =>
@@ -44,7 +44,7 @@ describe('useCodexContext', () => {
     vi.useFakeTimers();
     const aria = makeEntity('Aria');
     const mockService = {
-      listEntities: vi.fn().mockResolvedValue([aria]),
+      listEntities: vi.fn().mockReturnValue([aria]),
     } as unknown as BibleService;
 
     const { result } = renderHook(() =>
@@ -60,7 +60,7 @@ describe('useCodexContext', () => {
     vi.useFakeTimers();
     const ark = makeEntity('Ark');
     const mockService = {
-      listEntities: vi.fn().mockResolvedValue([ark]),
+      listEntities: vi.fn().mockReturnValue([ark]),
     } as unknown as BibleService;
 
     const { result } = renderHook(() =>

--- a/src/test/scene/scene-editor-shell.test.tsx
+++ b/src/test/scene/scene-editor-shell.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { SceneEditorServicePort } from '@/application/scene/scene-editor-service';
+import type { BibleService } from '@/application/bible/bible-service';
 import { SceneEditorShell } from '@/components/scene/scene-editor-shell';
 import type { Scene } from '@/domain/scene/types';
 
@@ -14,6 +15,9 @@ const createScene = (overrides: Partial<Scene> = {}): Scene => ({
   updatedAt: '2026-02-25T10:00:00.000Z',
   ...overrides,
 });
+
+const createBibleServiceDouble = (): BibleService =>
+  ({ listEntities: vi.fn().mockReturnValue([]) }) as unknown as BibleService;
 
 const createServiceDouble = (options: {
   saveScene?: SceneEditorServicePort['saveScene'];
@@ -69,7 +73,7 @@ describe('SceneEditorShell', () => {
   it('updates word count when scene content changes', async () => {
     const service = createServiceDouble({});
 
-    render(<SceneEditorShell projectId="demo-project" sceneId="scene-1" service={service} />);
+    render(<SceneEditorShell projectId="demo-project" sceneId="scene-1" service={service} bibleService={createBibleServiceDouble()} />);
 
     await screen.findByText('Scene 1');
     expect(screen.getByText('2 words')).toBeInTheDocument();
@@ -91,7 +95,7 @@ describe('SceneEditorShell', () => {
     );
     const service = createServiceDouble({ saveScene });
 
-    render(<SceneEditorShell projectId="demo-project" sceneId="scene-1" service={service} />);
+    render(<SceneEditorShell projectId="demo-project" sceneId="scene-1" service={service} bibleService={createBibleServiceDouble()} />);
     await screen.findByText('Scene 1');
     vi.useFakeTimers();
 
@@ -120,7 +124,7 @@ describe('SceneEditorShell', () => {
       );
     const service = createServiceDouble({ saveScene });
 
-    render(<SceneEditorShell projectId="demo-project" sceneId="scene-1" service={service} />);
+    render(<SceneEditorShell projectId="demo-project" sceneId="scene-1" service={service} bibleService={createBibleServiceDouble()} />);
     await screen.findByText('Scene 1');
     vi.useFakeTimers();
 
@@ -144,7 +148,7 @@ describe('SceneEditorShell', () => {
     vi.mocked(service.loadScene).mockRejectedValueOnce(new Error('LOAD_FAILURE'));
     vi.mocked(service.toUserErrorMessage).mockReturnValueOnce('Unable to load scene.');
 
-    render(<SceneEditorShell projectId="demo-project" sceneId="scene-1" service={service} />);
+    render(<SceneEditorShell projectId="demo-project" sceneId="scene-1" service={service} bibleService={createBibleServiceDouble()} />);
 
     expect(await screen.findByText('Unable to load scene')).toBeInTheDocument();
     expect(screen.getByText('Unable to load scene.')).toBeInTheDocument();


### PR DESCRIPTION
## Summary

- Add `useCodexContext` hook that scans scene content for story bible entity name mentions (debounced 800ms, whole-word case-insensitive, max 10 results)
- Add `CodexContextPanel` component displaying matched entities with category badge, name, and summary; collapsible
- Integrate panel into `SceneEditorShell` as a right-side panel alongside the editor
- Fix `LocalBibleRepository` SSR crash by replacing unconditional `throw` with `noOpStorage` fallback (matching `LocalWritingSessionRepository` pattern)

## Test plan

- [x] Unit tests: 111/111 passing (`npm run test:ci`)
- [x] Codex panel appears after 800ms when entity names are mentioned
- [x] Case-insensitive matching works (ARIA matches Aria)
- [x] Whole-word matching — no false positives on substrings
- [x] Panel collapses/expands via toggle button
- [x] Panel disappears when editor is empty
- [x] Scene page SSR returns 200 (was 500 before SSR fix)
- [ ] Visual check: category badge colors (blue/green/orange/purple)
- [ ] Entity with no summary renders without layout gap
- [ ] 10+ matches capped at 10 in the panel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes: Codex Context System (v1.0)

### ✨ New Features
- **Codex Context System**: New `useCodexContext` hook that intelligently scans scene content for story bible entity mentions with:
  - Debounced matching (800ms) for performance
  - Whole-word, case-insensitive matching
  - Results capped at 10 matches
- **CodexContextPanel Component**: New collapsible right-side panel that displays matched entities with:
  - Color-coded category badges
  - Entity names and summaries
  - Collapse/expand toggle
  - Auto-hides when no matches found

### 🔧 Improvements & Fixes
- **SSR Stability**: Fixed critical 500 error on scene editor page during server-side rendering by implementing fallback storage in `LocalBibleRepository` (matches pattern used in `LocalWritingSessionRepository`)
- **Scene Editor Integration**: Integrated CodexContextPanel into SceneEditorShell as a right-side panel with optional BibleService dependency injection

### ✅ Quality Assurance
- 111/111 unit tests passing
- Comprehensive test coverage for hook debouncing, matching logic, and component rendering
- Manual test checklist completed for panel visibility, matching accuracy, and collapse/expand behaviour

### 📍 Affected Areas
- **Frontend**: Scene editor UI enhanced with contextual entity matching panel
- **Data Layer**: Bible entity retrieval and rendering
- **Server-Side Rendering**: SSR crash resolution

### 📝 Technical Notes
- `SceneEditorShell` now accepts optional `bibleService` prop (backward compatible)
- Entity matching uses safe regex escaping with word boundaries
- Panel renders nothing when editor is empty (no visual clutter)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->