### PR TITLE
🐛 fix: separate CI jobs and remove Firebase env vars

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: CI
 
 on:
   push:
@@ -11,38 +11,41 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
-    strategy:
-      matrix:
-        node-version: [20.x]
-
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 20.x
           cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Run tests (lint, typecheck, test)
+      - name: Lint, typecheck, test
         run: npm run test:ci
-        timeout-minutes: 5
         env:
           CI: true
 
-      - name: Build check
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
         run: npm run build
         env:
           CI: true
-          NEXT_PUBLIC_FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
-          NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
-          NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
-          NEXT_PUBLIC_FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
-          NEXT_PUBLIC_FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
-          NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
 
   coverage:
     runs-on: ubuntu-latest
@@ -50,8 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js 20.x
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20.x
           cache: 'npm'


### PR DESCRIPTION
## Summary

- Split monolithic `test` job into distinct `test`, `build`, and `coverage` jobs
- Remove `NEXT_PUBLIC_FIREBASE_*` secrets — ainkwell is localStorage-only, no Firebase dependency
- Remove unnecessary `node-version` matrix (single version 20.x)
- Rename workflow from `Tests` to `CI`

## Test plan

- [ ] Verify CI workflow triggers on push/PR to `main` and `develop`
- [ ] Confirm `test` job runs lint, typecheck, and unit tests
- [ ] Confirm `build` job runs Next.js build without Firebase env vars
- [ ] Confirm `coverage` job generates and uploads report to Codecov