### PR TITLE
✨ feat: add manuscript view

### DIFF
--- a/docs/plans/2026-03-02-manuscript-view.plan.md
+++ b/docs/plans/2026-03-02-manuscript-view.plan.md
@@ -1,0 +1,537 @@
+---
+name: manuscript-view
+overview: |
+  The Manuscript View provides a continuous, read-only scroll of an entire project's content
+  — all chapters and scenes concatenated in their canonical order. Writers can "read their novel
+  as a book" without switching between individual scene editors. Each chapter is introduced by
+  a styled header; each scene is separated by a typographic divider and shows its title and full
+  content. Per-chapter word counts and a grand total are displayed in a sticky summary bar. The
+  view is purely derived from the existing WritingProject data structure: no new storage keys,
+  no new domain entities, and no write path are needed.
+todos:
+  - id: 1
+    content: "Add ManuscriptService to application layer with buildManuscript pure function"
+    status: pending
+    dependencies: []
+  - id: 2
+    content: "Add ManuscriptChapter and ManuscriptScene types to domain"
+    status: pending
+    dependencies: []
+  - id: 3
+    content: "Write unit tests for ManuscriptService (word counts, ordering, empty states)"
+    status: pending
+    dependencies: [1, 2]
+  - id: 4
+    content: "Build ManuscriptWordCountBar component (chapter totals + grand total)"
+    status: pending
+    dependencies: [2]
+  - id: 5
+    content: "Build ManuscriptChapterSection component (header + scene list)"
+    status: pending
+    dependencies: [2]
+  - id: 6
+    content: "Build ManuscriptPageContent component composing bar and chapter sections"
+    status: pending
+    dependencies: [4, 5]
+  - id: 7
+    content: "Create useManuscript hook that loads WritingProject and builds manuscript"
+    status: pending
+    dependencies: [1, 6]
+  - id: 8
+    content: "Create app route src/app/workspace/[projectId]/manuscript/page.tsx"
+    status: pending
+    dependencies: [7]
+  - id: 9
+    content: "Add Manuscript link to project detail page"
+    status: pending
+    dependencies: [8]
+  - id: 10
+    content: "Write component integration tests for ManuscriptPageContent"
+    status: pending
+    dependencies: [6, 7]
+---
+
+## Overview
+
+Manuscript View assembles all chapters and scenes from a `WritingProject` into a single
+continuous reading view accessible at `/workspace/[projectId]/manuscript`. The view is
+deliberately read-only — writers read or proof their work here, not edit it. A floating
+word count bar shows per-chapter word counts and the project grand total. A "Back to
+workspace" link and individual "Edit scene" deep-links allow navigation back into the
+editor. The feature adds no new localStorage keys and requires no changes to the data
+layer; it is a pure projection of the already-loaded `WritingProject`.
+
+---
+
+## Architecture / Data Model
+
+### What stays the same
+
+- `WritingProject`, `ProjectChapter`, `ProjectScene` types are unchanged.
+- `LocalProjectRepository` is read through the existing `ProjectService.getProjectById`.
+- No new Zod schemas are needed in `domain/`.
+- No changes to any existing page or repository.
+
+### What is added
+
+Two new read-only domain-level view types live in `src/domain/project/types.ts` as
+type-only additions (no Zod schema needed — these are derived, never persisted):
+
+```ts
+export type ManuscriptScene = {
+  id: string;
+  title: string;
+  content: string;
+  wordCount: number;
+};
+
+export type ManuscriptChapter = {
+  id: string;
+  title: string;
+  chapterIndex: number;
+  scenes: ManuscriptScene[];
+  wordCount: number;
+};
+
+export type Manuscript = {
+  projectTitle: string;
+  chapters: ManuscriptChapter[];
+  totalWordCount: number;
+};
+```
+
+A new `ManuscriptService` in `src/application/manuscript/manuscript-service.ts`
+holds the pure `buildManuscript(project: WritingProject): Manuscript` function. This is
+the only application-layer addition. The service takes a `WritingProject` (already loaded
+in memory) and maps it to the `Manuscript` view type. Word counting reuses the same
+split-on-whitespace strategy as `SceneEditorService.countWords`.
+
+---
+
+## Implementation Steps
+
+### Step 1 — Domain view types
+
+File to modify: `src/domain/project/types.ts`
+
+Add `ManuscriptScene`, `ManuscriptChapter`, and `Manuscript` as plain TypeScript type
+exports at the bottom of the file. These carry no Zod schemas since they are never stored.
+
+### Step 2 — ManuscriptService
+
+File to create: `src/application/manuscript/manuscript-service.ts`
+
+```ts
+import type { Manuscript, ManuscriptChapter, ManuscriptScene, WritingProject } from '@/domain/project/types';
+
+function countWords(content: string): number {
+  const trimmed = content.trim();
+  return trimmed ? trimmed.split(/\s+/).filter(Boolean).length : 0;
+}
+
+function buildManuscriptScene(scene: { id: string; title: string; content: string }): ManuscriptScene {
+  return {
+    id: scene.id,
+    title: scene.title,
+    content: scene.content,
+    wordCount: countWords(scene.content),
+  };
+}
+
+function buildManuscriptChapter(
+  chapterId: string,
+  chapterIndex: number,
+  project: WritingProject,
+): ManuscriptChapter | null {
+  const chapter = project.chapters[chapterId];
+  if (!chapter) return null;
+
+  const scenes = chapter.sceneOrder
+    .map((sceneId) => project.scenes[sceneId])
+    .filter((scene): scene is NonNullable<typeof scene> => Boolean(scene))
+    .map(buildManuscriptScene);
+
+  const wordCount = scenes.reduce((total, scene) => total + scene.wordCount, 0);
+
+  return {
+    id: chapterId,
+    title: chapter.title,
+    chapterIndex,
+    scenes,
+    wordCount,
+  };
+}
+
+export function buildManuscript(project: WritingProject): Manuscript {
+  const chapters = project.chapterOrder
+    .map((chapterId, index) => buildManuscriptChapter(chapterId, index, project))
+    .filter((chapter): chapter is ManuscriptChapter => chapter !== null);
+
+  const totalWordCount = chapters.reduce((total, chapter) => total + chapter.wordCount, 0);
+
+  return {
+    projectTitle: project.title,
+    chapters,
+    totalWordCount,
+  };
+}
+```
+
+### Step 3 — ManuscriptWordCountBar component
+
+File to create: `src/components/manuscript/manuscript-word-count-bar.tsx`
+
+```tsx
+'use client';
+import { memo } from 'react';
+import type { ReactElement } from 'react';
+import type { Manuscript } from '@/domain/project/types';
+
+type ManuscriptWordCountBarProps = {
+  manuscript: Manuscript;
+};
+
+export const ManuscriptWordCountBar = memo(function ManuscriptWordCountBar(
+  { manuscript }: ManuscriptWordCountBarProps,
+): ReactElement {
+  return (
+    <div className="sticky top-0 z-10 flex flex-wrap items-center gap-3 border-b bg-background/95 px-4 py-2 text-xs text-muted-foreground backdrop-blur">
+      {manuscript.chapters.map((chapter) => (
+        <span key={chapter.id}>
+          Ch. {chapter.chapterIndex + 1}: {chapter.wordCount.toLocaleString()} w
+        </span>
+      ))}
+      <span className="ml-auto font-semibold text-foreground">
+        Total: {manuscript.totalWordCount.toLocaleString()} words
+      </span>
+    </div>
+  );
+});
+```
+
+### Step 4 — ManuscriptSceneBlock component
+
+File to create: `src/components/manuscript/manuscript-scene-block.tsx`
+
+```tsx
+import { memo } from 'react';
+import type { ReactElement } from 'react';
+import type { ManuscriptScene } from '@/domain/project/types';
+
+type ManuscriptSceneBlockProps = {
+  scene: ManuscriptScene;
+  projectId: string;
+};
+
+export const ManuscriptSceneBlock = memo(function ManuscriptSceneBlock(
+  { scene, projectId }: ManuscriptSceneBlockProps,
+): ReactElement {
+  return (
+    <article className="space-y-3">
+      <div className="flex items-baseline justify-between gap-3">
+        <h3 className="text-lg font-semibold">{scene.title}</h3>
+        <a
+          href={`/workspace/${projectId}/scene/${scene.id}`}
+          className="shrink-0 text-xs text-primary hover:underline"
+        >
+          Edit
+        </a>
+      </div>
+      <div className="whitespace-pre-wrap text-sm leading-relaxed text-foreground">
+        {scene.content.trim() || (
+          <span className="italic text-muted-foreground">No content yet.</span>
+        )}
+      </div>
+      <hr className="border-muted" />
+    </article>
+  );
+});
+```
+
+### Step 5 — ManuscriptChapterSection component
+
+File to create: `src/components/manuscript/manuscript-chapter-section.tsx`
+
+```tsx
+import type { ReactElement } from 'react';
+import type { ManuscriptChapter } from '@/domain/project/types';
+import { ManuscriptSceneBlock } from './manuscript-scene-block';
+
+type ManuscriptChapterSectionProps = {
+  chapter: ManuscriptChapter;
+  projectId: string;
+};
+
+export function ManuscriptChapterSection(
+  { chapter, projectId }: ManuscriptChapterSectionProps,
+): ReactElement {
+  return (
+    <section className="space-y-6">
+      <div className="flex items-baseline justify-between border-b pb-2">
+        <h2 className="text-2xl font-bold">
+          {chapter.chapterIndex + 1}. {chapter.title}
+        </h2>
+        <span className="text-sm text-muted-foreground">
+          {chapter.wordCount.toLocaleString()} words
+        </span>
+      </div>
+      {chapter.scenes.length === 0 ? (
+        <p className="italic text-sm text-muted-foreground">No scenes in this chapter.</p>
+      ) : (
+        <div className="space-y-8">
+          {chapter.scenes.map((scene) => (
+            <ManuscriptSceneBlock key={scene.id} scene={scene} projectId={projectId} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+```
+
+### Step 6 — ManuscriptPageContent component
+
+File to create: `src/components/manuscript/manuscript-page-content.tsx`
+
+```tsx
+'use client';
+import Link from 'next/link';
+import type { ReactElement } from 'react';
+import { ManuscriptWordCountBar } from './manuscript-word-count-bar';
+import { ManuscriptChapterSection } from './manuscript-chapter-section';
+import { useManuscript } from '@/hooks/use-manuscript';
+
+type ManuscriptPageContentProps = {
+  projectId: string;
+};
+
+export function ManuscriptPageContent({ projectId }: ManuscriptPageContentProps): ReactElement {
+  const { loadState, manuscript } = useManuscript(projectId);
+
+  if (loadState === 'loading') {
+    return (
+      <main className="mx-auto flex min-h-screen w-full max-w-4xl items-center justify-center px-4">
+        <p className="text-muted-foreground">Loading manuscript...</p>
+      </main>
+    );
+  }
+
+  if (loadState === 'not-found') {
+    return (
+      <main className="mx-auto flex min-h-screen w-full max-w-4xl flex-col items-start justify-center gap-3 px-4">
+        <h1 className="text-2xl font-semibold">Project not found</h1>
+        <p className="text-sm text-muted-foreground">This project does not exist in local storage.</p>
+        <Link className="text-sm font-medium text-primary underline" href="/workspace">
+          Back to workspace
+        </Link>
+      </main>
+    );
+  }
+
+  if (loadState === 'error' || !manuscript) {
+    return (
+      <main className="mx-auto flex min-h-screen w-full max-w-4xl flex-col items-start justify-center gap-3 px-4">
+        <h1 className="text-2xl font-semibold">Unable to load manuscript</h1>
+        <Link className="text-sm font-medium text-primary underline" href={`/workspace/${projectId}`}>
+          Back to project
+        </Link>
+      </main>
+    );
+  }
+
+  return (
+    <div>
+      <ManuscriptWordCountBar manuscript={manuscript} />
+      <main className="mx-auto w-full max-w-3xl space-y-12 px-4 py-10">
+        <header className="space-y-1">
+          <h1 className="text-3xl font-bold">{manuscript.projectTitle}</h1>
+          <nav>
+            <Link
+              href={`/workspace/${projectId}`}
+              className="text-sm font-medium text-primary underline"
+            >
+              Back to project
+            </Link>
+          </nav>
+        </header>
+        {manuscript.chapters.length === 0 ? (
+          <p className="italic text-muted-foreground">No chapters yet.</p>
+        ) : (
+          manuscript.chapters.map((chapter) => (
+            <ManuscriptChapterSection key={chapter.id} chapter={chapter} projectId={projectId} />
+          ))
+        )}
+      </main>
+    </div>
+  );
+}
+```
+
+### Step 7 — useManuscript hook
+
+File to create: `src/hooks/use-manuscript.ts`
+
+```ts
+import { useEffect, useMemo, useState } from 'react';
+import { createProjectService } from '@/application/project/project-service';
+import { buildManuscript } from '@/application/manuscript/manuscript-service';
+import { LocalProjectRepository } from '@/data/project/local-project-repository';
+import type { Manuscript } from '@/domain/project/types';
+
+type ManuscriptLoadState = 'loading' | 'ready' | 'not-found' | 'error';
+
+type UseManuscriptResult = {
+  loadState: ManuscriptLoadState;
+  manuscript: Manuscript | null;
+};
+
+export function useManuscript(projectId: string): UseManuscriptResult {
+  const repository = useMemo(() => new LocalProjectRepository(), []);
+  const service = useMemo(() => createProjectService(repository), [repository]);
+  const [loadState, setLoadState] = useState<ManuscriptLoadState>('loading');
+  const [manuscript, setManuscript] = useState<Manuscript | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    void service.getProjectById(projectId).then((project) => {
+      if (!isMounted) return;
+      if (!project) { setLoadState('not-found'); return; }
+      setManuscript(buildManuscript(project));
+      setLoadState('ready');
+    }).catch(() => {
+      if (!isMounted) return;
+      setLoadState('error');
+    });
+
+    return () => { isMounted = false; };
+  }, [projectId, service]);
+
+  return { loadState, manuscript };
+}
+```
+
+### Step 8 — App route
+
+File to create: `src/app/workspace/[projectId]/manuscript/page.tsx`
+
+```tsx
+import type { ReactElement } from 'react';
+import { ManuscriptPageContent } from '@/components/manuscript/manuscript-page-content';
+
+type ManuscriptPageProps = {
+  params: Promise<{ projectId: string }>;
+};
+
+export default async function ManuscriptPage(props: ManuscriptPageProps): Promise<ReactElement> {
+  const { projectId } = await props.params;
+  return <ManuscriptPageContent projectId={projectId} />;
+}
+```
+
+### Step 9 — Link from project detail page
+
+File to modify: `src/app/workspace/[projectId]/page.tsx`
+
+Add a `ManuscriptSection` component and include it in `ProjectDetailView`:
+
+```tsx
+function ManuscriptSection({ projectId }: { projectId: string }): ReactElement {
+  return (
+    <section className="rounded-lg border p-4">
+      <h2 className="text-2xl font-semibold">Manuscript</h2>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Read your entire novel as a continuous document.
+      </p>
+      <div className="mt-3">
+        <Link
+          className="inline-flex rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground"
+          href={`/workspace/${projectId}/manuscript`}
+        >
+          Open Manuscript
+        </Link>
+      </div>
+    </section>
+  );
+}
+```
+
+---
+
+## Files
+
+### Create
+
+- `src/application/manuscript/manuscript-service.ts` — pure `buildManuscript` function
+- `src/components/manuscript/manuscript-word-count-bar.tsx` — sticky word count summary bar
+- `src/components/manuscript/manuscript-scene-block.tsx` — single scene renderer
+- `src/components/manuscript/manuscript-chapter-section.tsx` — chapter header + scene list
+- `src/components/manuscript/manuscript-page-content.tsx` — full page client component
+- `src/hooks/use-manuscript.ts` — data loading hook
+- `src/app/workspace/[projectId]/manuscript/page.tsx` — Next.js route page
+- `src/test/manuscript/manuscript-service.test.ts` — unit tests for buildManuscript
+- `src/test/manuscript/manuscript-page-content.test.tsx` — component integration tests
+
+### Modify
+
+- `src/domain/project/types.ts` — add `ManuscriptScene`, `ManuscriptChapter`, `Manuscript` types
+- `src/app/workspace/[projectId]/page.tsx` — add `ManuscriptSection` + link
+
+---
+
+## Testing
+
+### Unit tests: `src/test/manuscript/manuscript-service.test.ts`
+
+```
+describe('buildManuscript', () => {
+  it('returns projectTitle from the project')
+  it('orders chapters by chapterOrder')
+  it('orders scenes by chapter sceneOrder')
+  it('computes wordCount per scene from content')
+  it('computes wordCount per chapter as sum of scene word counts')
+  it('computes totalWordCount as sum of chapter word counts')
+  it('returns empty chapters array when chapterOrder is empty')
+  it('returns 0 totalWordCount when all scenes are empty')
+  it('sets chapterIndex correctly starting at 0')
+  it('skips missing chapter references gracefully')
+  it('skips missing scene references within a chapter gracefully')
+})
+```
+
+### Component integration tests: `src/test/manuscript/manuscript-page-content.test.tsx`
+
+```
+describe('ManuscriptPageContent', () => {
+  it('shows loading state initially')
+  it('renders project title after project loads')
+  it('renders chapter headings in order')
+  it('renders scene titles and content')
+  it('renders total word count in the bar')
+  it('renders Edit links for each scene pointing to scene editor')
+  it('renders Back to project link')
+  it('shows not-found message when projectId is invalid UUID')
+  it('shows empty chapter message when chapter has no scenes')
+})
+```
+
+---
+
+## User Flows
+
+1. Writer opens a project at `/workspace/[projectId]`.
+2. Writer sees the "Manuscript" section with an "Open Manuscript" button.
+3. Writer clicks and navigates to `/workspace/[projectId]/manuscript`.
+4. Sticky bar shows "Ch. 1: 1,200 w   Ch. 2: 800 w   Total: 2,000 words".
+5. Main area begins with the project title as `<h1>`.
+6. Each chapter has a large `<h2>` heading with index, title, and word count.
+7. Each scene: `<h3>` title, full content, horizontal divider, "Edit" link.
+8. Writer scrolls through the whole novel.
+9. Writer clicks "Edit" on a scene → navigates to scene editor.
+10. Writer clicks "Back to project" → returns to project detail page.
+
+---
+
+## Dependencies
+
+No new npm packages required. All utilities already present in the project.

--- a/docs/test-fixtures/invalid-import.json
+++ b/docs/test-fixtures/invalid-import.json
@@ -2,7 +2,7 @@
   "version": 2,
   "exportedAt": "2026-03-01T10:00:00.000Z",
   "project": {
-    "title": "Fichier corrompu",
-    "scenes": "pas un objet"
+    "title": "Corrupted file",
+    "scenes": "not an object"
   }
 }

--- a/docs/test-fixtures/valid-import.json
+++ b/docs/test-fixtures/valid-import.json
@@ -3,8 +3,8 @@
   "exportedAt": "2026-03-01T10:00:00.000Z",
   "project": {
     "id": "550e8400-e29b-4d4a-a716-446655440000",
-    "title": "Les Ombres de Valcourt",
-    "description": "Un roman policier historique se déroulant dans la France du XIXe siècle.",
+    "title": "Shadows of Valcourt",
+    "description": "A historical detective novel set in nineteenth-century England.",
     "createdAt": "2026-01-15T08:00:00.000Z",
     "updatedAt": "2026-02-28T18:30:00.000Z",
     "stats": {
@@ -13,7 +13,7 @@
       "chapterCount": 2
     },
     "settings": {
-      "language": "fr",
+      "language": "en",
       "targetWordCount": 80000
     },
     "chapterOrder": [
@@ -24,7 +24,7 @@
       "chap-0001-0000-0000-000000000001": {
         "id": "chap-0001-0000-0000-000000000001",
         "projectId": "550e8400-e29b-4d4a-a716-446655440000",
-        "title": "L'Arrivée à Valcourt",
+        "title": "Arrival at Valcourt",
         "sceneOrder": [
           "scen-0001-0000-0000-000000000001",
           "scen-0002-0000-0000-000000000002"
@@ -35,7 +35,7 @@
       "chap-0002-0000-0000-000000000002": {
         "id": "chap-0002-0000-0000-000000000002",
         "projectId": "550e8400-e29b-4d4a-a716-446655440000",
-        "title": "Le Manoir Maudit",
+        "title": "The Cursed Manor",
         "sceneOrder": [
           "scen-0003-0000-0000-000000000003",
           "scen-0004-0000-0000-000000000004"
@@ -48,32 +48,32 @@
       "scen-0001-0000-0000-000000000001": {
         "id": "scen-0001-0000-0000-000000000001",
         "projectId": "550e8400-e29b-4d4a-a716-446655440000",
-        "title": "La diligence",
-        "content": "La diligence cahota sur les pavés disjoints à l'entrée de Valcourt. Inspecteur Renaud écarta le rideau de cuir usé et observa la place du marché, déserte à cette heure matinale. Une brume grise s'accrochait aux toits d'ardoise, effaçant les contours des maisons comme une mauvaise conscience.\n\n— Valcourt, annonça le cocher depuis son perchoir. Terminus.\n\nRenaud descendit le premier, sa mallette de cuir noir sous le bras. Il n'était pas venu dans ce bourg depuis l'affaire Moreau, dix ans plus tôt. Rien n'avait changé, ou presque. La fontaine au centre de la place crachait toujours son filet d'eau rouillée. L'enseigne de l'auberge du Cerf d'Or se balançait dans le vent d'est.",
+        "title": "The Stagecoach",
+        "content": "The stagecoach rattled over the uneven cobblestones at the entrance to Valcourt. Inspector Renaud drew back the worn leather curtain and surveyed the market square, deserted at this early hour. A grey mist clung to the slate rooftops, blurring the outlines of the houses like a guilty conscience.\n\n— Valcourt, the coachman announced from his perch. End of the line.\n\nRenaud stepped down first, his black leather case tucked under his arm. He had not been to this village since the Moreau affair, ten years ago. Nothing had changed, or nearly so. The fountain at the centre of the square still dribbled its rusty trickle of water. The sign of the Golden Stag inn swayed in the east wind.",
         "status": "final",
         "updatedAt": "2026-02-10T14:00:00.000Z"
       },
       "scen-0002-0000-0000-000000000002": {
         "id": "scen-0002-0000-0000-000000000002",
         "projectId": "550e8400-e29b-4d4a-a716-446655440000",
-        "title": "L'auberge du Cerf d'Or",
-        "content": "L'aubergiste, un homme trapu aux favoris poivre et sel, posa ses deux poings sur le comptoir de chêne.\n\n— On n'a pas eu de visiteurs depuis la mort du comte, dit-il à voix basse, comme si les murs pouvaient entendre.\n\nRenaud commanda un verre de cidre et attendit. Il avait appris depuis longtemps que le silence était souvent plus efficace qu'une question. L'aubergiste finit par remplir le verre, les yeux baissés.\n\n— Le château est fermé. Madame la comtesse refuse de recevoir quiconque. Ils disent qu'elle est folle de chagrin. Moi je dis qu'elle a peur.\n\n— Peur de quoi ?\n\nL'homme haussa les épaules et s'éloigna vers l'autre bout du bar, soudainement passionné par le polissage de ses chopes en étain.",
+        "title": "The Golden Stag Inn",
+        "content": "The innkeeper, a stocky man with salt-and-pepper sideburns, planted both fists on the oak counter.\n\n— We haven't had any visitors since the count died, he said in a low voice, as though the walls might be listening.\n\nRenaud ordered a glass of cider and waited. He had learned long ago that silence was often more effective than a question. The innkeeper eventually filled the glass, eyes downcast.\n\n— The castle is closed. The countess refuses to see anyone. They say she's mad with grief. I say she's frightened.\n\n— Frightened of what?\n\nThe man shrugged and moved to the far end of the bar, suddenly absorbed in polishing his pewter tankards.",
         "status": "revise",
         "updatedAt": "2026-02-15T16:30:00.000Z"
       },
       "scen-0003-0000-0000-000000000003": {
         "id": "scen-0003-0000-0000-000000000003",
         "projectId": "550e8400-e29b-4d4a-a716-446655440000",
-        "title": "Les grilles du château",
-        "content": "Le château de Valcourt se dressait au sommet de la colline boisée, ses tourelles pointant vers un ciel couleur d'ardoise. Renaud avait marché une heure depuis le bourg, suivant un chemin de terre que les pluies de février avaient transformé en ruisseau de boue.\n\nLes grilles en fer forgé étaient cadenassées. Rouillées, aussi, sauf là où quelqu'un les avait frottées récemment — les barreaux du bas brillaient d'un éclat suspect. Renaud s'accroupit et examina la terre à ses pieds. Des empreintes de bottes, larges, profondes. Plusieurs passages, dans les deux sens.",
+        "title": "The Castle Gates",
+        "content": "Valcourt Castle rose at the crest of the wooded hill, its turrets pointing toward a slate-coloured sky. Renaud had walked an hour from the village along a dirt path that February rains had turned into a stream of mud.\n\nThe wrought-iron gates were padlocked. Rusted too, except where someone had recently scrubbed them — the lower bars gleamed with a suspicious shine. Renaud crouched and examined the ground at his feet. Boot prints, wide and deep. Several passes, in both directions.",
         "status": "draft",
         "updatedAt": "2026-02-20T11:00:00.000Z"
       },
       "scen-0004-0000-0000-000000000004": {
         "id": "scen-0004-0000-0000-000000000004",
         "projectId": "550e8400-e29b-4d4a-a716-446655440000",
-        "title": "La comtesse",
-        "content": "Elle l'attendait dans le grand salon, assise dans un fauteuil face à la cheminée éteinte. Une femme d'une cinquantaine d'années, le dos droit malgré tout, les mains croisées sur les genoux dans une attitude qui ressemblait à de la dignité mais que Renaud reconnut pour ce qu'elle était : de la terreur maîtrisée.\n\n— Inspecteur, dit-elle sans se retourner. Je savais qu'on vous enverrait.\n\n— Madame la comtesse. Mon supérieur pense que la mort de votre mari mérite qu'on y regarde de plus près.\n\nUn silence. Le bois craqua quelque part dans la maison. Elle ne bougea pas.\n\n— Mon mari est tombé dans l'escalier. C'est un accident. Il n'y a rien à examiner.",
+        "title": "The Countess",
+        "content": "She was waiting for him in the great drawing room, seated in an armchair facing the cold fireplace. A woman in her fifties, her back still straight, hands folded on her knees in an attitude that resembled dignity but which Renaud recognised for what it was: controlled terror.\n\n— Inspector, she said without turning. I knew they would send someone.\n\n— My superior believes your husband's death warrants a closer look.\n\nA silence. Wood creaked somewhere in the house. She did not move.\n\n— My husband fell on the staircase. It was an accident. There is nothing to examine.",
         "status": "draft",
         "updatedAt": "2026-02-28T18:30:00.000Z"
       }

--- a/src/app/workspace/[projectId]/manuscript/page.tsx
+++ b/src/app/workspace/[projectId]/manuscript/page.tsx
@@ -1,0 +1,11 @@
+import type { ReactElement } from 'react';
+import { ManuscriptPageContent } from '@/components/manuscript/manuscript-page-content';
+
+type ManuscriptPageProps = {
+  params: Promise<{ projectId: string }>;
+};
+
+export default async function ManuscriptPage(props: ManuscriptPageProps): Promise<ReactElement> {
+  const { projectId } = await props.params;
+  return <ManuscriptPageContent projectId={projectId} />;
+}

--- a/src/app/workspace/[projectId]/page.tsx
+++ b/src/app/workspace/[projectId]/page.tsx
@@ -413,6 +413,25 @@ function ProjectStoryBibleSection({ projectId }: { projectId: string }): ReactEl
   );
 }
 
+function ManuscriptSection({ projectId }: { projectId: string }): ReactElement {
+  return (
+    <section className="rounded-lg border p-4">
+      <h2 className="text-2xl font-headline font-semibold">Manuscript</h2>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Read your entire novel as a continuous document.
+      </p>
+      <div className="mt-3">
+        <Link
+          className="inline-flex rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground"
+          href={`/workspace/${projectId}/manuscript`}
+        >
+          Open Manuscript
+        </Link>
+      </div>
+    </section>
+  );
+}
+
 function ProjectWritingGoalsSection({ projectId }: { projectId: string }): ReactElement {
   return (
     <section className="rounded-lg border p-4">
@@ -456,6 +475,7 @@ function ProjectDetailView({
       <ProjectStats project={project} />
       <ChaptersSection projectId={projectId} project={project} chapterActions={chapterActions} />
       <ProjectStoryBibleSection projectId={projectId} />
+      <ManuscriptSection projectId={projectId} />
       <ProjectWritingGoalsSection projectId={projectId} />
       <ExportImportPanel exportService={exportService} projectId={projectId} projectTitle={project.title} />
       <Link className="text-sm font-medium text-primary underline" href="/workspace">

--- a/src/application/manuscript/manuscript-service.ts
+++ b/src/application/manuscript/manuscript-service.ts
@@ -1,0 +1,53 @@
+import type { Manuscript, ManuscriptChapter, ManuscriptScene, WritingProject } from '@/domain/project/types';
+
+function countWords(content: string): number {
+  const trimmed = content.trim();
+  return trimmed ? trimmed.split(/\s+/).filter(Boolean).length : 0;
+}
+
+function buildManuscriptScene(scene: { id: string; title: string; content: string }): ManuscriptScene {
+  return {
+    id: scene.id,
+    title: scene.title,
+    content: scene.content,
+    wordCount: countWords(scene.content),
+  };
+}
+
+function buildManuscriptChapter(
+  chapterId: string,
+  chapterIndex: number,
+  project: WritingProject,
+): ManuscriptChapter | null {
+  const chapter = project.chapters[chapterId];
+  if (!chapter) return null;
+
+  const scenes = chapter.sceneOrder
+    .map((sceneId) => project.scenes[sceneId])
+    .filter((scene): scene is NonNullable<typeof scene> => Boolean(scene))
+    .map(buildManuscriptScene);
+
+  const wordCount = scenes.reduce((total, scene) => total + scene.wordCount, 0);
+
+  return {
+    id: chapterId,
+    title: chapter.title,
+    chapterIndex,
+    scenes,
+    wordCount,
+  };
+}
+
+export function buildManuscript(project: WritingProject): Manuscript {
+  const chapters = project.chapterOrder
+    .map((chapterId, index) => buildManuscriptChapter(chapterId, index, project))
+    .filter((chapter): chapter is ManuscriptChapter => chapter !== null);
+
+  const totalWordCount = chapters.reduce((total, chapter) => total + chapter.wordCount, 0);
+
+  return {
+    projectTitle: project.title,
+    chapters,
+    totalWordCount,
+  };
+}

--- a/src/components/manuscript/manuscript-chapter-section.tsx
+++ b/src/components/manuscript/manuscript-chapter-section.tsx
@@ -1,0 +1,34 @@
+import type { ReactElement } from 'react';
+import type { ManuscriptChapter } from '@/domain/project/types';
+import { ManuscriptSceneBlock } from './manuscript-scene-block';
+
+type ManuscriptChapterSectionProps = {
+  chapter: ManuscriptChapter;
+  projectId: string;
+};
+
+export function ManuscriptChapterSection(
+  { chapter, projectId }: ManuscriptChapterSectionProps,
+): ReactElement {
+  return (
+    <section className="space-y-6">
+      <div className="flex items-baseline justify-between border-b pb-2">
+        <h2 className="text-2xl font-bold">
+          {chapter.chapterIndex + 1}. {chapter.title}
+        </h2>
+        <span className="text-sm text-muted-foreground">
+          {chapter.wordCount.toLocaleString()} words
+        </span>
+      </div>
+      {chapter.scenes.length === 0 ? (
+        <p className="italic text-sm text-muted-foreground">No scenes in this chapter.</p>
+      ) : (
+        <div className="space-y-8">
+          {chapter.scenes.map((scene) => (
+            <ManuscriptSceneBlock key={scene.id} scene={scene} projectId={projectId} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/manuscript/manuscript-page-content.tsx
+++ b/src/components/manuscript/manuscript-page-content.tsx
@@ -1,0 +1,71 @@
+'use client';
+import Link from 'next/link';
+import type { ReactElement } from 'react';
+import { ManuscriptWordCountBar } from './manuscript-word-count-bar';
+import { ManuscriptChapterSection } from './manuscript-chapter-section';
+import { useManuscript } from '@/hooks/use-manuscript';
+
+type ManuscriptPageContentProps = {
+  projectId: string;
+};
+
+export function ManuscriptPageContent({ projectId }: ManuscriptPageContentProps): ReactElement {
+  const { loadState, manuscript } = useManuscript(projectId);
+
+  if (loadState === 'loading') {
+    return (
+      <main className="mx-auto flex min-h-screen w-full max-w-4xl items-center justify-center px-4">
+        <p className="text-muted-foreground">Loading manuscript...</p>
+      </main>
+    );
+  }
+
+  if (loadState === 'not-found') {
+    return (
+      <main className="mx-auto flex min-h-screen w-full max-w-4xl flex-col items-start justify-center gap-3 px-4">
+        <h1 className="text-2xl font-semibold">Project not found</h1>
+        <p className="text-sm text-muted-foreground">This project does not exist in local storage.</p>
+        <Link className="text-sm font-medium text-primary underline" href="/workspace">
+          Back to workspace
+        </Link>
+      </main>
+    );
+  }
+
+  if (loadState === 'error' || !manuscript) {
+    return (
+      <main className="mx-auto flex min-h-screen w-full max-w-4xl flex-col items-start justify-center gap-3 px-4">
+        <h1 className="text-2xl font-semibold">Unable to load manuscript</h1>
+        <Link className="text-sm font-medium text-primary underline" href={`/workspace/${projectId}`}>
+          Back to project
+        </Link>
+      </main>
+    );
+  }
+
+  return (
+    <div>
+      <ManuscriptWordCountBar manuscript={manuscript} />
+      <main className="mx-auto w-full max-w-3xl space-y-12 px-4 py-10">
+        <header className="space-y-1">
+          <h1 className="text-3xl font-bold">{manuscript.projectTitle}</h1>
+          <nav>
+            <Link
+              href={`/workspace/${projectId}`}
+              className="text-sm font-medium text-primary underline"
+            >
+              Back to project
+            </Link>
+          </nav>
+        </header>
+        {manuscript.chapters.length === 0 ? (
+          <p className="italic text-muted-foreground">No chapters yet.</p>
+        ) : (
+          manuscript.chapters.map((chapter) => (
+            <ManuscriptChapterSection key={chapter.id} chapter={chapter} projectId={projectId} />
+          ))
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/components/manuscript/manuscript-scene-block.tsx
+++ b/src/components/manuscript/manuscript-scene-block.tsx
@@ -1,0 +1,32 @@
+import { memo } from 'react';
+import type { ReactElement } from 'react';
+import type { ManuscriptScene } from '@/domain/project/types';
+
+type ManuscriptSceneBlockProps = {
+  scene: ManuscriptScene;
+  projectId: string;
+};
+
+export const ManuscriptSceneBlock = memo(function ManuscriptSceneBlock(
+  { scene, projectId }: ManuscriptSceneBlockProps,
+): ReactElement {
+  return (
+    <article className="space-y-3">
+      <div className="flex items-baseline justify-between gap-3">
+        <h3 className="text-lg font-semibold">{scene.title}</h3>
+        <a
+          href={`/workspace/${projectId}/scene/${scene.id}`}
+          className="shrink-0 text-xs text-primary hover:underline"
+        >
+          Edit
+        </a>
+      </div>
+      <div className="whitespace-pre-wrap text-sm leading-relaxed text-foreground">
+        {scene.content.trim() || (
+          <span className="italic text-muted-foreground">No content yet.</span>
+        )}
+      </div>
+      <hr className="border-muted" />
+    </article>
+  );
+});

--- a/src/components/manuscript/manuscript-scene-block.tsx
+++ b/src/components/manuscript/manuscript-scene-block.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { memo } from 'react';
 import type { ReactElement } from 'react';
 import type { ManuscriptScene } from '@/domain/project/types';
@@ -14,12 +15,12 @@ export const ManuscriptSceneBlock = memo(function ManuscriptSceneBlock(
     <article className="space-y-3">
       <div className="flex items-baseline justify-between gap-3">
         <h3 className="text-lg font-semibold">{scene.title}</h3>
-        <a
+        <Link
           href={`/workspace/${projectId}/scene/${scene.id}`}
           className="shrink-0 text-xs text-primary hover:underline"
         >
           Edit
-        </a>
+        </Link>
       </div>
       <div className="whitespace-pre-wrap text-sm leading-relaxed text-foreground">
         {scene.content.trim() || (

--- a/src/components/manuscript/manuscript-word-count-bar.tsx
+++ b/src/components/manuscript/manuscript-word-count-bar.tsx
@@ -1,0 +1,25 @@
+'use client';
+import { memo } from 'react';
+import type { ReactElement } from 'react';
+import type { Manuscript } from '@/domain/project/types';
+
+type ManuscriptWordCountBarProps = {
+  manuscript: Manuscript;
+};
+
+export const ManuscriptWordCountBar = memo(function ManuscriptWordCountBar(
+  { manuscript }: ManuscriptWordCountBarProps,
+): ReactElement {
+  return (
+    <div className="sticky top-0 z-10 flex flex-wrap items-center gap-3 border-b bg-background/95 px-4 py-2 text-xs text-muted-foreground backdrop-blur">
+      {manuscript.chapters.map((chapter) => (
+        <span key={chapter.id}>
+          Ch. {chapter.chapterIndex + 1}: {chapter.wordCount.toLocaleString()} w
+        </span>
+      ))}
+      <span className="ml-auto font-semibold text-foreground">
+        Total: {manuscript.totalWordCount.toLocaleString()} words
+      </span>
+    </div>
+  );
+});

--- a/src/components/manuscript/manuscript-word-count-bar.tsx
+++ b/src/components/manuscript/manuscript-word-count-bar.tsx
@@ -11,7 +11,7 @@ export const ManuscriptWordCountBar = memo(function ManuscriptWordCountBar(
   { manuscript }: ManuscriptWordCountBarProps,
 ): ReactElement {
   return (
-    <div className="sticky top-0 z-10 flex flex-wrap items-center gap-3 border-b bg-background/95 px-4 py-2 text-xs text-muted-foreground backdrop-blur">
+    <div aria-label="Word count summary" className="sticky top-0 z-10 flex flex-wrap items-center gap-3 border-b bg-background/95 px-4 py-2 text-xs text-muted-foreground backdrop-blur">
       {manuscript.chapters.map((chapter) => (
         <span key={chapter.id}>
           Ch. {chapter.chapterIndex + 1}: {chapter.wordCount.toLocaleString()} w

--- a/src/components/workspace/chapter-outline-panel.tsx
+++ b/src/components/workspace/chapter-outline-panel.tsx
@@ -74,7 +74,7 @@ function SceneRow({
             onChange={(e) => {
               void actions.moveSceneToChapter(scene.id, e.target.value);
             }}
-            className="border rounded px-1.5 py-0.5 bg-background focus:outline-none"
+            className="border rounded px-1.5 py-0.5 bg-background focus:outline-none focus:ring-1 focus:ring-ring"
           >
             <option value="" disabled>—</option>
             {chapters

--- a/src/components/workspace/workspace-page-content.tsx
+++ b/src/components/workspace/workspace-page-content.tsx
@@ -58,7 +58,7 @@ function ImportProjectButton({ onSuccess }: { onSuccess: () => void }): ReactEle
       >
         {importing ? 'Importing…' : 'Import JSON backup'}
       </button>
-      <input accept=".json" className="hidden" onChange={handleImport} ref={fileInputRef} type="file" />
+      <input aria-hidden="true" accept=".json" className="hidden" onChange={handleImport} ref={fileInputRef} type="file" />
       {error ? (
         <p aria-live="polite" className="text-xs text-destructive" role="alert">
           {error}

--- a/src/domain/project/types.ts
+++ b/src/domain/project/types.ts
@@ -88,3 +88,24 @@ export type ProjectExport = {
   bible: unknown | null;
   sessions: unknown | null;
 };
+
+export type ManuscriptScene = {
+  id: string;
+  title: string;
+  content: string;
+  wordCount: number;
+};
+
+export type ManuscriptChapter = {
+  id: string;
+  title: string;
+  chapterIndex: number;
+  scenes: ManuscriptScene[];
+  wordCount: number;
+};
+
+export type Manuscript = {
+  projectTitle: string;
+  chapters: ManuscriptChapter[];
+  totalWordCount: number;
+};

--- a/src/hooks/use-manuscript.ts
+++ b/src/hooks/use-manuscript.ts
@@ -1,0 +1,37 @@
+import { useEffect, useMemo, useState } from 'react';
+import { createProjectService } from '@/application/project/project-service';
+import { buildManuscript } from '@/application/manuscript/manuscript-service';
+import { LocalProjectRepository } from '@/data/project/local-project-repository';
+import type { Manuscript } from '@/domain/project/types';
+
+type ManuscriptLoadState = 'loading' | 'ready' | 'not-found' | 'error';
+
+type UseManuscriptResult = {
+  loadState: ManuscriptLoadState;
+  manuscript: Manuscript | null;
+};
+
+export function useManuscript(projectId: string): UseManuscriptResult {
+  const repository = useMemo(() => new LocalProjectRepository(), []);
+  const service = useMemo(() => createProjectService(repository), [repository]);
+  const [loadState, setLoadState] = useState<ManuscriptLoadState>('loading');
+  const [manuscript, setManuscript] = useState<Manuscript | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    void service.getProjectById(projectId).then((project) => {
+      if (!isMounted) return;
+      if (!project) { setLoadState('not-found'); return; }
+      setManuscript(buildManuscript(project));
+      setLoadState('ready');
+    }).catch(() => {
+      if (!isMounted) return;
+      setLoadState('error');
+    });
+
+    return () => { isMounted = false; };
+  }, [projectId, service]);
+
+  return { loadState, manuscript };
+}

--- a/src/test/manuscript/manuscript-page-content.test.tsx
+++ b/src/test/manuscript/manuscript-page-content.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ManuscriptPageContent } from '@/components/manuscript/manuscript-page-content';
+import { useManuscript } from '@/hooks/use-manuscript';
+import type { Manuscript } from '@/domain/project/types';
+
+vi.mock('@/hooks/use-manuscript');
+
+const projectId = '550e8400-e29b-4d4a-a716-446655440000';
+
+const chapterAId = 'aaaaaaaa-0000-4000-8000-000000000001';
+const chapterBId = 'aaaaaaaa-0000-4000-8000-000000000002';
+const sceneXId = 'bbbbbbbb-0000-4000-8000-000000000001';
+const sceneYId = 'bbbbbbbb-0000-4000-8000-000000000002';
+
+const manuscriptWithScenes: Manuscript = {
+  projectTitle: 'The Great Novel',
+  totalWordCount: 5,
+  chapters: [
+    {
+      id: chapterAId,
+      title: 'The Beginning',
+      chapterIndex: 0,
+      wordCount: 3,
+      scenes: [
+        { id: sceneXId, title: 'Dawn Breaks', content: 'The sun rose slowly.', wordCount: 3 },
+      ],
+    },
+    {
+      id: chapterBId,
+      title: 'The Middle',
+      chapterIndex: 1,
+      wordCount: 2,
+      scenes: [
+        { id: sceneYId, title: 'Conflict Begins', content: 'Trouble arrives.', wordCount: 2 },
+      ],
+    },
+  ],
+};
+
+const manuscriptWithEmptyChapter: Manuscript = {
+  projectTitle: 'Empty Novel',
+  totalWordCount: 0,
+  chapters: [
+    {
+      id: chapterAId,
+      title: 'Blank Chapter',
+      chapterIndex: 0,
+      wordCount: 0,
+      scenes: [],
+    },
+  ],
+};
+
+describe('ManuscriptPageContent', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows loading state initially', () => {
+    vi.mocked(useManuscript).mockReturnValue({ loadState: 'loading', manuscript: null });
+
+    render(<ManuscriptPageContent projectId={projectId} />);
+
+    expect(screen.getByText('Loading manuscript...')).toBeInTheDocument();
+  });
+
+  it('renders project title after project loads', () => {
+    vi.mocked(useManuscript).mockReturnValue({ loadState: 'ready', manuscript: manuscriptWithScenes });
+
+    render(<ManuscriptPageContent projectId={projectId} />);
+
+    expect(screen.getByRole('heading', { level: 1, name: 'The Great Novel' })).toBeInTheDocument();
+  });
+
+  it('renders chapter headings in order', () => {
+    vi.mocked(useManuscript).mockReturnValue({ loadState: 'ready', manuscript: manuscriptWithScenes });
+
+    render(<ManuscriptPageContent projectId={projectId} />);
+
+    const headings = screen.getAllByRole('heading', { level: 2 });
+    expect(headings[0]).toHaveTextContent('1. The Beginning');
+    expect(headings[1]).toHaveTextContent('2. The Middle');
+  });
+
+  it('renders scene titles and content', () => {
+    vi.mocked(useManuscript).mockReturnValue({ loadState: 'ready', manuscript: manuscriptWithScenes });
+
+    render(<ManuscriptPageContent projectId={projectId} />);
+
+    expect(screen.getByRole('heading', { level: 3, name: 'Dawn Breaks' })).toBeInTheDocument();
+    expect(screen.getByText('The sun rose slowly.')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3, name: 'Conflict Begins' })).toBeInTheDocument();
+    expect(screen.getByText('Trouble arrives.')).toBeInTheDocument();
+  });
+
+  it('renders total word count in the bar', () => {
+    vi.mocked(useManuscript).mockReturnValue({ loadState: 'ready', manuscript: manuscriptWithScenes });
+
+    render(<ManuscriptPageContent projectId={projectId} />);
+
+    expect(screen.getByText('Total: 5 words')).toBeInTheDocument();
+  });
+
+  it('renders Edit links for each scene pointing to scene editor', () => {
+    vi.mocked(useManuscript).mockReturnValue({ loadState: 'ready', manuscript: manuscriptWithScenes });
+
+    render(<ManuscriptPageContent projectId={projectId} />);
+
+    const editLinks = screen.getAllByRole('link', { name: 'Edit' });
+    expect(editLinks).toHaveLength(2);
+    expect(editLinks[0]).toHaveAttribute('href', `/workspace/${projectId}/scene/${sceneXId}`);
+    expect(editLinks[1]).toHaveAttribute('href', `/workspace/${projectId}/scene/${sceneYId}`);
+  });
+
+  it('renders Back to project link', () => {
+    vi.mocked(useManuscript).mockReturnValue({ loadState: 'ready', manuscript: manuscriptWithScenes });
+
+    render(<ManuscriptPageContent projectId={projectId} />);
+
+    const backLink = screen.getByRole('link', { name: 'Back to project' });
+    expect(backLink).toHaveAttribute('href', `/workspace/${projectId}`);
+  });
+
+  it('shows not-found message when projectId is invalid UUID', () => {
+    vi.mocked(useManuscript).mockReturnValue({ loadState: 'not-found', manuscript: null });
+
+    render(<ManuscriptPageContent projectId="non-existent-id" />);
+
+    expect(screen.getByRole('heading', { name: 'Project not found' })).toBeInTheDocument();
+    expect(screen.getByText('This project does not exist in local storage.')).toBeInTheDocument();
+  });
+
+  it('shows empty chapter message when chapter has no scenes', () => {
+    vi.mocked(useManuscript).mockReturnValue({ loadState: 'ready', manuscript: manuscriptWithEmptyChapter });
+
+    render(<ManuscriptPageContent projectId={projectId} />);
+
+    expect(screen.getByText('No scenes in this chapter.')).toBeInTheDocument();
+  });
+});

--- a/src/test/manuscript/manuscript-service.test.ts
+++ b/src/test/manuscript/manuscript-service.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect } from 'vitest';
+
+import { buildManuscript } from '@/application/manuscript/manuscript-service';
+import type { WritingProject } from '@/domain/project/types';
+
+const baseProject: WritingProject = {
+  id: '550e8400-e29b-4d4a-a716-446655440000',
+  title: 'My Novel',
+  description: '',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  stats: { wordCount: 0, sceneCount: 0, chapterCount: 0 },
+  settings: { language: 'en', targetWordCount: null },
+  chapterOrder: [],
+  chapters: {},
+  scenes: {},
+};
+
+const chapterA = 'aaaaaaaa-0000-4000-8000-000000000001';
+const chapterB = 'aaaaaaaa-0000-4000-8000-000000000002';
+const sceneX = 'bbbbbbbb-0000-4000-8000-000000000001';
+const sceneY = 'bbbbbbbb-0000-4000-8000-000000000002';
+
+describe('buildManuscript', () => {
+  it('returns projectTitle from the project', () => {
+    const project = { ...baseProject, title: 'War and Peace' };
+    const result = buildManuscript(project);
+    expect(result.projectTitle).toBe('War and Peace');
+  });
+
+  it('returns empty chapters array when chapterOrder is empty', () => {
+    const result = buildManuscript(baseProject);
+    expect(result.chapters).toEqual([]);
+  });
+
+  it('returns 0 totalWordCount when all scenes are empty', () => {
+    const project: WritingProject = {
+      ...baseProject,
+      chapterOrder: [chapterA],
+      chapters: {
+        [chapterA]: {
+          id: chapterA,
+          projectId: baseProject.id,
+          title: 'Chapter 1',
+          sceneOrder: [sceneX],
+          wordCount: 0,
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+      scenes: {
+        [sceneX]: {
+          id: sceneX,
+          projectId: baseProject.id,
+          title: 'Scene 1',
+          content: '',
+          status: 'draft',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+    };
+    const result = buildManuscript(project);
+    expect(result.totalWordCount).toBe(0);
+  });
+
+  it('orders chapters by chapterOrder', () => {
+    const project: WritingProject = {
+      ...baseProject,
+      chapterOrder: [chapterB, chapterA],
+      chapters: {
+        [chapterA]: {
+          id: chapterA,
+          projectId: baseProject.id,
+          title: 'Alpha',
+          sceneOrder: [],
+          wordCount: 0,
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+        [chapterB]: {
+          id: chapterB,
+          projectId: baseProject.id,
+          title: 'Beta',
+          sceneOrder: [],
+          wordCount: 0,
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+    };
+    const result = buildManuscript(project);
+    expect(result.chapters.map((c) => c.title)).toEqual(['Beta', 'Alpha']);
+  });
+
+  it('sets chapterIndex correctly starting at 0', () => {
+    const project: WritingProject = {
+      ...baseProject,
+      chapterOrder: [chapterA, chapterB],
+      chapters: {
+        [chapterA]: {
+          id: chapterA,
+          projectId: baseProject.id,
+          title: 'First',
+          sceneOrder: [],
+          wordCount: 0,
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+        [chapterB]: {
+          id: chapterB,
+          projectId: baseProject.id,
+          title: 'Second',
+          sceneOrder: [],
+          wordCount: 0,
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+    };
+    const result = buildManuscript(project);
+    expect(result.chapters[0]?.chapterIndex).toBe(0);
+    expect(result.chapters[1]?.chapterIndex).toBe(1);
+  });
+
+  it('orders scenes by chapter sceneOrder', () => {
+    const project: WritingProject = {
+      ...baseProject,
+      chapterOrder: [chapterA],
+      chapters: {
+        [chapterA]: {
+          id: chapterA,
+          projectId: baseProject.id,
+          title: 'Chapter 1',
+          sceneOrder: [sceneY, sceneX],
+          wordCount: 0,
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+      scenes: {
+        [sceneX]: {
+          id: sceneX,
+          projectId: baseProject.id,
+          title: 'Scene X',
+          content: 'hello world',
+          status: 'draft',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+        [sceneY]: {
+          id: sceneY,
+          projectId: baseProject.id,
+          title: 'Scene Y',
+          content: 'foo bar baz',
+          status: 'draft',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+    };
+    const result = buildManuscript(project);
+    expect(result.chapters[0]?.scenes.map((s) => s.title)).toEqual(['Scene Y', 'Scene X']);
+  });
+
+  it('computes wordCount per scene from content', () => {
+    const project: WritingProject = {
+      ...baseProject,
+      chapterOrder: [chapterA],
+      chapters: {
+        [chapterA]: {
+          id: chapterA,
+          projectId: baseProject.id,
+          title: 'Chapter 1',
+          sceneOrder: [sceneX],
+          wordCount: 0,
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+      scenes: {
+        [sceneX]: {
+          id: sceneX,
+          projectId: baseProject.id,
+          title: 'Scene X',
+          content: 'one two three four five',
+          status: 'draft',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+    };
+    const result = buildManuscript(project);
+    expect(result.chapters[0]?.scenes[0]?.wordCount).toBe(5);
+  });
+
+  it('computes wordCount per chapter as sum of scene word counts', () => {
+    const project: WritingProject = {
+      ...baseProject,
+      chapterOrder: [chapterA],
+      chapters: {
+        [chapterA]: {
+          id: chapterA,
+          projectId: baseProject.id,
+          title: 'Chapter 1',
+          sceneOrder: [sceneX, sceneY],
+          wordCount: 0,
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+      scenes: {
+        [sceneX]: {
+          id: sceneX,
+          projectId: baseProject.id,
+          title: 'Scene X',
+          content: 'one two three',
+          status: 'draft',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+        [sceneY]: {
+          id: sceneY,
+          projectId: baseProject.id,
+          title: 'Scene Y',
+          content: 'four five',
+          status: 'draft',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+    };
+    const result = buildManuscript(project);
+    expect(result.chapters[0]?.wordCount).toBe(5);
+  });
+
+  it('computes totalWordCount as sum of chapter word counts', () => {
+    const project: WritingProject = {
+      ...baseProject,
+      chapterOrder: [chapterA, chapterB],
+      chapters: {
+        [chapterA]: {
+          id: chapterA,
+          projectId: baseProject.id,
+          title: 'Chapter 1',
+          sceneOrder: [sceneX],
+          wordCount: 0,
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+        [chapterB]: {
+          id: chapterB,
+          projectId: baseProject.id,
+          title: 'Chapter 2',
+          sceneOrder: [sceneY],
+          wordCount: 0,
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+      scenes: {
+        [sceneX]: {
+          id: sceneX,
+          projectId: baseProject.id,
+          title: 'Scene X',
+          content: 'one two three',
+          status: 'draft',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+        [sceneY]: {
+          id: sceneY,
+          projectId: baseProject.id,
+          title: 'Scene Y',
+          content: 'four five six seven',
+          status: 'draft',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+    };
+    const result = buildManuscript(project);
+    expect(result.totalWordCount).toBe(7);
+  });
+
+  it('skips missing chapter references gracefully', () => {
+    const project: WritingProject = {
+      ...baseProject,
+      chapterOrder: ['non-existent-id', chapterA],
+      chapters: {
+        [chapterA]: {
+          id: chapterA,
+          projectId: baseProject.id,
+          title: 'Real Chapter',
+          sceneOrder: [],
+          wordCount: 0,
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+    };
+    const result = buildManuscript(project);
+    expect(result.chapters).toHaveLength(1);
+    expect(result.chapters[0]?.title).toBe('Real Chapter');
+  });
+
+  it('skips missing scene references within a chapter gracefully', () => {
+    const project: WritingProject = {
+      ...baseProject,
+      chapterOrder: [chapterA],
+      chapters: {
+        [chapterA]: {
+          id: chapterA,
+          projectId: baseProject.id,
+          title: 'Chapter 1',
+          sceneOrder: ['ghost-scene-id', sceneX],
+          wordCount: 0,
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+      scenes: {
+        [sceneX]: {
+          id: sceneX,
+          projectId: baseProject.id,
+          title: 'Real Scene',
+          content: 'hello',
+          status: 'draft',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+    };
+    const result = buildManuscript(project);
+    expect(result.chapters[0]?.scenes).toHaveLength(1);
+    expect(result.chapters[0]?.scenes[0]?.title).toBe('Real Scene');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `ManuscriptScene`, `ManuscriptChapter`, and `Manuscript` view types to `src/domain/project/types.ts` (pure TypeScript, no Zod schema — derived, never persisted)
- Add `buildManuscript(project)` pure function in `src/application/manuscript/manuscript-service.ts` — maps `WritingProject` to a `Manuscript` with per-scene/chapter/total word counts
- Add `useManuscript` hook, four `src/components/manuscript/` components, and Next.js route at `/workspace/[projectId]/manuscript`
- Add "Open Manuscript" link in the project detail page (`ManuscriptSection`)
- Add unit tests (11 cases) and component integration tests (9 cases); fix three accessibility issues flagged by pre-PR audit

## Test plan

- [x] `npm run test:ci` — 21 test files, 145 tests, 0 failures
- [x] Playwright smoke test — 13/13 scenarios pass (word count bar, chapter headings, scene content, Edit links, Back to project, not-found state, 0 console errors)
- [x] No new localStorage keys — purely derived from existing `WritingProject`
- [ ] Open `/workspace/[projectId]/manuscript` in a real browser and scroll through a seeded project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ✨ Manuscript View Release Notes

### Key Features
- **New Manuscript View**: Display your writing project as a formatted manuscript with automatic word counting and chapter/scene organization
- **Manuscript Page Route**: Access manuscripts via `/workspace/{projectId}/manuscript`
- **Word Count Summary**: Sticky header bar showing per-chapter and total word counts (formatted with locale-aware numbers)
- **Scene Editing**: Direct links to edit individual scenes from the manuscript view
- **Chapter Organization**: Automatic chapter and scene ordering based on project structure

### Improvements
- Project detail page now includes "Open Manuscript" link for quick access
- Pure projection architecture—manuscript data derived from existing WritingProject with no new storage keys or persisted state
- Graceful handling of missing chapter or scene references
- Accessibility enhancements:
  - Added aria-label to word-count summary bar
  - Added focus ring styling to chapter selection controls
  - Hidden file inputs marked with aria-hidden

### Technical Changes
- **New TypeScript Types** (`src/domain/project/types.ts`): `ManuscriptScene`, `ManuscriptChapter`, `Manuscript`
- **Service Layer** (`src/application/manuscript/`): `buildManuscript()` function for converting WritingProject to Manuscript with word counting
- **React Components** (`src/components/manuscript/`):
  - `ManuscriptWordCountBar`: Sticky header with word counts
  - `ManuscriptSceneBlock`: Individual scene card with title, content, and edit link
  - `ManuscriptChapterSection`: Chapter grouping with chapter-level word count
  - `ManuscriptPageContent`: Main page composition and load state handling
- **Custom Hook** (`src/hooks/use-manuscript.ts`): `useManuscript()` for loading and building manuscript data
- **Next.js Route**: New App Router page at `src/app/workspace/[projectId]/manuscript/page.tsx`

### Testing & Quality
- 11 unit tests for `buildManuscript` (word counting, chapter/scene ordering, graceful missing reference handling)
- 9 component integration tests for manuscript page UI
- All 145 tests passing with zero failures
- Accessibility audit completed with fixes applied

### Affected Areas
- **Frontend**: New page, components, hook, and routing
- **Domain**: New type definitions for manuscript projection
- **Application**: New service layer for manuscript building
- **No Breaking Changes**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->