### PR TITLE
⚡ perf: rendering performance optimizations

### DIFF
--- a/src/components/scene/scene-beat-panel.tsx
+++ b/src/components/scene/scene-beat-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { memo, useCallback, useState } from 'react';
 import type { ReactElement } from 'react';
 
 import type { BeatType, SceneBeat } from '@/domain/scene/schemas';
@@ -23,21 +23,21 @@ const BEAT_LABELS: Record<BeatType, string> = {
   revelation: 'Revelation',
 };
 
-export function SceneBeatPanel({ synopsis, beats, onSynopsisChange, onBeatsChange }: Props): ReactElement {
+export const SceneBeatPanel = memo(function SceneBeatPanel({ synopsis, beats, onSynopsisChange, onBeatsChange }: Props): ReactElement {
   const [isOpen, setIsOpen] = useState(false);
 
-  function addBeat(): void {
+  const addBeat = useCallback((): void => {
     if (beats.length >= maxBeatsPerScene) return;
     onBeatsChange([...beats, { id: `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`, content: '', type: 'setup' }]);
-  }
+  }, [beats, onBeatsChange]);
 
-  function updateBeat(id: string, changes: Partial<SceneBeat>): void {
+  const updateBeat = useCallback((id: string, changes: Partial<SceneBeat>): void => {
     onBeatsChange(beats.map((beat) => (beat.id === id ? { ...beat, ...changes } : beat)));
-  }
+  }, [beats, onBeatsChange]);
 
-  function removeBeat(id: string): void {
+  const removeBeat = useCallback((id: string): void => {
     onBeatsChange(beats.filter((beat) => beat.id !== id));
-  }
+  }, [beats, onBeatsChange]);
 
   return (
     <div className="border-b border-border bg-card">
@@ -54,9 +54,10 @@ export function SceneBeatPanel({ synopsis, beats, onSynopsisChange, onBeatsChang
       {isOpen && (
         <div className="space-y-3 px-4 pb-4" id="scene-plan-panel">
           <div>
-            <label className="mb-1 block text-xs font-medium text-muted-foreground">Synopsis</label>
+            <label className="mb-1 block text-xs font-medium text-muted-foreground" htmlFor="beat-synopsis">Synopsis</label>
             <input
               className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+              id="beat-synopsis"
               maxLength={300}
               onChange={(event) => onSynopsisChange(event.target.value)}
               placeholder="What happens in this scene?"
@@ -114,4 +115,4 @@ export function SceneBeatPanel({ synopsis, beats, onSynopsisChange, onBeatsChang
       )}
     </div>
   );
-}
+});

--- a/src/components/scene/scene-beat-panel.tsx
+++ b/src/components/scene/scene-beat-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { memo, useCallback, useState } from 'react';
+import { memo, useCallback, useId, useState } from 'react';
 import type { ReactElement } from 'react';
 
 import type { BeatType, SceneBeat } from '@/domain/scene/schemas';
@@ -23,8 +23,14 @@ const BEAT_LABELS: Record<BeatType, string> = {
   revelation: 'Revelation',
 };
 
-export const SceneBeatPanel = memo(function SceneBeatPanel({ synopsis, beats, onSynopsisChange, onBeatsChange }: Props): ReactElement {
+export const SceneBeatPanel = memo(function SceneBeatPanel({
+  synopsis,
+  beats,
+  onSynopsisChange,
+  onBeatsChange,
+}: Props): ReactElement {
   const [isOpen, setIsOpen] = useState(false);
+  const synopsisId = useId();
 
   const addBeat = useCallback((): void => {
     if (beats.length >= maxBeatsPerScene) return;
@@ -54,10 +60,10 @@ export const SceneBeatPanel = memo(function SceneBeatPanel({ synopsis, beats, on
       {isOpen && (
         <div className="space-y-3 px-4 pb-4" id="scene-plan-panel">
           <div>
-            <label className="mb-1 block text-xs font-medium text-muted-foreground" htmlFor="beat-synopsis">Synopsis</label>
+            <label className="mb-1 block text-xs font-medium text-muted-foreground" htmlFor={synopsisId}>Synopsis</label>
             <input
               className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-              id="beat-synopsis"
+              id={synopsisId}
               maxLength={300}
               onChange={(event) => onSynopsisChange(event.target.value)}
               placeholder="What happens in this scene?"

--- a/src/components/scene/scene-editor-shell.tsx
+++ b/src/components/scene/scene-editor-shell.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import type { ReactElement } from 'react';
-import { useCallback, useContext, useMemo } from 'react';
+import { memo, useCallback, useMemo, type ReactElement } from 'react';
 
 import { BibleService } from '@/application/bible/bible-service';
 import { createBibleService as createDefaultBibleService } from '@/application/bible/create-bible-service';
@@ -15,7 +14,7 @@ import { CodexContextPanel } from '@/components/scene/codex-context-panel';
 import { SceneBeatPanel } from '@/components/scene/scene-beat-panel';
 import { SceneToolbar } from '@/components/scene/scene-toolbar';
 import { SessionTimer } from '@/components/writing-session/session-timer';
-import { WritingSessionContext } from '@/context/writing-session-context';
+import { useWritingSessionActions, useWritingSessionTimer } from '@/context/writing-session-context';
 
 import { LocalProjectRepository } from '@/data/project/local-project-repository';
 import { LocalWritingSessionRepository } from '@/data/writing-session/local-writing-session-repository';
@@ -143,7 +142,7 @@ type SceneEditorNavigationProps = {
   nextSceneId: string | null;
 };
 
-function SceneEditorNavigation(props: SceneEditorNavigationProps): ReactElement {
+const SceneEditorNavigation = memo(function SceneEditorNavigation(props: SceneEditorNavigationProps): ReactElement {
   return (
     <nav className="flex items-center justify-between">
       {props.previousSceneId ? (
@@ -177,7 +176,7 @@ function SceneEditorNavigation(props: SceneEditorNavigationProps): ReactElement 
       )}
     </nav>
   );
-}
+});
 
 type SceneContentSectionProps = {
   content: string;
@@ -189,7 +188,7 @@ type SceneContentSectionProps = {
   onBeatsChange: (beats: import('@/domain/scene/schemas').SceneBeat[]) => void;
 };
 
-function SceneContentSection({
+const SceneContentSection = memo(function SceneContentSection({
   content,
   onContentChange,
   matchedEntities,
@@ -222,19 +221,34 @@ function SceneContentSection({
       </div>
     </section>
   );
+});
+
+type SessionTimerConnectorProps = {
+  onStart: () => void;
+  onStop: () => Promise<void>;
+};
+
+function SessionTimerConnector({ onStart, onStop }: SessionTimerConnectorProps): ReactElement {
+  const contextTimer = useWritingSessionTimer();
+  return (
+    <SessionTimer
+      isRunning={contextTimer?.isRunning ?? false}
+      elapsedSeconds={contextTimer?.elapsedSeconds ?? 0}
+      onStart={onStart}
+      onStop={onStop}
+    />
+  );
 }
 
 type SceneEditorLoadedViewProps = {
   projectId: string;
   sceneEditor: UseSceneEditorResult;
-  isSessionRunning: boolean;
-  sessionElapsedSeconds: number;
   onSessionStart: () => void;
   onSessionStop: () => Promise<void>;
   bibleService: BibleService;
 };
 
-function SceneEditorLoadedView(props: SceneEditorLoadedViewProps): ReactElement {
+const SceneEditorLoadedView = memo(function SceneEditorLoadedView(props: SceneEditorLoadedViewProps): ReactElement {
   const { matchedEntities } = useCodexContext({
     projectId: props.projectId,
     content: props.sceneEditor.content,
@@ -257,12 +271,7 @@ function SceneEditorLoadedView(props: SceneEditorLoadedViewProps): ReactElement 
         onRetrySave={props.sceneEditor.retrySave}
       />
 
-      <SessionTimer
-        isRunning={props.isSessionRunning}
-        elapsedSeconds={props.sessionElapsedSeconds}
-        onStart={props.onSessionStart}
-        onStop={props.onSessionStop}
-      />
+      <SessionTimerConnector onStart={props.onSessionStart} onStop={props.onSessionStop} />
 
       <SceneContentSection
         content={props.sceneEditor.content}
@@ -281,23 +290,26 @@ function SceneEditorLoadedView(props: SceneEditorLoadedViewProps): ReactElement 
       />
     </main>
   );
-}
+});
 
 export function SceneEditorShell(props: SceneEditorShellProps): ReactElement {
   const { service, writingService, bibleService } = useShellServices(props);
-  const contextSession = useContext(WritingSessionContext);
+  const contextActions = useWritingSessionActions();
   const localSession = useWritingSession({ projectId: props.projectId, service: writingService });
-  const writingSession = contextSession ?? localSession;
+
+  const startSession = contextActions?.startSession ?? localSession.startSession;
+  const stopSession = contextActions?.stopSession ?? localSession.stopSession;
+  const onWordsSaved = contextActions?.onWordsSaved ?? localSession.onWordsSaved;
 
   const handleSessionStop = useCallback(async (): Promise<void> => {
-    await writingSession.stopSession();
-  }, [writingSession]);
+    await stopSession();
+  }, [stopSession]);
 
   const sceneEditor = useSceneEditor({
     projectId: props.projectId,
     sceneId: props.sceneId,
     service,
-    onWordsSaved: writingSession.onWordsSaved,
+    onWordsSaved,
   });
   const stateView = getSceneStateView({
     projectId: props.projectId,
@@ -314,9 +326,7 @@ export function SceneEditorShell(props: SceneEditorShellProps): ReactElement {
     <SceneEditorLoadedView
       projectId={props.projectId}
       sceneEditor={sceneEditor}
-      isSessionRunning={writingSession.isRunning}
-      sessionElapsedSeconds={writingSession.elapsedSeconds}
-      onSessionStart={writingSession.startSession}
+      onSessionStart={startSession}
       onSessionStop={handleSessionStop}
       bibleService={bibleService}
     />

--- a/src/components/scene/scene-editor-shell.tsx
+++ b/src/components/scene/scene-editor-shell.tsx
@@ -19,6 +19,7 @@ import { useWritingSessionActions, useWritingSessionTimer } from '@/context/writ
 import { LocalProjectRepository } from '@/data/project/local-project-repository';
 import { LocalWritingSessionRepository } from '@/data/writing-session/local-writing-session-repository';
 import type { BibleEntity } from '@/domain/bible/types';
+import type { SceneBeat } from '@/domain/scene/schemas';
 import { useCodexContext } from '@/hooks/use-codex-context';
 import { useSceneEditor, type UseSceneEditorResult } from '@/hooks/use-scene-editor';
 import { useWritingSession } from '@/hooks/use-writing-session';
@@ -183,9 +184,9 @@ type SceneContentSectionProps = {
   onContentChange: (value: string) => void;
   matchedEntities: BibleEntity[];
   synopsis: string;
-  beats: import('@/domain/scene/schemas').SceneBeat[];
+  beats: SceneBeat[];
   onSynopsisChange: (value: string) => void;
-  onBeatsChange: (beats: import('@/domain/scene/schemas').SceneBeat[]) => void;
+  onBeatsChange: (beats: SceneBeat[]) => void;
 };
 
 const SceneContentSection = memo(function SceneContentSection({
@@ -226,14 +227,16 @@ const SceneContentSection = memo(function SceneContentSection({
 type SessionTimerConnectorProps = {
   onStart: () => void;
   onStop: () => Promise<void>;
+  fallbackIsRunning: boolean;
+  fallbackElapsedSeconds: number;
 };
 
-function SessionTimerConnector({ onStart, onStop }: SessionTimerConnectorProps): ReactElement {
+function SessionTimerConnector({ onStart, onStop, fallbackIsRunning, fallbackElapsedSeconds }: SessionTimerConnectorProps): ReactElement {
   const contextTimer = useWritingSessionTimer();
   return (
     <SessionTimer
-      isRunning={contextTimer?.isRunning ?? false}
-      elapsedSeconds={contextTimer?.elapsedSeconds ?? 0}
+      isRunning={contextTimer?.isRunning ?? fallbackIsRunning}
+      elapsedSeconds={contextTimer?.elapsedSeconds ?? fallbackElapsedSeconds}
       onStart={onStart}
       onStop={onStop}
     />
@@ -246,6 +249,8 @@ type SceneEditorLoadedViewProps = {
   onSessionStart: () => void;
   onSessionStop: () => Promise<void>;
   bibleService: BibleService;
+  fallbackIsRunning: boolean;
+  fallbackElapsedSeconds: number;
 };
 
 const SceneEditorLoadedView = memo(function SceneEditorLoadedView(props: SceneEditorLoadedViewProps): ReactElement {
@@ -271,7 +276,12 @@ const SceneEditorLoadedView = memo(function SceneEditorLoadedView(props: SceneEd
         onRetrySave={props.sceneEditor.retrySave}
       />
 
-      <SessionTimerConnector onStart={props.onSessionStart} onStop={props.onSessionStop} />
+      <SessionTimerConnector
+        onStart={props.onSessionStart}
+        onStop={props.onSessionStop}
+        fallbackIsRunning={props.fallbackIsRunning}
+        fallbackElapsedSeconds={props.fallbackElapsedSeconds}
+      />
 
       <SceneContentSection
         content={props.sceneEditor.content}
@@ -329,6 +339,8 @@ export function SceneEditorShell(props: SceneEditorShellProps): ReactElement {
       onSessionStart={startSession}
       onSessionStop={handleSessionStop}
       bibleService={bibleService}
+      fallbackIsRunning={localSession.isRunning}
+      fallbackElapsedSeconds={localSession.elapsedSeconds}
     />
   );
 }

--- a/src/components/writing-session/daily-progress.tsx
+++ b/src/components/writing-session/daily-progress.tsx
@@ -37,6 +37,7 @@ export function DailyProgress({ progress, dailyGoal }: DailyProgressProps): Reac
             className="h-full rounded-full bg-primary transition-all"
             style={{ width: `${percentage}%` }}
             role="progressbar"
+            aria-label="Daily writing progress"
             aria-valuenow={progress.wordsWritten}
             aria-valuemin={0}
             aria-valuemax={dailyGoal}

--- a/src/context/writing-session-context.tsx
+++ b/src/context/writing-session-context.tsx
@@ -1,12 +1,27 @@
 'use client';
 
-import { createContext, useEffect, useMemo, type ReactElement, type ReactNode } from 'react';
+import { createContext, useContext, useEffect, useMemo, type ReactElement, type ReactNode } from 'react';
 
 import { WritingSessionService } from '@/application/writing-session/writing-session-service';
 import { LocalWritingSessionRepository } from '@/data/writing-session/local-writing-session-repository';
 import { useWritingSession, type UseWritingSessionResult } from '@/hooks/use-writing-session';
 
-export const WritingSessionContext = createContext<UseWritingSessionResult | null>(null);
+type WritingSessionTimerValue = Pick<UseWritingSessionResult, 'isRunning' | 'elapsedSeconds'>;
+type WritingSessionActionsValue = Pick<
+  UseWritingSessionResult,
+  'startSession' | 'stopSession' | 'setDailyGoal' | 'onWordsSaved' | 'dashboard' | 'error'
+>;
+
+const WritingSessionTimerContext = createContext<WritingSessionTimerValue | null>(null);
+const WritingSessionActionsContext = createContext<WritingSessionActionsValue | null>(null);
+
+export function useWritingSessionTimer(): WritingSessionTimerValue | null {
+  return useContext(WritingSessionTimerContext);
+}
+
+export function useWritingSessionActions(): WritingSessionActionsValue | null {
+  return useContext(WritingSessionActionsContext);
+}
 
 export function WritingSessionProvider({
   projectId,
@@ -26,9 +41,35 @@ export function WritingSessionProvider({
     };
   }, [stopSession]);
 
+  const timerValue = useMemo(
+    () => ({ isRunning: session.isRunning, elapsedSeconds: session.elapsedSeconds }),
+    [session.isRunning, session.elapsedSeconds],
+  );
+
+  const actionsValue = useMemo(
+    () => ({
+      startSession: session.startSession,
+      stopSession: session.stopSession,
+      setDailyGoal: session.setDailyGoal,
+      onWordsSaved: session.onWordsSaved,
+      dashboard: session.dashboard,
+      error: session.error,
+    }),
+    [
+      session.startSession,
+      session.stopSession,
+      session.setDailyGoal,
+      session.onWordsSaved,
+      session.dashboard,
+      session.error,
+    ],
+  );
+
   return (
-    <WritingSessionContext.Provider value={session}>
-      {children}
-    </WritingSessionContext.Provider>
+    <WritingSessionTimerContext.Provider value={timerValue}>
+      <WritingSessionActionsContext.Provider value={actionsValue}>
+        {children}
+      </WritingSessionActionsContext.Provider>
+    </WritingSessionTimerContext.Provider>
   );
 }

--- a/src/data/bible/local-bible-repository.ts
+++ b/src/data/bible/local-bible-repository.ts
@@ -77,6 +77,8 @@ const unavailableStorage: Storage = {
 
 export class LocalBibleRepository implements BibleRepository {
   private readonly storage: Storage;
+  private readonly bibleCache = new Map<string, BibleStorageDocument>();
+  private readonly scenesCache = new Map<string, ProjectScene[]>();
 
   public constructor(storage?: Storage) {
     if (storage) {
@@ -262,22 +264,24 @@ export class LocalBibleRepository implements BibleRepository {
 
   private readBible(projectId: string): BibleStorageDocument {
     const normalizedProjectId = normalizeProjectId(projectId);
-    const rawValue = this.storage.getItem(this.bibleStorageKey(normalizedProjectId));
-    const parsedValue = parseJson(rawValue);
 
-    if (!parsedValue) {
-      return cloneEmptyBibleStorage();
+    if (!this.bibleCache.has(normalizedProjectId)) {
+      const rawValue = this.storage.getItem(this.bibleStorageKey(normalizedProjectId));
+      const parsedValue = parseJson(rawValue);
+      const parsedStorage = parsedValue ? bibleStorageSchema.safeParse(parsedValue) : null;
+      this.bibleCache.set(
+        normalizedProjectId,
+        parsedStorage?.success
+          ? { entities: parsedStorage.data.entities, relationships: parsedStorage.data.relationships, sceneLinks: parsedStorage.data.sceneLinks }
+          : cloneEmptyBibleStorage(),
+      );
     }
 
-    const parsedStorage = bibleStorageSchema.safeParse(parsedValue);
-    if (!parsedStorage.success) {
-      return cloneEmptyBibleStorage();
-    }
-
+    const cached = this.bibleCache.get(normalizedProjectId)!;
     return {
-      entities: [...parsedStorage.data.entities],
-      relationships: [...parsedStorage.data.relationships],
-      sceneLinks: [...parsedStorage.data.sceneLinks],
+      entities: [...cached.entities],
+      relationships: [...cached.relationships],
+      sceneLinks: [...cached.sceneLinks],
     };
   }
 
@@ -286,23 +290,20 @@ export class LocalBibleRepository implements BibleRepository {
     const parsedStorage = bibleStorageSchema.parse(bibleStorage);
     const payload = JSON.stringify(parsedStorage);
     this.storage.setItem(this.bibleStorageKey(normalizedProjectId), payload);
+    this.bibleCache.set(normalizedProjectId, { entities: parsedStorage.entities, relationships: parsedStorage.relationships, sceneLinks: parsedStorage.sceneLinks });
   }
 
   private readScenes(projectId: string): ProjectScene[] {
     const normalizedProjectId = normalizeProjectId(projectId);
-    const rawValue = this.storage.getItem(this.projectScenesStorageKey(normalizedProjectId));
-    const parsedValue = parseJson(rawValue);
 
-    if (!parsedValue) {
-      return [];
+    if (!this.scenesCache.has(normalizedProjectId)) {
+      const rawValue = this.storage.getItem(this.projectScenesStorageKey(normalizedProjectId));
+      const parsedValue = parseJson(rawValue);
+      const parsedScenes = parsedValue ? projectScenesSchema.safeParse(parsedValue) : null;
+      this.scenesCache.set(normalizedProjectId, parsedScenes?.success ? parsedScenes.data : []);
     }
 
-    const parsedScenes = projectScenesSchema.safeParse(parsedValue);
-    if (!parsedScenes.success) {
-      return [];
-    }
-
-    return [...parsedScenes.data];
+    return [...this.scenesCache.get(normalizedProjectId)!];
   }
 
   private writeScenes(projectId: string, scenes: ProjectScene[]): void {
@@ -310,6 +311,7 @@ export class LocalBibleRepository implements BibleRepository {
     const parsedScenes = projectScenesSchema.parse(scenes);
     const payload = JSON.stringify(parsedScenes);
     this.storage.setItem(this.projectScenesStorageKey(normalizedProjectId), payload);
+    this.scenesCache.set(normalizedProjectId, parsedScenes);
   }
 
   private bibleStorageKey(projectId: string): string {

--- a/src/data/bible/local-bible-repository.ts
+++ b/src/data/bible/local-bible-repository.ts
@@ -279,9 +279,9 @@ export class LocalBibleRepository implements BibleRepository {
 
     const cached = this.bibleCache.get(normalizedProjectId)!;
     return {
-      entities: [...cached.entities],
-      relationships: [...cached.relationships],
-      sceneLinks: [...cached.sceneLinks],
+      entities: cached.entities.map((entity) => ({ ...entity, tags: [...entity.tags] })),
+      relationships: cached.relationships.map((relationship) => ({ ...relationship })),
+      sceneLinks: cached.sceneLinks.map((sceneLink) => ({ ...sceneLink })),
     };
   }
 
@@ -303,7 +303,7 @@ export class LocalBibleRepository implements BibleRepository {
       this.scenesCache.set(normalizedProjectId, parsedScenes?.success ? parsedScenes.data : []);
     }
 
-    return [...this.scenesCache.get(normalizedProjectId)!];
+    return this.scenesCache.get(normalizedProjectId)!.map((scene) => ({ ...scene }));
   }
 
   private writeScenes(projectId: string, scenes: ProjectScene[]): void {


### PR DESCRIPTION
## Summary

- Split `WritingSessionContext` into two contexts (`timer` + `actions`) to isolate per-second re-renders from stable action callbacks
- Extract `SessionTimerConnector` component to subscribe to timer context in isolation, preventing re-renders from propagating to memoized parents
- Wrap `SceneBeatPanel`, `SceneContentSection`, `SceneEditorNavigation`, and `SceneEditorLoadedView` with `React.memo`; stabilize beat handlers with `useCallback`
- Add in-memory read cache (`bibleCache`, `scenesCache` Maps) to `LocalBibleRepository` — avoids redundant localStorage reads and Zod re-parses on every keystroke
- Fix missing `aria-label` on progressbar in `DailyProgress`

## Test plan

- [ ] Open a scene editor — timer ticks every second without re-rendering the scene content area
- [ ] Type in the scene textarea — no visible lag; beat panel does not flicker
- [ ] Add/remove/update beats — handlers respond correctly
- [ ] Navigate between scenes via Previous/Next links
- [ ] Open the Bible page, create/edit entities — reads and writes behave correctly
- [ ] Writing session starts and stops as expected from the scene editor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes: Rendering Performance Optimizations

### Performance Improvements
- **Context Optimization**: Split `WritingSessionContext` into two separate contexts (`WritingSessionTimerContext` and `WritingSessionActionsContext`) to isolate timer-driven re-renders from stable action callbacks, preventing unnecessary cascading updates across the application.
- **Component Memoization**: Wrapped `SceneBeatPanel`, `SceneContentSection`, `SceneEditorNavigation`, and `SceneEditorLoadedView` with `React.memo` to prevent unnecessary re-renders from parent updates.
- **Callback Stabilization**: Added `useCallback` hooks for beat management handlers (`addBeat`, `updateBeat`, `removeBeat`) to maintain stable function references across renders.
- **Timer Isolation**: Extracted new `SessionTimerConnector` component to subscribe to timer context separately, preventing timer updates from triggering re-renders in memoized parent components.
- **In-Memory Caching**: Added per-instance read caches (`bibleCache`, `scenesCache`) to `LocalBibleRepository` to eliminate repeated localStorage reads and Zod parsing operations.

### Accessibility
- Added `aria-label="Daily writing progress"` to the daily progress bar for improved screen reader support.

### Breaking Changes
- **`WritingSessionContext` Removed**: Direct consumption of `WritingSessionContext` is no longer supported. Replace with:
  - `useWritingSessionTimer()` — for timer state (`isRunning`, `elapsedSeconds`)
  - `useWritingSessionActions()` — for session actions and callbacks

### Affected Areas
- **Frontend**: Scene editor components, writing session context consumption, daily progress accessibility
- **Data Layer**: Bible repository caching strategy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->