### PR TITLE
🔧 build: improve CI workflow structure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ main, develop ]
@@ -23,9 +27,18 @@ jobs:
         run: npm ci
 
       - name: Lint, typecheck, test
-        run: npm run test:ci
+        run: npm run lint && npm run typecheck && npm run test:coverage
+        timeout-minutes: 5
         env:
           CI: true
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: ./coverage/coverage-final.json
+          retention-days: 1
+          if-no-files-found: warn
 
   build:
     runs-on: ubuntu-latest
@@ -39,6 +52,13 @@ jobs:
           node-version: 20.x
           cache: 'npm'
 
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('package-lock.json') }}-${{ hashFiles('src/**/*.{ts,tsx}') }}
+          restore-keys: ${{ runner.os }}-nextjs-
+
       - name: Install dependencies
         run: npm ci
 
@@ -49,25 +69,17 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    needs: [test]
 
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4
         with:
-          node-version: 20.x
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Generate coverage report
-        run: npm run test:coverage
-        env:
-          CI: true
+          name: coverage-report
+          path: ./coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ./coverage/coverage-final.json
           flags: unittests


### PR DESCRIPTION
## Summary

- Add `concurrency` group to cancel in-progress duplicate runs on the same branch
- Generate coverage once in the `test` job and share via artifact (tests no longer run twice)
- Add Next.js build cache in the `build` job for faster builds
- Upgrade `codecov/codecov-action` from v3 to v4

## Test plan

- [ ] Verify CI runs pass on this PR
- [ ] Confirm coverage is uploaded to Codecov via the artifact flow
- [ ] Confirm Next.js build cache is hit on subsequent runs
- [ ] Verify concurrency cancels duplicate runs when pushing twice rapidly