### PR TITLE
🐛 fix: connect Goals page timer to WritingSessionContext

### DIFF
--- a/src/components/writing-session/goals-page-client.tsx
+++ b/src/components/writing-session/goals-page-client.tsx
@@ -2,11 +2,8 @@
 
 import Link from 'next/link';
 import type { ReactElement } from 'react';
-import { useMemo } from 'react';
 
-import { WritingSessionService } from '@/application/writing-session/writing-session-service';
-import { LocalWritingSessionRepository } from '@/data/writing-session/local-writing-session-repository';
-import { useWritingSession } from '@/hooks/use-writing-session';
+import { useWritingSessionActions, useWritingSessionTimer } from '@/context/writing-session-context';
 
 import { DailyGoalForm } from './daily-goal-form';
 import { DailyProgress } from './daily-progress';
@@ -70,13 +67,18 @@ function DashboardPanels({ dashboard }: { dashboard: SessionDashboard }): ReactE
 }
 
 export function GoalsPageClient({ projectId, projectTitle }: GoalsPageClientProps): ReactElement {
-  const repository = useMemo(() => new LocalWritingSessionRepository(), []);
-  const service = useMemo(() => new WritingSessionService(repository), [repository]);
-  const { dashboard, isRunning, elapsedSeconds, error, startSession, stopSession, setDailyGoal } =
-    useWritingSession({ projectId, service });
+  const contextActions = useWritingSessionActions();
+  const contextTimer = useWritingSessionTimer();
+
+  const dashboard = contextActions?.dashboard ?? null;
+  const error = contextActions?.error ?? null;
+  const startSession = contextActions?.startSession ?? (() => undefined);
+  const setDailyGoal = contextActions?.setDailyGoal ?? (() => undefined);
+  const isRunning = contextTimer?.isRunning ?? false;
+  const elapsedSeconds = contextTimer?.elapsedSeconds ?? 0;
 
   const handleStop = async (): Promise<void> => {
-    await stopSession();
+    await contextActions?.stopSession();
   };
 
   return (

--- a/src/test/writing-session/goals-page.test.tsx
+++ b/src/test/writing-session/goals-page.test.tsx
@@ -2,10 +2,19 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { WritingSessionProvider } from '@/context/writing-session-context';
 import { LocalWritingSessionRepository } from '@/data/writing-session/local-writing-session-repository';
 import { GoalsPageClient } from '@/components/writing-session/goals-page-client';
 
 const PROJECT_A = '8b5d05ea-3f90-4fd4-91cb-c18edfd3de71';
+
+function renderWithProvider(projectId: string) {
+  return render(
+    <WritingSessionProvider projectId={projectId}>
+      <GoalsPageClient projectId={projectId} projectTitle="My Novel" />
+    </WritingSessionProvider>,
+  );
+}
 
 describe('GoalsPageClient', () => {
   beforeEach(() => {
@@ -13,23 +22,23 @@ describe('GoalsPageClient', () => {
   });
 
   it('renders dashboard after mount', async () => {
-    render(<GoalsPageClient projectId={PROJECT_A} projectTitle="My Novel" />);
+    renderWithProvider(PROJECT_A);
     expect(await screen.findByText("Today's Progress")).toBeInTheDocument();
   });
 
   it('renders empty state for session history', async () => {
-    render(<GoalsPageClient projectId={PROJECT_A} projectTitle="My Novel" />);
+    renderWithProvider(PROJECT_A);
     expect(await screen.findByText('No sessions recorded yet.')).toBeInTheDocument();
   });
 
   it('renders weekly chart section', async () => {
-    render(<GoalsPageClient projectId={PROJECT_A} projectTitle="My Novel" />);
+    renderWithProvider(PROJECT_A);
     expect(await screen.findByText('This Week')).toBeInTheDocument();
   });
 
   it('daily goal form saves and updates persisted goal', async () => {
     const user = userEvent.setup();
-    render(<GoalsPageClient projectId={PROJECT_A} projectTitle="My Novel" />);
+    renderWithProvider(PROJECT_A);
 
     const input = await screen.findByLabelText('Daily word count goal');
     await user.clear(input);
@@ -45,7 +54,7 @@ describe('GoalsPageClient', () => {
 
   it('start and stop session cycle persists a session', async () => {
     const user = userEvent.setup();
-    render(<GoalsPageClient projectId={PROJECT_A} projectTitle="My Novel" />);
+    renderWithProvider(PROJECT_A);
 
     await user.click(await screen.findByRole('button', { name: 'Start session' }));
     await user.click(screen.getByRole('button', { name: 'Stop session' }));


### PR DESCRIPTION
## Summary

- `GoalsPageClient` créait sa propre instance `useWritingSession` isolée, causant l'arrêt du timer à chaque navigation
- Remplacé par `useWritingSessionActions()` + `useWritingSessionTimer()` pour consommer le context partagé du layout
- Le `WritingSessionProvider` dans `app/workspace/[projectId]/layout.tsx` persiste à travers toutes les pages du workspace — le timer continue de tourner lors des navigations client-side

## Test plan

- [x] `npm run test:ci` — 119/119 tests passent
- [x] Démarrer une session sur la page Goals → timer démarre
- [x] Naviguer vers le workspace (`Back to project`) → revenir sur Goals → timer toujours actif (ex: 17s)
- [x] Naviguer vers le scene editor → timer visible avec elapsed time (ex: 40s, bouton "Stop session")
- [x] Aucune erreur console
- [ ] Vérifier que `Stop session` depuis le scene editor met aussi fin à la session sur Goals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 🐛 Bug Fix: Goals Page Timer Persistence

**Affected Areas:** Frontend (Goals Page, Writing Session Management)

### Key Changes
- **Fixed timer persistence issue** on the Goals page by connecting GoalsPageClient to the shared WritingSessionContext instead of maintaining an isolated session instance
- **Updated context integration** to use `useWritingSessionActions()` and `useWritingSessionTimer()` hooks, allowing the timer to remain active during client-side navigation between workspace pages
- **Removed redundant code** that directly instantiated LocalWritingSessionRepository and WritingSessionService
- **Updated test suite** to wrap GoalsPageClient with WritingSessionProvider, ensuring tests reflect the actual application context structure

### Improvements
- Timer now persists correctly when navigating between Goals page, workspace, and scene editor
- Consistent session state across all workspace pages through the shared WritingSessionProvider in the workspace layout
- All 119 tests passing

### Breaking Changes
None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->