### PR TITLE
✨ feat: AI scene draft with OpenRouter model selector

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,0 @@
-# No required environment variables for local-first development.

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,2 @@
+# For testing with a real OpenRouter key:
+OPENROUTER_TEST_KEY=sk-or-v1-your-key-here

--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ next-env.d.ts
 
 # environment variables
 .env*
-!.env.example
+!.env.local.example
 
 # Editors
 .vscode/*

--- a/docs/plans/2026-03-02-ai-scene-draft.plan.md
+++ b/docs/plans/2026-03-02-ai-scene-draft.plan.md
@@ -1,0 +1,399 @@
+---
+name: ai-scene-draft
+overview: |
+  From the scene editor, a writer can click "Generate Draft" to send the scene synopsis, beats, and
+  relevant Codex entities (via the existing codex context system) to OpenRouter's AI API, which returns
+  a prose draft that pre-fills the scene content editor. The writer provides their own OpenRouter API key
+  stored in localStorage. The feature is entirely local-first: no key or content ever touches a server.
+todos:
+  - id: 1
+    content: "Add AiSettings domain type and localStorage key; build LocalAiSettingsRepository to persist the OpenRouter API key"
+    status: pending
+    dependencies: []
+  - id: 2
+    content: "Build AiSettingsService in application layer (saveKey, loadKey, clearKey, hasKey)"
+    status: pending
+    dependencies: [1]
+  - id: 3
+    content: "Add domain types for SceneDraftRequest and SceneDraftResult"
+    status: pending
+    dependencies: []
+  - id: 4
+    content: "Build SceneDraftService: assemble prompt from scene + entities, call OpenRouter via fetch, return draft string"
+    status: pending
+    dependencies: [2, 3]
+  - id: 5
+    content: "Write Vitest unit tests for SceneDraftService (mock fetch, assert prompt shape, assert error handling)"
+    status: pending
+    dependencies: [4]
+  - id: 6
+    content: "Build AiSettingsPanel component for API key entry (input + save + clear)"
+    status: pending
+    dependencies: [2]
+  - id: 7
+    content: "Add AI Settings section to the workspace project page"
+    status: pending
+    dependencies: [6]
+  - id: 8
+    content: "Build useSceneDraft hook: calls SceneDraftService, exposes isGenerating / generateError / generate()"
+    status: pending
+    dependencies: [4]
+  - id: 9
+    content: "Add GenerateDraftButton component to scene editor"
+    status: pending
+    dependencies: [8]
+  - id: 10
+    content: "Wire GenerateDraftButton into SceneEditorShell with matchedEntities from useCodexContext"
+    status: pending
+    dependencies: [9]
+  - id: 11
+    content: "Run npm run test:ci and fix any regressions"
+    status: pending
+    dependencies: [10]
+---
+
+## Overview
+
+When a writer has filled in a synopsis and beats for a scene, they can click "Generate Draft" in the
+scene editor. The app assembles a structured prompt from the scene title, synopsis, beat list, and any
+Codex entities currently detected by `useCodexContext`, then calls the OpenRouter API
+(`https://openrouter.ai/api/v1/chat/completions`) directly from the browser. The returned prose
+pre-fills the content textarea, and the existing autosave debounce persists it after 800ms of inactivity.
+
+The writer supplies their own OpenRouter API key once, via a new "AI Settings" panel on the project
+page. The key is stored only in `localStorage` under `ainkwell:ai:settings:v1`. It is never sent to
+any Ainkwell server, never exported with the project JSON, and rendered as a password input in the UI.
+
+---
+
+## Architecture / Data Model
+
+### New localStorage key
+
+| Key | Contents |
+|-----|----------|
+| `ainkwell:ai:settings:v1` | `{ openRouterApiKey: string }` — global, not per-project |
+
+This key is intentionally not namespaced per project because it is a user-level credential.
+
+### New domain layer — `src/domain/ai/types.ts`
+
+```ts
+export type AiSettings = {
+  openRouterApiKey: string;
+};
+
+export type SceneDraftRequest = {
+  sceneTitle: string;
+  synopsis: string;
+  beats: SceneBeat[];
+  entities: BibleEntity[];
+  language: string;
+};
+
+export type SceneDraftResult =
+  | { state: 'success'; draft: string }
+  | { state: 'no-api-key' }
+  | { state: 'api-error'; message: string };
+```
+
+No Zod schemas for `SceneDraftRequest` or `SceneDraftResult` — transient in-memory types, never
+persisted. A minimal Zod schema for `AiSettings` lives in the data layer for safe deserialization.
+
+### New application services — `src/application/ai/`
+
+**`AiSettingsService`**: thin wrapper over `LocalAiSettingsRepository`.
+- `loadSettings(): AiSettings | null`
+- `saveKey(key: string): void` — trims, rejects empty, throws `AiSettingsError`
+- `clearKey(): void`
+- `hasKey(): boolean`
+
+**`SceneDraftService`**: orchestrates the OpenRouter call.
+- `generateDraft(request: SceneDraftRequest): Promise<SceneDraftResult>`
+- Builds system + user prompts
+- Calls `https://openrouter.ai/api/v1/chat/completions` via native `fetch`
+- Default model constant: `OPENROUTER_DEFAULT_MODEL = 'google/gemini-flash-1.5'`
+- Handles HTTP 4xx/5xx, JSON parse errors, missing response body
+
+### New data repository — `src/data/ai/local-ai-settings-repository.ts`
+
+Mirrors `LocalBibleRepository` SSR guard pattern:
+
+```ts
+export class LocalAiSettingsRepository {
+  private readonly storage: Storage | null;
+
+  public constructor(storage?: Storage) {
+    this.storage = storage ?? (typeof window !== 'undefined' ? window.localStorage : null);
+  }
+}
+```
+
+---
+
+## Implementation Steps
+
+### Task 1 — Domain types and repository
+
+**Create:** `src/domain/ai/types.ts`, `src/data/ai/local-ai-settings-repository.ts`
+
+```ts
+const AI_SETTINGS_STORAGE_KEY = 'ainkwell:ai:settings:v1';
+
+const aiSettingsSchema = z.object({
+  openRouterApiKey: z.string(),
+});
+```
+
+Implement `load()`, `save(settings)`, `clear()` with `JSON.parse`/`JSON.stringify` guarded by `try/catch`.
+
+### Task 2 — AiSettingsService
+
+**Create:** `src/application/ai/ai-settings-service.ts`
+
+```ts
+export class AiSettingsError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = 'AiSettingsError';
+  }
+}
+
+export class AiSettingsService {
+  public constructor(private readonly repository: LocalAiSettingsRepository) {}
+
+  public saveKey(key: string): void {
+    const trimmedKey = key.trim();
+    if (!trimmedKey) throw new AiSettingsError('API key cannot be empty');
+    this.repository.save({ openRouterApiKey: trimmedKey });
+  }
+  // ...
+}
+```
+
+### Task 3 — SceneDraftService
+
+**Create:** `src/application/ai/scene-draft-service.ts`
+
+**System prompt:**
+```
+You are a creative writing assistant. Write immersive, literary prose.
+Language: {language}.
+Do not include chapter headings or scene titles.
+Return only the scene prose.
+
+Story context:
+{entities.map(e => `- ${e.name} (${e.category}): ${e.summary.slice(0, 200)}`).join('\n')}
+```
+
+**User prompt:**
+```
+Write a scene draft based on this outline:
+
+Title: {sceneTitle}
+Synopsis: {synopsis}
+Beats:
+{beats.map(b => `- [${b.type}] ${b.content}`).join('\n')}
+
+Write the full scene in {language}.
+```
+
+**Fetch call:**
+```ts
+const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+  method: 'POST',
+  headers: {
+    'Authorization': `Bearer ${apiKey}`,
+    'Content-Type': 'application/json',
+    'HTTP-Referer': 'https://ainkwell.app',
+  },
+  body: JSON.stringify({
+    model: OPENROUTER_DEFAULT_MODEL,
+    messages: [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userPrompt },
+    ],
+    max_tokens: 2000,
+    temperature: 0.7,
+  }),
+});
+```
+
+Return `{ state: 'no-api-key' }` immediately when `hasKey()` is false. On non-2xx:
+`{ state: 'api-error', message: \`${status}: ${statusText}\` }`. On fetch throw:
+`{ state: 'api-error', message: 'Network error. Check your connection.' }`.
+
+### Task 4 — Tests
+
+**Create:**
+- `src/test/ai/ai-settings-service.test.ts` — uses real `LocalAiSettingsRepository` backed by `window.localStorage`
+- `src/test/ai/scene-draft-service.test.ts` — mocks fetch with `vi.stubGlobal`
+
+### Task 5 — AiSettingsPanel component
+
+**Create:** `src/components/ai/ai-settings-panel.tsx`
+
+Collapsible section (same pattern as `ExportImportPanel`). Renders:
+- Status: "API key configured" or "No API key set"
+- `<input type="password">` for key entry
+- "Save Key" / "Clear Key" buttons
+- Disclaimer: "Your key is stored only in this browser. It is never sent to any Ainkwell server."
+- Link to `https://openrouter.ai/keys`
+
+**Modify:** `src/app/workspace/[projectId]/page.tsx` — add `AiSettingsSection` after `ProjectWritingGoalsSection`.
+
+### Task 6 — useSceneDraft hook
+
+**Create:** `src/hooks/use-scene-draft.ts`
+
+```ts
+type UseSceneDraftResult = {
+  isGenerating: boolean;
+  generateError: string | null;
+  canGenerate: boolean;   // Boolean(scene?.synopsis?.trim())
+  generate: () => Promise<void>;
+  clearError: () => void;
+};
+```
+
+`generate()` guards on `canGenerate`, sets `isGenerating`, calls service, handles all three
+`SceneDraftResult` states, calls `onDraftReady` on success, always clears `isGenerating` in `finally`.
+
+### Task 7 — GenerateDraftButton component
+
+**Create:** `src/components/scene/generate-draft-button.tsx`
+
+```ts
+type GenerateDraftButtonProps = {
+  isGenerating: boolean;
+  generateError: string | null;
+  canGenerate: boolean;
+  onGenerate: () => void;
+  onClearError: () => void;
+};
+```
+
+Reuses `SceneSaveError` styling from `scene-toolbar.tsx` for the inline error alert.
+
+### Task 8 — Wire into SceneEditorShell
+
+**Modify:** `src/components/scene/scene-editor-shell.tsx`
+
+In `useShellServices`, add:
+```ts
+const draftService = useMemo(
+  () => new SceneDraftService(new AiSettingsService(new LocalAiSettingsRepository())),
+  [],
+);
+```
+
+Pass `draftService` to `SceneEditorLoadedView`. Inside it:
+```ts
+const { isGenerating, generateError, canGenerate, generate, clearError } = useSceneDraft({
+  scene: props.sceneEditor.scene,
+  entities: matchedEntities,
+  language: props.language ?? 'en',
+  service: props.draftService,
+  onDraftReady: props.sceneEditor.setContent,
+});
+```
+
+Place `<GenerateDraftButton>` above the content textarea, right-aligned.
+
+---
+
+## Files
+
+### Create
+- `src/domain/ai/types.ts`
+- `src/data/ai/local-ai-settings-repository.ts`
+- `src/application/ai/ai-settings-service.ts`
+- `src/application/ai/scene-draft-service.ts`
+- `src/components/ai/ai-settings-panel.tsx`
+- `src/components/scene/generate-draft-button.tsx`
+- `src/hooks/use-scene-draft.ts`
+- `src/test/ai/ai-settings-service.test.ts`
+- `src/test/ai/scene-draft-service.test.ts`
+
+### Modify
+- `src/app/workspace/[projectId]/page.tsx` — add `AiSettingsSection`
+- `src/components/scene/scene-editor-shell.tsx` — add `draftService`, `useSceneDraft`, `GenerateDraftButton`, `language` prop
+
+---
+
+## Security
+
+**API key in localStorage:** Rendered as `type="password"`, never re-displayed after saving, not
+included in `ProjectExport` schema. Clear disclaimer in UI.
+
+**Direct browser-to-OpenRouter:** No Ainkwell server sees the key or prompt. `HTTP-Referer` header
+identifies the app per OpenRouter guidelines, contains no user data.
+
+**Prompt injection:** Synopsis capped at 300 chars, each beat at 200 chars by existing Zod schemas.
+Entity summaries truncated to 200 chars before embedding. Output only affects local scene content.
+
+**HTTPS only:** Fetch target hardcoded to `https://openrouter.ai`.
+
+---
+
+## Testing
+
+```
+src/test/ai/ai-settings-service.test.ts
+  - returns null when no key is stored
+  - saves and retrieves a trimmed key
+  - throws AiSettingsError when saving an empty string
+  - throws AiSettingsError when saving whitespace-only string
+  - hasKey returns false after clearKey
+  - hasKey returns true after saveKey
+
+src/test/ai/scene-draft-service.test.ts
+  - returns no-api-key state when no key is configured
+  - returns success with draft content on 200 response
+  - returns api-error on 401 response with message
+  - returns api-error on 429 response with message
+  - returns api-error when fetch throws a network error
+  - includes entity names and categories in the request body
+  - includes beat content in the request body
+  - includes language in the request body
+  - strips code fences from the returned draft
+```
+
+---
+
+## User Flows
+
+**Flow A — First-time API key setup:**
+1. User opens `/workspace/{projectId}`
+2. User finds the "AI Settings" section (below Writing Goals)
+3. User pastes OpenRouter API key → clicks "Save Key" → shows "Saved" for 2s
+4. Key written to `ainkwell:ai:settings:v1`
+
+**Flow B — Generating a draft:**
+1. User opens scene with synopsis + beats filled in
+2. "Generate Draft" button appears above content textarea
+3. User clicks → button shows "Generating..." (disabled)
+4. Fetch to OpenRouter → on success: textarea fills with draft, autosave fires after 800ms
+5. User edits freely
+
+**Flow C — No API key:**
+- Inline error: "Set your OpenRouter API key in project settings."
+
+**Flow D — No synopsis:**
+- Button disabled; tooltip: "Add a synopsis to enable AI draft generation"
+
+**Flow E — API error:**
+- Inline error with status message (e.g., "401: Unauthorized")
+
+---
+
+## Dependencies
+
+No new npm packages required. Native browser `fetch` API, fully available in modern browsers and
+`happy-dom` test environment. OpenRouter uses the OpenAI request/response format — no SDK needed.
+
+Default model: `google/gemini-flash-1.5` — fast, low-cost, strong prose quality. Defined as named
+constant `OPENROUTER_DEFAULT_MODEL` at the top of `SceneDraftService`.
+
+If streaming responses are desired later, the `openai` npm package can be added for a progressive
+text-reveal UI. For this iteration, a single-fill approach is appropriate.

--- a/docs/plans/2026-03-08-model-selector-design.md
+++ b/docs/plans/2026-03-08-model-selector-design.md
@@ -1,0 +1,60 @@
+# Model Selector Design
+
+**Date:** 2026-03-08
+**Status:** approved
+
+## Goal
+
+Let writers choose their OpenRouter model from a searchable dialog — same UX as mivoa — without leaving the AI Settings panel. The selected model persists in localStorage and is used on every "Generate Draft" call.
+
+## Approach
+
+Option A: model stored in `AiSettings` (localStorage), read at generation time by `SceneDraftService`. No React Context, no global state.
+
+## Data Model
+
+`AiSettings` gains an optional `selectedModel` field:
+
+```ts
+export type AiSettings = {
+  openRouterApiKey: string;
+  selectedModel?: string;
+};
+
+export type OpenRouterModel = {
+  id: string;
+  name: string;
+  description: string;
+  context_length: number | null;
+  pricing: { prompt: string; completion: string };
+};
+```
+
+Default model: `google/gemini-2.0-flash-001`
+
+## Layers Changed
+
+| File | Change |
+|------|--------|
+| `src/domain/ai/types.ts` | Add `OpenRouterModel`, add `selectedModel?` to `AiSettings` |
+| `src/data/ai/local-ai-settings-repository.ts` | Zod schema: `selectedModel: z.string().optional()` |
+| `src/application/ai/model-fetcher.ts` | New — `fetchAvailableModels(apiKey)`, `formatPrice()`, `formatContextLength()`, `extractProvider()` |
+| `src/application/ai/ai-settings-service.ts` | Add `saveModel(modelId)`, `getSelectedModel(): string` |
+| `src/application/ai/scene-draft-service.ts` | Use `aiSettingsService.getSelectedModel()` instead of hardcoded constant |
+| `src/hooks/use-model-loader.ts` | Fetches models when dialog opens, manages loading/error state |
+| `src/components/ai/model-card.tsx` | Clickable card: name, provider, price/1K tokens, context length, checkmark if selected |
+| `src/components/ai/model-selection-dialog.tsx` | `<dialog>` HTML, search input, scrollable model list |
+| `src/components/ai/ai-settings-panel.tsx` | Add "Model: [name]" button that opens dialog |
+
+## User Flow
+
+1. AI Settings panel shows current model name (e.g. "Gemini 2.0 Flash")
+2. Click → dialog opens, fetches `/api/v1/models` with stored API key
+3. User filters by name, selects model → `aiSettingsService.saveModel(id)` → dialog closes
+4. "Generate Draft" → `SceneDraftService.generateDraft()` → `getSelectedModel()` → uses selected model
+
+## Testing
+
+- Unit: `model-fetcher.ts` helpers (formatPrice, formatContextLength, extractProvider)
+- Unit: `ai-settings-service` — saveModel, getSelectedModel (default and stored)
+- No Playwright needed (model list is an external API; key interaction is covered by existing tests)

--- a/docs/plans/2026-03-08-model-selector.plan.md
+++ b/docs/plans/2026-03-08-model-selector.plan.md
@@ -1,0 +1,707 @@
+# Model Selector Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a searchable model selection dialog to the AI Settings panel, letting writers pick any OpenRouter model. The selected model persists in localStorage and is used at generation time.
+
+**Architecture:** Option A — `selectedModel` added to `AiSettings` (localStorage). `SceneDraftService` reads the model from `aiSettingsService.getSelectedModel()` on every `generateDraft()` call. No React Context needed. Models are fetched live from OpenRouter when the dialog opens, using the stored API key.
+
+**Tech Stack:** Next.js App Router (`'use client'`), Vitest, `<dialog>` HTML element, Tailwind CSS, Zod (schema update), fetch API.
+
+---
+
+### Task 1: Add `OpenRouterModel` type and `selectedModel` to `AiSettings`
+
+**Files:**
+- Modify: `src/domain/ai/types.ts`
+
+**Step 1: Update the file**
+
+Replace the current content of `src/domain/ai/types.ts`:
+
+```ts
+import type { BibleEntity } from '@/domain/bible/types';
+import type { SceneBeat } from '@/domain/scene/schemas';
+
+export type OpenRouterModel = {
+  id: string;
+  name: string;
+  description: string;
+  context_length: number | null;
+  pricing: {
+    prompt: string;
+    completion: string;
+  };
+};
+
+export type AiSettings = {
+  openRouterApiKey: string;
+  selectedModel?: string;
+};
+
+export type SceneDraftRequest = {
+  sceneTitle: string;
+  synopsis: string;
+  beats: SceneBeat[];
+  entities: BibleEntity[];
+  language: string;
+};
+
+export type SceneDraftResult =
+  | { state: 'success'; draft: string }
+  | { state: 'no-api-key' }
+  | { state: 'api-error'; message: string };
+```
+
+**Step 2: Run typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: no errors (the new optional field is backward-compatible).
+
+**Step 3: Commit**
+
+```bash
+git add src/domain/ai/types.ts
+git commit -m "✨ feat: add OpenRouterModel type and selectedModel to AiSettings"
+```
+
+---
+
+### Task 2: Update repository Zod schema for `selectedModel`
+
+**Files:**
+- Modify: `src/data/ai/local-ai-settings-repository.ts`
+
+**Step 1: Update the schema**
+
+In `src/data/ai/local-ai-settings-repository.ts`, update `aiSettingsSchema`:
+
+```ts
+const aiSettingsSchema = z.object({
+  openRouterApiKey: z.string(),
+  selectedModel: z.string().optional(),
+});
+```
+
+No other changes needed — `save()` and `load()` already handle the full `AiSettings` object.
+
+**Step 2: Run existing tests**
+
+```bash
+npx vitest run src/test/ai/ai-settings-service.test.ts
+```
+
+Expected: all pass (schema change is backward-compatible — `selectedModel` is optional).
+
+**Step 3: Commit**
+
+```bash
+git add src/data/ai/local-ai-settings-repository.ts
+git commit -m "✨ feat: persist selectedModel in ai settings repository"
+```
+
+---
+
+### Task 3: Create `model-fetcher.ts` with fetch + format helpers
+
+**Files:**
+- Create: `src/application/ai/model-fetcher.ts`
+- Create: `src/test/ai/model-fetcher.test.ts`
+
+**Step 1: Write the failing tests**
+
+Create `src/test/ai/model-fetcher.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  formatPrice,
+  formatContextLength,
+  extractProvider,
+} from '@/application/ai/model-fetcher';
+
+describe('formatPrice', () => {
+  it('formats non-zero prompt and completion prices per 1K tokens', () => {
+    expect(formatPrice('0.000001', '0.000002')).toBe('$0.001 / $0.002 per 1K tokens');
+  });
+
+  it('shows $0 for zero prices', () => {
+    expect(formatPrice('0', '0')).toBe('$0 / $0 per 1K tokens');
+  });
+
+  it('returns N/A for invalid prices', () => {
+    expect(formatPrice('', '')).toBe('N/A');
+  });
+});
+
+describe('formatContextLength', () => {
+  it('formats millions', () => {
+    expect(formatContextLength(1_000_000)).toBe('1.0M tokens');
+  });
+
+  it('formats thousands', () => {
+    expect(formatContextLength(128_000)).toBe('128K tokens');
+  });
+
+  it('formats small values', () => {
+    expect(formatContextLength(512)).toBe('512 tokens');
+  });
+
+  it('returns N/A for null', () => {
+    expect(formatContextLength(null)).toBe('N/A');
+  });
+});
+
+describe('extractProvider', () => {
+  it('capitalizes the provider from a model id', () => {
+    expect(extractProvider('google/gemini-2.0-flash-001')).toBe('Google');
+  });
+
+  it('handles anthropic', () => {
+    expect(extractProvider('anthropic/claude-3-5-sonnet')).toBe('Anthropic');
+  });
+
+  it('returns empty string for malformed id', () => {
+    expect(extractProvider('')).toBe('');
+  });
+});
+```
+
+**Step 2: Run to verify failure**
+
+```bash
+npx vitest run src/test/ai/model-fetcher.test.ts
+```
+
+Expected: FAIL — "Cannot find module '@/application/ai/model-fetcher'"
+
+**Step 3: Implement `model-fetcher.ts`**
+
+Create `src/application/ai/model-fetcher.ts`:
+
+```ts
+import type { OpenRouterModel } from '@/domain/ai/types';
+
+const OPENROUTER_MODELS_URL = 'https://openrouter.ai/api/v1/models';
+const PRICE_PER_K = 1000;
+const PRICE_DECIMAL_PLACES = 3;
+
+export async function fetchAvailableModels(apiKey: string): Promise<OpenRouterModel[]> {
+  const response = await fetch(OPENROUTER_MODELS_URL, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+  if (!response.ok) throw new Error(`Failed to fetch models: ${response.status}`);
+  const data = (await response.json()) as { data: OpenRouterModel[] };
+  return data.data ?? [];
+}
+
+export function formatPrice(prompt: string, completion: string): string {
+  const p = parseFloat(prompt);
+  const c = parseFloat(completion);
+  if (isNaN(p) || isNaN(c)) return 'N/A';
+  const fmt = (v: number): string =>
+    v === 0 ? '$0' : `$${(v * PRICE_PER_K).toFixed(PRICE_DECIMAL_PLACES)}`;
+  return `${fmt(p)} / ${fmt(c)} per 1K tokens`;
+}
+
+export function formatContextLength(contextLength: number | null): string {
+  if (!contextLength) return 'N/A';
+  if (contextLength >= 1_000_000) return `${(contextLength / 1_000_000).toFixed(1)}M tokens`;
+  if (contextLength >= 1_000) return `${Math.round(contextLength / 1_000)}K tokens`;
+  return `${contextLength} tokens`;
+}
+
+export function extractProvider(modelId: string): string {
+  const provider = modelId.split('/')[0] ?? '';
+  return provider.charAt(0).toUpperCase() + provider.slice(1);
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+npx vitest run src/test/ai/model-fetcher.test.ts
+```
+
+Expected: all pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/application/ai/model-fetcher.ts src/test/ai/model-fetcher.test.ts
+git commit -m "✨ feat: add model-fetcher with fetch and format helpers"
+```
+
+---
+
+### Task 4: Add `saveModel` and `getSelectedModel` to `AiSettingsService`
+
+**Files:**
+- Modify: `src/application/ai/ai-settings-service.ts`
+- Modify: `src/test/ai/ai-settings-service.test.ts`
+
+**Step 1: Write the failing tests**
+
+Add to `src/test/ai/ai-settings-service.test.ts` inside the `AiSettingsService` describe block:
+
+```ts
+describe('AiSettingsService model selection', () => {
+  it('returns default model when none is saved', () => {
+    const repo = new LocalAiSettingsRepository(new InMemoryStorage());
+    const service = new AiSettingsService(repo);
+    expect(service.getSelectedModel()).toBe('google/gemini-2.0-flash-001');
+  });
+
+  it('returns the saved model after saveModel', () => {
+    const repo = new LocalAiSettingsRepository(new InMemoryStorage());
+    const service = new AiSettingsService(repo);
+    // need a key first so repo has settings to merge into
+    service.saveKey('sk-test-key');
+    service.saveModel('anthropic/claude-3-5-sonnet');
+    expect(service.getSelectedModel()).toBe('anthropic/claude-3-5-sonnet');
+  });
+
+  it('preserves the api key when saving a model', () => {
+    const repo = new LocalAiSettingsRepository(new InMemoryStorage());
+    const service = new AiSettingsService(repo);
+    service.saveKey('sk-my-key');
+    service.saveModel('openai/gpt-4o');
+    expect(service.hasKey()).toBe(true);
+  });
+});
+```
+
+**Step 2: Run to verify failure**
+
+```bash
+npx vitest run src/test/ai/ai-settings-service.test.ts
+```
+
+Expected: FAIL — "service.getSelectedModel is not a function"
+
+**Step 3: Implement the new methods**
+
+In `src/application/ai/ai-settings-service.ts`, add after `hasKey()`:
+
+```ts
+const DEFAULT_MODEL = 'google/gemini-2.0-flash-001';
+
+public getSelectedModel(): string {
+  return this.repository.load()?.selectedModel ?? DEFAULT_MODEL;
+}
+
+public saveModel(modelId: string): void {
+  const current = this.repository.load();
+  const apiKey = current?.openRouterApiKey ?? '';
+  this.repository.save({ openRouterApiKey: apiKey, selectedModel: modelId });
+}
+```
+
+Place `DEFAULT_MODEL` as a module-level constant at the top of the file, after the imports.
+
+**Step 4: Run tests**
+
+```bash
+npx vitest run src/test/ai/ai-settings-service.test.ts
+```
+
+Expected: all pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/application/ai/ai-settings-service.ts src/test/ai/ai-settings-service.test.ts
+git commit -m "✨ feat: add saveModel and getSelectedModel to AiSettingsService"
+```
+
+---
+
+### Task 5: Use `getSelectedModel()` in `SceneDraftService`
+
+**Files:**
+- Modify: `src/application/ai/scene-draft-service.ts`
+
+**Step 1: Remove the hardcoded constant and use the service**
+
+In `src/application/ai/scene-draft-service.ts`:
+- Delete the line `const OPENROUTER_DEFAULT_MODEL = 'google/gemini-2.0-flash-001';`
+- In `generateDraft()`, replace `model: OPENROUTER_DEFAULT_MODEL` with `model: this.aiSettingsService.getSelectedModel()`
+
+**Step 2: Run existing draft service tests**
+
+```bash
+npx vitest run src/test/ai/scene-draft-service.test.ts
+```
+
+Expected: all pass. The tests mock `hasKey()` and `loadSettings()` — `getSelectedModel()` needs to be stubbed too. If any test fails because `getSelectedModel` is not mocked, add it to the mock:
+
+```ts
+getSelectedModel: vi.fn().mockReturnValue('google/gemini-2.0-flash-001'),
+```
+
+Add this to the `mockAiSettingsService` object in the test file.
+
+**Step 3: Run full CI**
+
+```bash
+npm run test:ci
+```
+
+Expected: all pass.
+
+**Step 4: Commit**
+
+```bash
+git add src/application/ai/scene-draft-service.ts src/test/ai/scene-draft-service.test.ts
+git commit -m "♻️ refactor: use getSelectedModel() instead of hardcoded model constant"
+```
+
+---
+
+### Task 6: Create `useModelLoader` hook
+
+**Files:**
+- Create: `src/hooks/use-model-loader.ts`
+
+No unit test needed — this hook is an async state wrapper around `fetchAvailableModels`. It will be covered by Playwright testing.
+
+**Step 1: Create the hook**
+
+Create `src/hooks/use-model-loader.ts`:
+
+```ts
+import { useState, useCallback } from 'react';
+
+import type { AiSettingsService } from '@/application/ai/ai-settings-service';
+import { fetchAvailableModels } from '@/application/ai/model-fetcher';
+import type { OpenRouterModel } from '@/domain/ai/types';
+
+export type UseModelLoaderResult = {
+  models: OpenRouterModel[];
+  isLoading: boolean;
+  error: string | null;
+  load: () => Promise<void>;
+};
+
+export function useModelLoader(service: AiSettingsService): UseModelLoaderResult {
+  const [models, setModels] = useState<OpenRouterModel[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async (): Promise<void> => {
+    const settings = service.loadSettings();
+    if (!settings?.openRouterApiKey) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const fetched = await fetchAvailableModels(settings.openRouterApiKey);
+      setModels(fetched);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load models.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [service]);
+
+  return { models, isLoading, error, load };
+}
+```
+
+**Step 2: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: no errors.
+
+**Step 3: Commit**
+
+```bash
+git add src/hooks/use-model-loader.ts
+git commit -m "✨ feat: add useModelLoader hook"
+```
+
+---
+
+### Task 7: Create `ModelCard` component
+
+**Files:**
+- Create: `src/components/ai/model-card.tsx`
+
+**Step 1: Create the component**
+
+Create `src/components/ai/model-card.tsx`:
+
+```tsx
+import type { ReactElement } from 'react';
+
+import { extractProvider, formatContextLength, formatPrice } from '@/application/ai/model-fetcher';
+import type { OpenRouterModel } from '@/domain/ai/types';
+
+type ModelCardProps = {
+  model: OpenRouterModel;
+  isSelected: boolean;
+  onSelect: (modelId: string) => void;
+};
+
+export function ModelCard({ model, isSelected, onSelect }: ModelCardProps): ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(model.id)}
+      className={`w-full text-left p-3 rounded-lg border transition-colors ${
+        isSelected
+          ? 'border-primary bg-primary/5'
+          : 'border-border hover:bg-muted'
+      }`}
+    >
+      <div className="flex items-start gap-2">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-0.5">
+            <span className="text-sm font-medium truncate">{model.name}</span>
+            {isSelected ? <span className="text-primary text-xs flex-shrink-0">✓</span> : null}
+          </div>
+          <p className="text-xs text-muted-foreground mb-1">{extractProvider(model.id)}</p>
+          <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-xs text-muted-foreground">
+            <span>💰 {formatPrice(model.pricing.prompt, model.pricing.completion)}</span>
+            <span>📏 {formatContextLength(model.context_length)}</span>
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+}
+```
+
+**Step 2: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: no errors.
+
+**Step 3: Commit**
+
+```bash
+git add src/components/ai/model-card.tsx
+git commit -m "✨ feat: add ModelCard component with price and context length"
+```
+
+---
+
+### Task 8: Create `ModelSelectionDialog` component
+
+**Files:**
+- Create: `src/components/ai/model-selection-dialog.tsx`
+
+**Step 1: Create the component**
+
+Create `src/components/ai/model-selection-dialog.tsx`:
+
+```tsx
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { ReactElement } from 'react';
+
+import type { AiSettingsService } from '@/application/ai/ai-settings-service';
+import { ModelCard } from '@/components/ai/model-card';
+import { useModelLoader } from '@/hooks/use-model-loader';
+
+type ModelSelectionDialogProps = {
+  service: AiSettingsService;
+  selectedModel: string;
+  onSelect: (modelId: string) => void;
+  onClose: () => void;
+};
+
+export function ModelSelectionDialog({
+  service,
+  selectedModel,
+  onSelect,
+  onClose,
+}: ModelSelectionDialogProps): ReactElement {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [search, setSearch] = useState('');
+  const { models, isLoading, error, load } = useModelLoader(service);
+
+  useEffect(() => {
+    dialogRef.current?.showModal();
+    void load();
+  }, [load]);
+
+  const filtered = models.filter(
+    (m) =>
+      m.name.toLowerCase().includes(search.toLowerCase()) ||
+      m.id.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  function handleSelect(modelId: string): void {
+    onSelect(modelId);
+    onClose();
+  }
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onClose={onClose}
+      className="w-full max-w-xl rounded-xl border bg-card p-0 shadow-lg backdrop:bg-black/50"
+    >
+      <div className="flex flex-col max-h-[80vh]">
+        <div className="p-4 border-b space-y-3">
+          <h2 className="text-lg font-headline font-semibold">Select model</h2>
+          <input
+            type="search"
+            placeholder="Search models…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full rounded border bg-background px-3 py-1.5 text-sm"
+            autoFocus
+          />
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-4 space-y-2 min-h-[200px]">
+          {isLoading ? (
+            <p className="text-sm text-muted-foreground text-center py-8">Loading models…</p>
+          ) : null}
+          {error ? (
+            <p className="text-sm text-destructive text-center py-8">{error}</p>
+          ) : null}
+          {!isLoading && !error && filtered.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-8">No models found.</p>
+          ) : null}
+          {!isLoading && !error
+            ? filtered.map((model) => (
+                <ModelCard
+                  key={model.id}
+                  model={model}
+                  isSelected={model.id === selectedModel}
+                  onSelect={handleSelect}
+                />
+              ))
+            : null}
+        </div>
+
+        <div className="p-4 border-t flex justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded border border-border px-3 py-1.5 text-sm hover:bg-muted"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </dialog>
+  );
+}
+```
+
+**Step 2: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: no errors.
+
+**Step 3: Commit**
+
+```bash
+git add src/components/ai/model-selection-dialog.tsx
+git commit -m "✨ feat: add ModelSelectionDialog with search and model list"
+```
+
+---
+
+### Task 9: Wire up model selector in `AiSettingsPanel`
+
+**Files:**
+- Modify: `src/components/ai/ai-settings-panel.tsx`
+
+**Step 1: Add model selector state and dialog**
+
+In `src/components/ai/ai-settings-panel.tsx`:
+
+1. Add import:
+```ts
+import { ModelSelectionDialog } from '@/components/ai/model-selection-dialog';
+```
+
+2. Add state inside `AiSettingsPanel`:
+```ts
+const [showModelDialog, setShowModelDialog] = useState(false);
+const [selectedModel, setSelectedModel] = useState(() => service.getSelectedModel());
+```
+
+3. Add handler:
+```ts
+function handleModelSelect(modelId: string): void {
+  service.saveModel(modelId);
+  setSelectedModel(modelId);
+}
+```
+
+4. Add the model button + dialog **after** the key section and before the disclaimer `<p>`, inside the JSX:
+```tsx
+<div className="flex items-center gap-2">
+  <span className="text-xs text-muted-foreground">Model:</span>
+  <button
+    type="button"
+    onClick={() => setShowModelDialog(true)}
+    disabled={!hasKey}
+    title={hasKey ? 'Change model' : 'Set an API key first'}
+    className="text-xs underline hover:no-underline disabled:cursor-not-allowed disabled:opacity-40"
+  >
+    {selectedModel.split('/').pop() ?? selectedModel}
+  </button>
+</div>
+
+{showModelDialog ? (
+  <ModelSelectionDialog
+    service={service}
+    selectedModel={selectedModel}
+    onSelect={handleModelSelect}
+    onClose={() => setShowModelDialog(false)}
+  />
+) : null}
+```
+
+**Step 2: Run full CI**
+
+```bash
+npm run test:ci
+```
+
+Expected: all pass.
+
+**Step 3: Commit**
+
+```bash
+git add src/components/ai/ai-settings-panel.tsx
+git commit -m "✨ feat: add model selector button and dialog to AiSettingsPanel"
+```
+
+---
+
+### Task 10: Final verification
+
+**Step 1: Run full CI**
+
+```bash
+npm run test:ci
+```
+
+Expected: all 146+ tests pass, no lint or type errors.
+
+**Step 2: Manual smoke test**
+- Go to `/workspace`, confirm "Model: gemini-2.0-flash-001" appears in AI Settings (only if key is set)
+- Click it → dialog opens, models load, search works, selection saves
+- Generate Draft in scene editor → uses the newly selected model

--- a/src/app/auth/openrouter/callback/page.tsx
+++ b/src/app/auth/openrouter/callback/page.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { Suspense, type ReactElement } from 'react';
+import { useOAuthCallback } from '@/hooks/use-oauth-callback';
+
+function CallbackContent(): ReactElement {
+  const { status, errorMessage } = useOAuthCallback();
+
+  if (status === 'success') {
+    return (
+      <div className="flex flex-col items-center gap-3 text-center">
+        <span className="text-4xl">✓</span>
+        <p className="font-medium">OpenRouter connected!</p>
+        <p className="text-sm text-muted-foreground">Redirecting to workspace…</p>
+      </div>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <div className="flex flex-col items-center gap-3 text-center">
+        <span className="text-4xl">✗</span>
+        <p className="font-medium text-destructive">Connection failed</p>
+        {errorMessage ? (
+          <p className="text-sm text-muted-foreground">{errorMessage}</p>
+        ) : null}
+        <a
+          href="/workspace"
+          className="mt-2 rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted"
+        >
+          Back to workspace
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-3 text-center">
+      <p className="text-sm text-muted-foreground">Connecting to OpenRouter…</p>
+    </div>
+  );
+}
+
+export default function OpenRouterCallbackPage(): ReactElement {
+  return (
+    <main className="flex min-h-screen items-center justify-center p-4">
+      <div className="w-full max-w-sm rounded-xl border bg-card p-8 text-card-foreground shadow-sm">
+        <Suspense
+          fallback={
+            <p className="text-center text-sm text-muted-foreground">Loading…</p>
+          }
+        >
+          <CallbackContent />
+        </Suspense>
+      </div>
+    </main>
+  );
+}

--- a/src/app/auth/openrouter/callback/page.tsx
+++ b/src/app/auth/openrouter/callback/page.tsx
@@ -8,8 +8,8 @@ function CallbackContent(): ReactElement {
 
   if (status === 'success') {
     return (
-      <div className="flex flex-col items-center gap-3 text-center">
-        <span className="text-4xl">✓</span>
+      <div aria-live="polite" className="flex flex-col items-center gap-3 text-center">
+        <span aria-hidden="true" className="text-4xl">✓</span>
         <p className="font-medium">OpenRouter connected!</p>
         <p className="text-sm text-muted-foreground">Redirecting to workspace…</p>
       </div>
@@ -18,8 +18,8 @@ function CallbackContent(): ReactElement {
 
   if (status === 'error') {
     return (
-      <div className="flex flex-col items-center gap-3 text-center">
-        <span className="text-4xl">✗</span>
+      <div aria-live="polite" className="flex flex-col items-center gap-3 text-center">
+        <span aria-hidden="true" className="text-4xl">✗</span>
         <p className="font-medium text-destructive">Connection failed</p>
         {errorMessage ? (
           <p className="text-sm text-muted-foreground">{errorMessage}</p>
@@ -35,7 +35,7 @@ function CallbackContent(): ReactElement {
   }
 
   return (
-    <div className="flex flex-col items-center gap-3 text-center">
+    <div aria-live="polite" className="flex flex-col items-center gap-3 text-center">
       <p className="text-sm text-muted-foreground">Connecting to OpenRouter…</p>
     </div>
   );

--- a/src/app/workspace/[projectId]/scene/[sceneId]/page.tsx
+++ b/src/app/workspace/[projectId]/scene/[sceneId]/page.tsx
@@ -7,12 +7,13 @@ type ScenePageProps = {
     projectId: string;
     sceneId: string;
   }>;
-  searchParams: Promise<{ from?: string }>;
+  searchParams: Promise<{ from?: string | string[] }>;
 };
 
 export default async function ScenePage(props: ScenePageProps): Promise<ReactElement> {
   const [params, searchParams] = await Promise.all([props.params, props.searchParams]);
-  const backTo = searchParams.from === 'outline' ? 'outline' : 'workspace';
+  const from = Array.isArray(searchParams.from) ? searchParams.from[0] : searchParams.from;
+  const backTo = from === 'outline' ? 'outline' : 'workspace';
 
   return <SceneEditorShell projectId={params.projectId} sceneId={params.sceneId} backTo={backTo} />;
 }

--- a/src/app/workspace/[projectId]/scene/[sceneId]/page.tsx
+++ b/src/app/workspace/[projectId]/scene/[sceneId]/page.tsx
@@ -7,10 +7,12 @@ type ScenePageProps = {
     projectId: string;
     sceneId: string;
   }>;
+  searchParams: Promise<{ from?: string }>;
 };
 
 export default async function ScenePage(props: ScenePageProps): Promise<ReactElement> {
-  const params = await props.params;
+  const [params, searchParams] = await Promise.all([props.params, props.searchParams]);
+  const backTo = searchParams.from === 'outline' ? 'outline' : 'workspace';
 
-  return <SceneEditorShell projectId={params.projectId} sceneId={params.sceneId} />;
+  return <SceneEditorShell projectId={params.projectId} sceneId={params.sceneId} backTo={backTo} />;
 }

--- a/src/app/workspace/page.tsx
+++ b/src/app/workspace/page.tsx
@@ -2,10 +2,13 @@
 
 import type { Dispatch, ReactElement, SetStateAction } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { AiSettingsService } from '@/application/ai/ai-settings-service';
 import { createProjectService } from '@/application/project/project-service';
 import type { ProjectService } from '@/application/project/project-service';
+import { AiSettingsPanel } from '@/components/ai/ai-settings-panel';
 import { WorkspacePageContent } from '@/components/workspace/workspace-page-content';
 import type { ProjectFormValues } from '@/components/workspace/project-form';
+import { LocalAiSettingsRepository } from '@/data/ai/local-ai-settings-repository';
 import { LocalProjectRepository } from '@/data/project/local-project-repository';
 import type { WritingProject } from '@/domain/project/types';
 
@@ -189,6 +192,7 @@ function useWorkspacePageState(service: ProjectService): WorkspacePageState {
 
 export default function WorkspacePage(): ReactElement {
   const service = useMemo(() => createProjectService(new LocalProjectRepository()), []);
+  const aiSettingsService = useMemo(() => new AiSettingsService(new LocalAiSettingsRepository()), []);
   const workspaceState = useWorkspacePageState(service);
   const { loadProjects } = workspaceState;
 
@@ -198,6 +202,7 @@ export default function WorkspacePage(): ReactElement {
 
   return (
     <WorkspacePageContent
+      aiSettingsPanel={<AiSettingsPanel service={aiSettingsService} />}
       editingProjectId={workspaceState.editingProjectId}
       errorMessage={workspaceState.errorMessage}
       loading={workspaceState.loading}

--- a/src/application/ai/ai-settings-service.ts
+++ b/src/application/ai/ai-settings-service.ts
@@ -21,11 +21,17 @@ export class AiSettingsService {
   public saveKey(key: string): void {
     const trimmedKey = key.trim();
     if (!trimmedKey) throw new AiSettingsError('API key cannot be empty');
-    this.repository.save({ openRouterApiKey: trimmedKey });
+    const current = this.repository.load();
+    this.repository.save({ openRouterApiKey: trimmedKey, selectedModel: current?.selectedModel });
   }
 
   public clearKey(): void {
-    this.repository.clear();
+    const current = this.repository.load();
+    if (current?.selectedModel) {
+      this.repository.save({ openRouterApiKey: '', selectedModel: current.selectedModel });
+    } else {
+      this.repository.clear();
+    }
   }
 
   public hasKey(): boolean {

--- a/src/application/ai/ai-settings-service.ts
+++ b/src/application/ai/ai-settings-service.ts
@@ -1,0 +1,69 @@
+import type { LocalAiSettingsRepository } from '@/data/ai/local-ai-settings-repository';
+import type { AiSettings } from '@/domain/ai/types';
+
+const OPENROUTER_KEY_VALIDATION_URL = 'https://openrouter.ai/api/v1/key';
+const DEFAULT_MODEL = 'google/gemini-3.1-flash-lite-preview';
+
+export class AiSettingsError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = 'AiSettingsError';
+  }
+}
+
+export class AiSettingsService {
+  public constructor(private readonly repository: LocalAiSettingsRepository) {}
+
+  public loadSettings(): AiSettings | null {
+    return this.repository.load();
+  }
+
+  public saveKey(key: string): void {
+    const trimmedKey = key.trim();
+    if (!trimmedKey) throw new AiSettingsError('API key cannot be empty');
+    this.repository.save({ openRouterApiKey: trimmedKey });
+  }
+
+  public clearKey(): void {
+    this.repository.clear();
+  }
+
+  public hasKey(): boolean {
+    const settings = this.repository.load();
+    return Boolean(settings?.openRouterApiKey);
+  }
+
+  public getSelectedModel(): string {
+    return this.repository.load()?.selectedModel ?? DEFAULT_MODEL;
+  }
+
+  public saveModel(modelId: string): void {
+    const current = this.repository.load();
+    const apiKey = current?.openRouterApiKey ?? '';
+    this.repository.save({ openRouterApiKey: apiKey, selectedModel: modelId });
+  }
+
+  public async validateKey(key: string): Promise<boolean> {
+    const trimmedKey = key.trim();
+    if (!trimmedKey) return false;
+
+    try {
+      const response = await fetch(OPENROUTER_KEY_VALIDATION_URL, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${trimmedKey}`,
+        },
+      });
+
+      if (!response.ok) return false;
+
+      const data: unknown = await response.json();
+      if (!data || typeof data !== 'object') return false;
+
+      const record = data as Record<string, unknown>;
+      return !record.error && (record.data !== undefined || typeof record.id === 'string');
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/application/ai/create-scene-draft-service.ts
+++ b/src/application/ai/create-scene-draft-service.ts
@@ -1,0 +1,7 @@
+import { AiSettingsService } from '@/application/ai/ai-settings-service';
+import { SceneDraftService } from '@/application/ai/scene-draft-service';
+import { LocalAiSettingsRepository } from '@/data/ai/local-ai-settings-repository';
+
+export function createSceneDraftService(): SceneDraftService {
+  return new SceneDraftService(new AiSettingsService(new LocalAiSettingsRepository()));
+}

--- a/src/application/ai/model-fetcher.ts
+++ b/src/application/ai/model-fetcher.ts
@@ -1,16 +1,33 @@
+import { z } from 'zod';
+
 import type { OpenRouterModel } from '@/domain/ai/types';
 
 const OPENROUTER_MODELS_URL = 'https://openrouter.ai/api/v1/models';
 const PRICE_PER_K = 1000;
 const PRICE_DECIMAL_PLACES = 3;
 
+const openRouterModelSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().default(''),
+  context_length: z.number().nullable(),
+  pricing: z.object({
+    prompt: z.string(),
+    completion: z.string(),
+  }),
+});
+
+const openRouterResponseSchema = z.object({
+  data: z.array(openRouterModelSchema),
+});
+
 export async function fetchAvailableModels(apiKey: string): Promise<OpenRouterModel[]> {
   const response = await fetch(OPENROUTER_MODELS_URL, {
     headers: { Authorization: `Bearer ${apiKey}` },
   });
   if (!response.ok) throw new Error(`Failed to fetch models: ${response.status}`);
-  const data = (await response.json()) as { data: OpenRouterModel[] };
-  return data.data ?? [];
+  const parsed = openRouterResponseSchema.parse(await response.json());
+  return parsed.data;
 }
 
 export function formatPrice(prompt: string, completion: string): string {

--- a/src/application/ai/model-fetcher.ts
+++ b/src/application/ai/model-fetcher.ts
@@ -1,0 +1,35 @@
+import type { OpenRouterModel } from '@/domain/ai/types';
+
+const OPENROUTER_MODELS_URL = 'https://openrouter.ai/api/v1/models';
+const PRICE_PER_K = 1000;
+const PRICE_DECIMAL_PLACES = 3;
+
+export async function fetchAvailableModels(apiKey: string): Promise<OpenRouterModel[]> {
+  const response = await fetch(OPENROUTER_MODELS_URL, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+  if (!response.ok) throw new Error(`Failed to fetch models: ${response.status}`);
+  const data = (await response.json()) as { data: OpenRouterModel[] };
+  return data.data ?? [];
+}
+
+export function formatPrice(prompt: string, completion: string): string {
+  const p = parseFloat(prompt);
+  const c = parseFloat(completion);
+  if (isNaN(p) || isNaN(c)) return 'N/A';
+  const fmt = (v: number): string =>
+    v === 0 ? '$0' : `$${(v * PRICE_PER_K).toFixed(PRICE_DECIMAL_PLACES)}`;
+  return `${fmt(p)} / ${fmt(c)} per 1K tokens`;
+}
+
+export function formatContextLength(contextLength: number | null): string {
+  if (!contextLength) return 'N/A';
+  if (contextLength >= 1_000_000) return `${(contextLength / 1_000_000).toFixed(1)}M tokens`;
+  if (contextLength >= 1_000) return `${Math.round(contextLength / 1_000)}K tokens`;
+  return `${contextLength} tokens`;
+}
+
+export function extractProvider(modelId: string): string {
+  const provider = modelId.split('/')[0] ?? '';
+  return provider.charAt(0).toUpperCase() + provider.slice(1);
+}

--- a/src/application/ai/scene-draft-service.ts
+++ b/src/application/ai/scene-draft-service.ts
@@ -1,0 +1,116 @@
+import type { AiSettingsService } from '@/application/ai/ai-settings-service';
+import type { SceneDraftRequest, SceneDraftResult } from '@/domain/ai/types';
+
+const OPENROUTER_API_URL = 'https://openrouter.ai/api/v1/chat/completions';
+
+function buildSystemPrompt(request: SceneDraftRequest): string {
+  const entityLines = request.entities
+    .map((entity) => `- ${entity.name} (${entity.category}): ${entity.summary.slice(0, 200)}`)
+    .join('\n');
+
+  const contextBlock = entityLines
+    ? `\nStory context:\n${entityLines}`
+    : '';
+
+  return [
+    'You are a creative writing assistant. Write immersive, literary prose.',
+    `Language: ${request.language}.`,
+    'Do not include chapter headings or scene titles.',
+    'Return only the scene prose.',
+    contextBlock,
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+function buildUserPrompt(request: SceneDraftRequest): string {
+  const beatLines = request.beats
+    .map((beat) => `- [${beat.type}] ${beat.content}`)
+    .join('\n');
+
+  return [
+    'Write a scene draft based on this outline:',
+    '',
+    `Title: ${request.sceneTitle}`,
+    `Synopsis: ${request.synopsis}`,
+    `Beats:\n${beatLines}`,
+    '',
+    `Write the full scene in ${request.language}.`,
+  ].join('\n');
+}
+
+function stripCodeFences(text: string): string {
+  return text.replace(/^```[\w]*\n?/m, '').replace(/\n?```$/m, '').trim();
+}
+
+function extractDraft(body: unknown): string | null {
+  if (
+    typeof body === 'object' &&
+    body !== null &&
+    'choices' in body &&
+    Array.isArray((body as Record<string, unknown>).choices)
+  ) {
+    const choices = (body as { choices: unknown[] }).choices;
+    const first = choices[0];
+    if (
+      typeof first === 'object' &&
+      first !== null &&
+      'message' in first &&
+      typeof (first as { message: unknown }).message === 'object'
+    ) {
+      const message = (first as { message: Record<string, unknown> }).message;
+      if (typeof message.content === 'string') {
+        return message.content;
+      }
+    }
+  }
+  return null;
+}
+
+export class SceneDraftService {
+  public constructor(private readonly aiSettingsService: AiSettingsService) {}
+
+  public async generateDraft(request: SceneDraftRequest): Promise<SceneDraftResult> {
+    if (!this.aiSettingsService.hasKey()) {
+      return { state: 'no-api-key' };
+    }
+
+    const settings = this.aiSettingsService.loadSettings();
+    const apiKey = settings?.openRouterApiKey ?? '';
+
+    try {
+      const response = await fetch(OPENROUTER_API_URL, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+          'HTTP-Referer': 'https://ainkwell.app',
+        },
+        body: JSON.stringify({
+          model: this.aiSettingsService.getSelectedModel(),
+          messages: [
+            { role: 'system', content: buildSystemPrompt(request) },
+            { role: 'user', content: buildUserPrompt(request) },
+          ],
+          max_tokens: 2000,
+          temperature: 0.7,
+        }),
+      });
+
+      if (!response.ok) {
+        return { state: 'api-error', message: `${response.status}: ${response.statusText}` };
+      }
+
+      const body: unknown = await response.json();
+      const raw = extractDraft(body);
+
+      if (!raw) {
+        return { state: 'api-error', message: 'Unexpected response format from API.' };
+      }
+
+      return { state: 'success', draft: stripCodeFences(raw) };
+    } catch {
+      return { state: 'api-error', message: 'Network error. Check your connection.' };
+    }
+  }
+}

--- a/src/components/ai/ai-settings-panel.tsx
+++ b/src/components/ai/ai-settings-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { ReactElement } from 'react';
 
 import type { AiSettingsService } from '@/application/ai/ai-settings-service';
@@ -18,11 +18,15 @@ export function AiSettingsPanel({ service }: Props): ReactElement {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [savedMessage, setSavedMessage] = useState(false);
   const [isVerifying, setIsVerifying] = useState(false);
+  const savedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [showModelDialog, setShowModelDialog] = useState(false);
   const [selectedModel, setSelectedModel] = useState(() => service.getSelectedModel());
 
   useEffect(() => {
     setHasKey(service.hasKey());
+    return () => {
+      if (savedTimeoutRef.current) clearTimeout(savedTimeoutRef.current);
+    };
   }, [service]);
 
   async function handleSave(): Promise<void> {
@@ -45,7 +49,7 @@ export function AiSettingsPanel({ service }: Props): ReactElement {
       setHasKey(true);
       setKeyInput('');
       setSavedMessage(true);
-      setTimeout(() => setSavedMessage(false), 2000);
+      savedTimeoutRef.current = setTimeout(() => setSavedMessage(false), 2000);
     } catch (error) {
       if (error instanceof AiSettingsError) {
         setErrorMessage(error.message);

--- a/src/components/ai/ai-settings-panel.tsx
+++ b/src/components/ai/ai-settings-panel.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
+
+import type { AiSettingsService } from '@/application/ai/ai-settings-service';
+import { AiSettingsError } from '@/application/ai/ai-settings-service';
+import { initiateOAuthFlow } from '@/lib/openrouter-oauth';
+import { ModelSelectionDialog } from '@/components/ai/model-selection-dialog';
+
+type Props = {
+  service: AiSettingsService;
+};
+
+export function AiSettingsPanel({ service }: Props): ReactElement {
+  const [hasKey, setHasKey] = useState(false);
+  const [keyInput, setKeyInput] = useState('');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [savedMessage, setSavedMessage] = useState(false);
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [showModelDialog, setShowModelDialog] = useState(false);
+  const [selectedModel, setSelectedModel] = useState(() => service.getSelectedModel());
+
+  useEffect(() => {
+    setHasKey(service.hasKey());
+  }, [service]);
+
+  async function handleSave(): Promise<void> {
+    setErrorMessage(null);
+
+    if (!keyInput.trim()) {
+      setErrorMessage('API key cannot be empty');
+      return;
+    }
+
+    setIsVerifying(true);
+    try {
+      const isValid = await service.validateKey(keyInput);
+      if (!isValid) {
+        setErrorMessage('Invalid API key. Check your key at openrouter.ai/keys.');
+        return;
+      }
+
+      service.saveKey(keyInput);
+      setHasKey(true);
+      setKeyInput('');
+      setSavedMessage(true);
+      setTimeout(() => setSavedMessage(false), 2000);
+    } catch (error) {
+      if (error instanceof AiSettingsError) {
+        setErrorMessage(error.message);
+      } else {
+        setErrorMessage('Unable to save API key.');
+      }
+    } finally {
+      setIsVerifying(false);
+    }
+  }
+
+  function handleModelSelect(modelId: string): void {
+    service.saveModel(modelId);
+    setSelectedModel(modelId);
+  }
+
+  function handleClear(): void {
+    service.clearKey();
+    setHasKey(false);
+    setKeyInput('');
+    setErrorMessage(null);
+  }
+
+  return (
+    <section className="rounded-lg border p-4 space-y-3">
+      <h2 className="text-2xl font-headline font-semibold">AI Settings</h2>
+      <p className="text-sm text-muted-foreground">
+        {hasKey ? 'API key configured.' : 'No API key set.'}
+        {savedMessage ? <span className="ml-2 text-green-600 dark:text-green-400">Saved!</span> : null}
+      </p>
+
+      <button
+        type="button"
+        onClick={() =>
+          void initiateOAuthFlow(`${window.location.origin}/auth/openrouter/callback`)
+        }
+        disabled={isVerifying}
+        className="rounded border border-border px-3 py-1.5 text-xs hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        Connect with OpenRouter
+      </button>
+
+      <p className="text-xs text-muted-foreground">or enter your key manually</p>
+
+      <div className="flex flex-wrap gap-2 items-end">
+        <div className="flex flex-col gap-1">
+          <label htmlFor="openrouter-api-key" className="text-xs font-medium">
+            OpenRouter API key
+          </label>
+          <input
+            id="openrouter-api-key"
+            type="password"
+            value={keyInput}
+            onChange={(event) => setKeyInput(event.target.value)}
+            placeholder="sk-or-..."
+            className="rounded border bg-background px-3 py-1.5 text-sm w-64"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={() => void handleSave()}
+          disabled={isVerifying}
+          className="rounded border border-border px-3 py-1.5 text-xs hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isVerifying ? 'Verifying...' : 'Save Key'}
+        </button>
+        {hasKey ? (
+          <button
+            type="button"
+            onClick={handleClear}
+            disabled={isVerifying}
+            className="rounded border border-destructive/50 px-3 py-1.5 text-xs text-destructive hover:bg-destructive/10 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Clear Key
+          </button>
+        ) : null}
+      </div>
+
+      {errorMessage ? (
+        <p aria-live="polite" className="text-xs text-destructive" role="alert">
+          {errorMessage}
+        </p>
+      ) : null}
+
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-muted-foreground">Model:</span>
+        <button
+          type="button"
+          onClick={() => setShowModelDialog(true)}
+          disabled={!hasKey}
+          title={hasKey ? 'Change model' : 'Set an API key first'}
+          className="text-xs underline hover:no-underline disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {selectedModel.split('/').pop() ?? selectedModel}
+        </button>
+      </div>
+
+      {showModelDialog ? (
+        <ModelSelectionDialog
+          service={service}
+          selectedModel={selectedModel}
+          onSelect={handleModelSelect}
+          onClose={() => setShowModelDialog(false)}
+        />
+      ) : null}
+
+      <p className="text-xs text-muted-foreground">
+        Your key is stored only in this browser. It is never sent to any Ainkwell server.{' '}
+        <a
+          href="https://openrouter.ai/keys"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline"
+        >
+          Get a key at openrouter.ai/keys
+        </a>
+      </p>
+    </section>
+  );
+}

--- a/src/components/ai/model-card.tsx
+++ b/src/components/ai/model-card.tsx
@@ -1,0 +1,38 @@
+import type { ReactElement } from 'react';
+
+import { extractProvider, formatContextLength, formatPrice } from '@/application/ai/model-fetcher';
+import type { OpenRouterModel } from '@/domain/ai/types';
+
+type ModelCardProps = {
+  model: OpenRouterModel;
+  isSelected: boolean;
+  onSelect: (modelId: string) => void;
+};
+
+export function ModelCard({ model, isSelected, onSelect }: ModelCardProps): ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(model.id)}
+      className={`w-full text-left p-3 rounded-lg border transition-colors ${
+        isSelected
+          ? 'border-primary bg-primary/5'
+          : 'border-border hover:bg-muted'
+      }`}
+    >
+      <div className="flex items-start gap-2">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-0.5">
+            <span className="text-sm font-medium truncate">{model.name}</span>
+            {isSelected ? <span className="text-primary text-xs flex-shrink-0">✓</span> : null}
+          </div>
+          <p className="text-xs text-muted-foreground mb-1">{extractProvider(model.id)}</p>
+          <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-xs text-muted-foreground">
+            <span>💰 {formatPrice(model.pricing.prompt, model.pricing.completion)}</span>
+            <span>📏 {formatContextLength(model.context_length)}</span>
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/src/components/ai/model-card.tsx
+++ b/src/components/ai/model-card.tsx
@@ -28,8 +28,8 @@ export function ModelCard({ model, isSelected, onSelect }: ModelCardProps): Reac
           </div>
           <p className="text-xs text-muted-foreground mb-1">{extractProvider(model.id)}</p>
           <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-xs text-muted-foreground">
-            <span>💰 {formatPrice(model.pricing.prompt, model.pricing.completion)}</span>
-            <span>📏 {formatContextLength(model.context_length)}</span>
+            <span><span aria-hidden="true">💰</span><span className="sr-only">Price:</span> {formatPrice(model.pricing.prompt, model.pricing.completion)}</span>
+            <span><span aria-hidden="true">📏</span><span className="sr-only">Context:</span> {formatContextLength(model.context_length)}</span>
           </div>
         </div>
       </div>

--- a/src/components/ai/model-selection-dialog.tsx
+++ b/src/components/ai/model-selection-dialog.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { ReactElement } from 'react';
+
+import type { AiSettingsService } from '@/application/ai/ai-settings-service';
+import { ModelCard } from '@/components/ai/model-card';
+import { useModelLoader } from '@/hooks/use-model-loader';
+
+type ModelSelectionDialogProps = {
+  service: AiSettingsService;
+  selectedModel: string;
+  onSelect: (modelId: string) => void;
+  onClose: () => void;
+};
+
+export function ModelSelectionDialog({
+  service,
+  selectedModel,
+  onSelect,
+  onClose,
+}: ModelSelectionDialogProps): ReactElement {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [search, setSearch] = useState('');
+  const { models, isLoading, error, load } = useModelLoader(service);
+
+  useEffect(() => {
+    dialogRef.current?.showModal();
+    void load();
+  }, [load]);
+
+  const filtered = models.filter(
+    (m) =>
+      m.name.toLowerCase().includes(search.toLowerCase()) ||
+      m.id.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  function handleSelect(modelId: string): void {
+    onSelect(modelId);
+    onClose();
+  }
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onClose={onClose}
+      className="w-full max-w-xl rounded-xl border bg-card p-0 shadow-lg backdrop:bg-black/50"
+    >
+      <div className="flex flex-col max-h-[80vh]">
+        <div className="p-4 border-b space-y-3">
+          <h2 className="text-lg font-headline font-semibold">Select model</h2>
+          <input
+            type="search"
+            placeholder="Search models…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full rounded border bg-background px-3 py-1.5 text-sm"
+            autoFocus
+          />
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-4 space-y-2 min-h-[200px]">
+          {isLoading ? (
+            <p className="text-sm text-muted-foreground text-center py-8">Loading models…</p>
+          ) : null}
+          {error ? (
+            <p className="text-sm text-destructive text-center py-8">{error}</p>
+          ) : null}
+          {!isLoading && !error && filtered.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-8">No models found.</p>
+          ) : null}
+          {!isLoading && !error
+            ? filtered.map((model) => (
+                <ModelCard
+                  key={model.id}
+                  model={model}
+                  isSelected={model.id === selectedModel}
+                  onSelect={handleSelect}
+                />
+              ))
+            : null}
+        </div>
+
+        <div className="p-4 border-t flex justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded border border-border px-3 py-1.5 text-sm hover:bg-muted"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </dialog>
+  );
+}

--- a/src/components/ai/model-selection-dialog.tsx
+++ b/src/components/ai/model-selection-dialog.tsx
@@ -29,11 +29,16 @@ export function ModelSelectionDialog({
     void load();
   }, [load]);
 
+  const MAX_VISIBLE = 50;
+
   const filtered = models.filter(
     (m) =>
       m.name.toLowerCase().includes(search.toLowerCase()) ||
       m.id.toLowerCase().includes(search.toLowerCase()),
   );
+
+  const visible = filtered.slice(0, MAX_VISIBLE);
+  const hiddenCount = filtered.length - visible.length;
 
   function handleSelect(modelId: string): void {
     onSelect(modelId);
@@ -73,7 +78,7 @@ export function ModelSelectionDialog({
             <p className="text-sm text-muted-foreground text-center py-8">No models found.</p>
           ) : null}
           {!isLoading && !error
-            ? filtered.map((model) => (
+            ? visible.map((model) => (
                 <ModelCard
                   key={model.id}
                   model={model}
@@ -82,6 +87,11 @@ export function ModelSelectionDialog({
                 />
               ))
             : null}
+          {hiddenCount > 0 ? (
+            <p className="text-xs text-muted-foreground text-center py-2">
+              {hiddenCount} more models — refine your search to narrow results.
+            </p>
+          ) : null}
         </div>
 
         <div className="p-4 border-t flex justify-end">

--- a/src/components/ai/model-selection-dialog.tsx
+++ b/src/components/ai/model-selection-dialog.tsx
@@ -44,12 +44,15 @@ export function ModelSelectionDialog({
     <dialog
       ref={dialogRef}
       onClose={onClose}
+      aria-labelledby="model-selection-title"
       className="w-full max-w-xl rounded-xl border bg-card p-0 shadow-lg backdrop:bg-black/50"
     >
       <div className="flex flex-col max-h-[80vh]">
         <div className="p-4 border-b space-y-3">
-          <h2 className="text-lg font-headline font-semibold">Select model</h2>
+          <h2 id="model-selection-title" className="text-lg font-headline font-semibold">Select model</h2>
+          <label htmlFor="model-search" className="sr-only">Search models</label>
           <input
+            id="model-search"
             type="search"
             placeholder="Search models…"
             value={search}

--- a/src/components/bible/bible-page-controller.ts
+++ b/src/components/bible/bible-page-controller.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { BibleService, BibleValidationError } from '@/application/bible/bible-service';
 import { createProjectService } from '@/application/project/project-service';
 import { LocalBibleRepository } from '@/data/bible/local-bible-repository';
@@ -285,9 +285,9 @@ function useEntitySelection(entities: BibleDataSnapshot['entities']): {
 
 function useRefreshTrigger(): () => void {
   const [, setDataRevision] = useState(0);
-  return () => {
+  return useCallback(() => {
     setDataRevision((currentRevision) => currentRevision + 1);
-  };
+  }, []);
 }
 
 function useRunBibleOperation(

--- a/src/components/outline/inline-scene-editor.tsx
+++ b/src/components/outline/inline-scene-editor.tsx
@@ -88,7 +88,7 @@ export function InlineSceneEditor({
         className="w-full resize-none rounded border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
       />
       <Link
-        href={`/workspace/${projectId}/scene/${scene.id}`}
+        href={`/workspace/${projectId}/scene/${scene.id}?from=outline`}
         className="self-start text-xs text-primary hover:underline"
       >
         Open full editor

--- a/src/components/scene/generate-draft-button.tsx
+++ b/src/components/scene/generate-draft-button.tsx
@@ -1,0 +1,52 @@
+import type { ReactElement } from 'react';
+
+type GenerateDraftButtonProps = {
+  isGenerating: boolean;
+  generateError: string | null;
+  canGenerate: boolean;
+  onGenerate: () => void;
+  onClearError: () => void;
+};
+
+export function GenerateDraftButton({
+  isGenerating,
+  generateError,
+  canGenerate,
+  onGenerate,
+  onClearError,
+}: GenerateDraftButtonProps): ReactElement {
+  return (
+    <div className="flex flex-col items-end gap-2">
+      <button
+        type="button"
+        onClick={onGenerate}
+        disabled={!canGenerate || isGenerating}
+        title={canGenerate ? undefined : 'Add a synopsis to enable AI draft generation'}
+        className="rounded border border-border px-3 py-1.5 text-xs hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {isGenerating ? 'Generating...' : 'Generate Draft'}
+      </button>
+
+      {!canGenerate && !isGenerating ? (
+        <p className="text-xs text-muted-foreground">Add a synopsis to generate</p>
+      ) : null}
+
+      {generateError ? (
+        <div
+          role="alert"
+          aria-live="assertive"
+          className="flex items-center gap-3 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+        >
+          <span>{generateError}</span>
+          <button
+            type="button"
+            onClick={onClearError}
+            className="rounded-md border border-destructive px-2 py-1 text-xs font-medium"
+          >
+            Dismiss
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/scene/scene-beat-panel.tsx
+++ b/src/components/scene/scene-beat-panel.tsx
@@ -73,7 +73,7 @@ export const SceneBeatPanel = memo(function SceneBeatPanel({
           </div>
           <div>
             <div className="mb-1 flex items-center justify-between">
-              <label className="text-xs font-medium text-muted-foreground">Beats</label>
+              <p className="text-xs font-medium text-muted-foreground">Beats</p>
               <button
                 className="text-xs text-primary hover:underline disabled:opacity-50"
                 disabled={beats.length >= maxBeatsPerScene}
@@ -111,7 +111,7 @@ export const SceneBeatPanel = memo(function SceneBeatPanel({
                     onClick={() => removeBeat(beat.id)}
                     type="button"
                   >
-                    ✕
+                    <span aria-hidden="true">✕</span>
                   </button>
                 </li>
               ))}

--- a/src/components/scene/scene-editor-shell.tsx
+++ b/src/components/scene/scene-editor-shell.tsx
@@ -3,6 +3,8 @@
 import Link from 'next/link';
 import { memo, useCallback, useMemo, type ReactElement } from 'react';
 
+import { AiSettingsService } from '@/application/ai/ai-settings-service';
+import { SceneDraftService } from '@/application/ai/scene-draft-service';
 import { BibleService } from '@/application/bible/bible-service';
 import { createBibleService as createDefaultBibleService } from '@/application/bible/create-bible-service';
 import {
@@ -11,25 +13,29 @@ import {
 } from '@/application/scene/scene-editor-service';
 import { WritingSessionService } from '@/application/writing-session/writing-session-service';
 import { CodexContextPanel } from '@/components/scene/codex-context-panel';
+import { GenerateDraftButton } from '@/components/scene/generate-draft-button';
 import { SceneBeatPanel } from '@/components/scene/scene-beat-panel';
 import { SceneToolbar } from '@/components/scene/scene-toolbar';
 import { SessionTimer } from '@/components/writing-session/session-timer';
 import { useWritingSessionActions, useWritingSessionTimer } from '@/context/writing-session-context';
-
+import { LocalAiSettingsRepository } from '@/data/ai/local-ai-settings-repository';
 import { LocalProjectRepository } from '@/data/project/local-project-repository';
 import { LocalWritingSessionRepository } from '@/data/writing-session/local-writing-session-repository';
 import type { BibleEntity } from '@/domain/bible/types';
 import type { SceneBeat } from '@/domain/scene/schemas';
 import { useCodexContext } from '@/hooks/use-codex-context';
+import { useSceneDraft } from '@/hooks/use-scene-draft';
 import { useSceneEditor, type UseSceneEditorResult } from '@/hooks/use-scene-editor';
 import { useWritingSession } from '@/hooks/use-writing-session';
 
 type SceneEditorShellProps = {
   projectId: string;
   sceneId: string;
+  language?: string;
   service?: SceneEditorServicePort;
   writingService?: WritingSessionService;
   bibleService?: BibleService;
+  draftService?: SceneDraftService;
 };
 
 const createSceneEditorService = (): SceneEditorServicePort =>
@@ -40,14 +46,18 @@ const createWritingSessionService = (): WritingSessionService =>
 
 const createBibleService = (): BibleService => createDefaultBibleService();
 
-function useShellServices(props: Pick<SceneEditorShellProps, 'service' | 'writingService' | 'bibleService'>) {
+const createDraftService = (): SceneDraftService =>
+  new SceneDraftService(new AiSettingsService(new LocalAiSettingsRepository()));
+
+function useShellServices(props: Pick<SceneEditorShellProps, 'service' | 'writingService' | 'bibleService' | 'draftService'>) {
   const service = useMemo(() => props.service ?? createSceneEditorService(), [props.service]);
   const writingService = useMemo(
     () => props.writingService ?? createWritingSessionService(),
     [props.writingService],
   );
   const bibleService = useMemo(() => props.bibleService ?? createBibleService(), [props.bibleService]);
-  return { service, writingService, bibleService };
+  const draftService = useMemo(() => props.draftService ?? createDraftService(), [props.draftService]);
+  return { service, writingService, bibleService, draftService };
 }
 
 type SceneStateViewProps = {
@@ -187,6 +197,11 @@ type SceneContentSectionProps = {
   beats: SceneBeat[];
   onSynopsisChange: (value: string) => void;
   onBeatsChange: (beats: SceneBeat[]) => void;
+  isGenerating: boolean;
+  generateError: string | null;
+  canGenerate: boolean;
+  onGenerate: () => void;
+  onClearGenerateError: () => void;
 };
 
 const SceneContentSection = memo(function SceneContentSection({
@@ -197,6 +212,11 @@ const SceneContentSection = memo(function SceneContentSection({
   beats,
   onSynopsisChange,
   onBeatsChange,
+  isGenerating,
+  generateError,
+  canGenerate,
+  onGenerate,
+  onClearGenerateError,
 }: SceneContentSectionProps): ReactElement {
   return (
     <section className="flex flex-1 flex-col overflow-hidden rounded-xl border bg-card text-card-foreground">
@@ -208,9 +228,18 @@ const SceneContentSection = memo(function SceneContentSection({
       />
       <div className="flex flex-1 overflow-hidden">
         <div className="flex flex-1 flex-col p-4">
-          <label htmlFor="scene-content" className="mb-2 block text-sm font-medium">
-            Markdown content
-          </label>
+          <div className="mb-2 flex items-center justify-between">
+            <label htmlFor="scene-content" className="block text-sm font-medium">
+              Markdown content
+            </label>
+            <GenerateDraftButton
+              isGenerating={isGenerating}
+              generateError={generateError}
+              canGenerate={canGenerate}
+              onGenerate={onGenerate}
+              onClearError={onClearGenerateError}
+            />
+          </div>
           <textarea
             id="scene-content"
             value={content}
@@ -245,10 +274,12 @@ function SessionTimerConnector({ onStart, onStop, fallbackIsRunning, fallbackEla
 
 type SceneEditorLoadedViewProps = {
   projectId: string;
+  language: string;
   sceneEditor: UseSceneEditorResult;
   onSessionStart: () => void;
   onSessionStop: () => Promise<void>;
   bibleService: BibleService;
+  draftService: SceneDraftService;
   fallbackIsRunning: boolean;
   fallbackElapsedSeconds: number;
 };
@@ -258,6 +289,16 @@ const SceneEditorLoadedView = memo(function SceneEditorLoadedView(props: SceneEd
     projectId: props.projectId,
     content: props.sceneEditor.content,
     service: props.bibleService,
+  });
+
+  const { isGenerating, generateError, canGenerate, generate, clearError } = useSceneDraft({
+    scene: props.sceneEditor.scene,
+    synopsis: props.sceneEditor.synopsis,
+    beats: props.sceneEditor.beats,
+    entities: matchedEntities,
+    language: props.language,
+    service: props.draftService,
+    onDraftReady: props.sceneEditor.setContent,
   });
 
   if (!props.sceneEditor.scene) return getSceneNotLoadedView();
@@ -291,6 +332,11 @@ const SceneEditorLoadedView = memo(function SceneEditorLoadedView(props: SceneEd
         beats={props.sceneEditor.beats}
         onSynopsisChange={props.sceneEditor.setSynopsis}
         onBeatsChange={props.sceneEditor.setBeats}
+        isGenerating={isGenerating}
+        generateError={generateError}
+        canGenerate={canGenerate}
+        onGenerate={() => void generate()}
+        onClearGenerateError={clearError}
       />
 
       <SceneEditorNavigation
@@ -303,7 +349,7 @@ const SceneEditorLoadedView = memo(function SceneEditorLoadedView(props: SceneEd
 });
 
 export function SceneEditorShell(props: SceneEditorShellProps): ReactElement {
-  const { service, writingService, bibleService } = useShellServices(props);
+  const { service, writingService, bibleService, draftService } = useShellServices(props);
   const contextActions = useWritingSessionActions();
   const localSession = useWritingSession({ projectId: props.projectId, service: writingService });
 
@@ -335,10 +381,12 @@ export function SceneEditorShell(props: SceneEditorShellProps): ReactElement {
   return (
     <SceneEditorLoadedView
       projectId={props.projectId}
+      language={props.language ?? 'en'}
       sceneEditor={sceneEditor}
       onSessionStart={startSession}
       onSessionStop={handleSessionStop}
       bibleService={bibleService}
+      draftService={draftService}
       fallbackIsRunning={localSession.isRunning}
       fallbackElapsedSeconds={localSession.elapsedSeconds}
     />

--- a/src/components/scene/scene-editor-shell.tsx
+++ b/src/components/scene/scene-editor-shell.tsx
@@ -30,6 +30,7 @@ import { useWritingSession } from '@/hooks/use-writing-session';
 type SceneEditorShellProps = {
   projectId: string;
   sceneId: string;
+  backTo?: 'outline' | 'workspace';
   language?: string;
   service?: SceneEditorServicePort;
   writingService?: WritingSessionService;
@@ -149,14 +150,25 @@ type SceneEditorNavigationProps = {
   projectId: string;
   previousSceneId: string | null;
   nextSceneId: string | null;
+  backTo: 'outline' | 'workspace';
 };
 
 const SceneEditorNavigation = memo(function SceneEditorNavigation(props: SceneEditorNavigationProps): ReactElement {
+  const sceneHref = (sceneId: string): string =>
+    `/workspace/${props.projectId}/scene/${sceneId}${props.backTo === 'outline' ? '?from=outline' : ''}`;
+
+  const backHref =
+    props.backTo === 'outline'
+      ? `/workspace/${props.projectId}/outline`
+      : `/workspace/${props.projectId}`;
+
+  const backLabel = props.backTo === 'outline' ? 'Back to outline' : 'Back to workspace';
+
   return (
     <nav className="flex items-center justify-between">
       {props.previousSceneId ? (
         <Link
-          href={`/workspace/${props.projectId}/scene/${props.previousSceneId}`}
+          href={sceneHref(props.previousSceneId)}
           className="inline-flex rounded-md border px-3 py-2 text-sm font-medium"
         >
           Previous
@@ -167,13 +179,13 @@ const SceneEditorNavigation = memo(function SceneEditorNavigation(props: SceneEd
         </button>
       )}
 
-      <Link href={`/workspace/${props.projectId}`} className="inline-flex rounded-md border px-3 py-2 text-sm font-medium">
-        Back to workspace
+      <Link href={backHref} className="inline-flex rounded-md border px-3 py-2 text-sm font-medium">
+        {backLabel}
       </Link>
 
       {props.nextSceneId ? (
         <Link
-          href={`/workspace/${props.projectId}/scene/${props.nextSceneId}`}
+          href={sceneHref(props.nextSceneId)}
           className="inline-flex rounded-md border px-3 py-2 text-sm font-medium"
         >
           Next
@@ -273,6 +285,7 @@ function SessionTimerConnector({ onStart, onStop, fallbackIsRunning, fallbackEla
 type SceneEditorLoadedViewProps = {
   projectId: string;
   language: string;
+  backTo: 'outline' | 'workspace';
   sceneEditor: UseSceneEditorResult;
   onSessionStart: () => void;
   onSessionStop: () => Promise<void>;
@@ -349,6 +362,7 @@ const SceneEditorLoadedView = memo(function SceneEditorLoadedView(props: SceneEd
         projectId={props.projectId}
         previousSceneId={props.sceneEditor.previousSceneId}
         nextSceneId={props.sceneEditor.nextSceneId}
+        backTo={props.backTo}
       />
     </main>
   );
@@ -388,6 +402,7 @@ export function SceneEditorShell(props: SceneEditorShellProps): ReactElement {
     <SceneEditorLoadedView
       projectId={props.projectId}
       language={props.language ?? 'en'}
+      backTo={props.backTo ?? 'workspace'}
       sceneEditor={sceneEditor}
       onSessionStart={startSession}
       onSessionStop={handleSessionStop}

--- a/src/components/scene/scene-editor-shell.tsx
+++ b/src/components/scene/scene-editor-shell.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { memo, useCallback, useMemo, type ReactElement } from 'react';
 
-import { AiSettingsService } from '@/application/ai/ai-settings-service';
+import { createSceneDraftService } from '@/application/ai/create-scene-draft-service';
 import { SceneDraftService } from '@/application/ai/scene-draft-service';
 import { BibleService } from '@/application/bible/bible-service';
 import { createBibleService as createDefaultBibleService } from '@/application/bible/create-bible-service';
@@ -18,7 +18,6 @@ import { SceneBeatPanel } from '@/components/scene/scene-beat-panel';
 import { SceneToolbar } from '@/components/scene/scene-toolbar';
 import { SessionTimer } from '@/components/writing-session/session-timer';
 import { useWritingSessionActions, useWritingSessionTimer } from '@/context/writing-session-context';
-import { LocalAiSettingsRepository } from '@/data/ai/local-ai-settings-repository';
 import { LocalProjectRepository } from '@/data/project/local-project-repository';
 import { LocalWritingSessionRepository } from '@/data/writing-session/local-writing-session-repository';
 import type { BibleEntity } from '@/domain/bible/types';
@@ -46,8 +45,7 @@ const createWritingSessionService = (): WritingSessionService =>
 
 const createBibleService = (): BibleService => createDefaultBibleService();
 
-const createDraftService = (): SceneDraftService =>
-  new SceneDraftService(new AiSettingsService(new LocalAiSettingsRepository()));
+const createDraftService = (): SceneDraftService => createSceneDraftService();
 
 function useShellServices(props: Pick<SceneEditorShellProps, 'service' | 'writingService' | 'bibleService' | 'draftService'>) {
   const service = useMemo(() => props.service ?? createSceneEditorService(), [props.service]);
@@ -298,7 +296,15 @@ const SceneEditorLoadedView = memo(function SceneEditorLoadedView(props: SceneEd
     entities: matchedEntities,
     language: props.language,
     service: props.draftService,
-    onDraftReady: props.sceneEditor.setContent,
+    onDraftReady: (draft: string) => {
+      if (
+        props.sceneEditor.content.trim() &&
+        !window.confirm('Replace the current scene content with the generated draft?')
+      ) {
+        return;
+      }
+      props.sceneEditor.setContent(draft);
+    },
   });
 
   if (!props.sceneEditor.scene) return getSceneNotLoadedView();

--- a/src/components/scene/scene-toolbar.tsx
+++ b/src/components/scene/scene-toolbar.tsx
@@ -100,8 +100,8 @@ export function SceneToolbar(props: SceneToolbarProps): ReactElement {
           <h1 className="text-2xl font-headline font-bold">{props.title}</h1>
           <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
             <SceneStatusBadge status={props.status} />
-            <span aria-live="polite">{props.wordCount} words</span>
-            <span aria-live="polite">{getSaveStateLabel(props)}</span>
+            <span>{props.wordCount} words</span>
+            <span aria-live="polite" role="status">{getSaveStateLabel(props)}</span>
           </div>
         </div>
 

--- a/src/components/workspace/chapter-outline-panel.tsx
+++ b/src/components/workspace/chapter-outline-panel.tsx
@@ -169,7 +169,7 @@ function ChapterRow({
             aria-label="Move chapter up"
             className="w-5 h-5 flex items-center justify-center text-muted-foreground hover:text-foreground disabled:opacity-30 text-xs"
           >
-            ↑
+            <span aria-hidden="true">↑</span>
           </button>
           <button
             type="button"
@@ -178,7 +178,7 @@ function ChapterRow({
             aria-label="Move chapter down"
             className="w-5 h-5 flex items-center justify-center text-muted-foreground hover:text-foreground disabled:opacity-30 text-xs"
           >
-            ↓
+            <span aria-hidden="true">↓</span>
           </button>
           <button
             type="button"
@@ -186,7 +186,7 @@ function ChapterRow({
             aria-label="Rename chapter"
             className="w-5 h-5 flex items-center justify-center text-muted-foreground hover:text-foreground text-xs"
           >
-            ✎
+            <span aria-hidden="true">✎</span>
           </button>
           <button
             type="button"
@@ -195,7 +195,7 @@ function ChapterRow({
             aria-label="Delete chapter"
             className="w-5 h-5 flex items-center justify-center text-muted-foreground hover:text-destructive disabled:opacity-30 text-xs"
           >
-            ✕
+            <span aria-hidden="true">✕</span>
           </button>
         </div>
       </div>

--- a/src/components/workspace/workspace-page-content.tsx
+++ b/src/components/workspace/workspace-page-content.tsx
@@ -2,6 +2,8 @@
 import { type ChangeEvent, useRef, useState } from 'react';
 import type { ReactElement } from 'react';
 
+import type { ReactNode } from 'react';
+
 import { ExportService } from '@/application/export/export-service';
 import { LocalProjectRepository } from '@/data/project/local-project-repository';
 import type { ProjectExport } from '@/domain/project/types';
@@ -22,6 +24,7 @@ type WorkspacePageContentProps = {
   onCancelEdit: () => void;
   onUpdateProject: (projectId: string, values: ProjectFormValues) => Promise<void>;
   onDeleteProject: (projectId: string) => void;
+  aiSettingsPanel?: ReactNode;
 };
 
 function ImportProjectButton({ onSuccess }: { onSuccess: () => void }): ReactElement {
@@ -231,6 +234,7 @@ export function WorkspacePageContent({
   onCancelEdit,
   onUpdateProject,
   onDeleteProject,
+  aiSettingsPanel,
 }: WorkspacePageContentProps): ReactElement {
   return (
     <main className="mx-auto flex min-h-screen w-full max-w-5xl flex-col gap-6 px-4 py-10">
@@ -253,6 +257,7 @@ export function WorkspacePageContent({
           submitting={submitting}
         />
       </section>
+      {aiSettingsPanel}
     </main>
   );
 }

--- a/src/data/ai/local-ai-settings-repository.ts
+++ b/src/data/ai/local-ai-settings-repository.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+
+import type { AiSettings } from '@/domain/ai/types';
+
+const AI_SETTINGS_STORAGE_KEY = 'ainkwell:ai:settings:v1';
+
+const aiSettingsSchema = z.object({
+  openRouterApiKey: z.string(),
+  selectedModel: z.string().optional(),
+});
+
+function parseJson(rawValue: string | null): unknown {
+  if (!rawValue) return null;
+  try {
+    return JSON.parse(rawValue) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+export class LocalAiSettingsRepository {
+  private readonly storage: Storage | null;
+
+  public constructor(storage?: Storage) {
+    this.storage = storage ?? (typeof window !== 'undefined' ? window.localStorage : null);
+  }
+
+  public load(): AiSettings | null {
+    if (!this.storage) return null;
+    const raw = this.storage.getItem(AI_SETTINGS_STORAGE_KEY);
+    const parsed = parseJson(raw);
+    const result = aiSettingsSchema.safeParse(parsed);
+    return result.success ? result.data : null;
+  }
+
+  public save(settings: AiSettings): void {
+    if (!this.storage) return;
+    this.storage.setItem(AI_SETTINGS_STORAGE_KEY, JSON.stringify(settings));
+  }
+
+  public clear(): void {
+    if (!this.storage) return;
+    this.storage.removeItem(AI_SETTINGS_STORAGE_KEY);
+  }
+}

--- a/src/data/ai/local-ai-settings-repository.ts
+++ b/src/data/ai/local-ai-settings-repository.ts
@@ -20,26 +20,31 @@ function parseJson(rawValue: string | null): unknown {
 
 export class LocalAiSettingsRepository {
   private readonly storage: Storage | null;
+  private _cache: AiSettings | null | undefined = undefined;
 
   public constructor(storage?: Storage) {
     this.storage = storage ?? (typeof window !== 'undefined' ? window.localStorage : null);
   }
 
   public load(): AiSettings | null {
-    if (!this.storage) return null;
+    if (this._cache !== undefined) return this._cache;
+    if (!this.storage) { this._cache = null; return null; }
     const raw = this.storage.getItem(AI_SETTINGS_STORAGE_KEY);
     const parsed = parseJson(raw);
     const result = aiSettingsSchema.safeParse(parsed);
-    return result.success ? result.data : null;
+    this._cache = result.success ? result.data : null;
+    return this._cache;
   }
 
   public save(settings: AiSettings): void {
     if (!this.storage) return;
     this.storage.setItem(AI_SETTINGS_STORAGE_KEY, JSON.stringify(settings));
+    this._cache = settings;
   }
 
   public clear(): void {
     if (!this.storage) return;
     this.storage.removeItem(AI_SETTINGS_STORAGE_KEY);
+    this._cache = null;
   }
 }

--- a/src/domain/ai/types.ts
+++ b/src/domain/ai/types.ts
@@ -1,0 +1,31 @@
+import type { BibleEntity } from '@/domain/bible/types';
+import type { SceneBeat } from '@/domain/scene/schemas';
+
+export type OpenRouterModel = {
+  id: string;
+  name: string;
+  description: string;
+  context_length: number | null;
+  pricing: {
+    prompt: string;
+    completion: string;
+  };
+};
+
+export type AiSettings = {
+  openRouterApiKey: string;
+  selectedModel?: string;
+};
+
+export type SceneDraftRequest = {
+  sceneTitle: string;
+  synopsis: string;
+  beats: SceneBeat[];
+  entities: BibleEntity[];
+  language: string;
+};
+
+export type SceneDraftResult =
+  | { state: 'success'; draft: string }
+  | { state: 'no-api-key' }
+  | { state: 'api-error'; message: string };

--- a/src/hooks/use-model-loader.ts
+++ b/src/hooks/use-model-loader.ts
@@ -1,0 +1,37 @@
+import { useState, useCallback } from 'react';
+
+import type { AiSettingsService } from '@/application/ai/ai-settings-service';
+import { fetchAvailableModels } from '@/application/ai/model-fetcher';
+import type { OpenRouterModel } from '@/domain/ai/types';
+
+export type UseModelLoaderResult = {
+  models: OpenRouterModel[];
+  isLoading: boolean;
+  error: string | null;
+  load: () => Promise<void>;
+};
+
+export function useModelLoader(service: AiSettingsService): UseModelLoaderResult {
+  const [models, setModels] = useState<OpenRouterModel[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async (): Promise<void> => {
+    const settings = service.loadSettings();
+    if (!settings?.openRouterApiKey) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const fetched = await fetchAvailableModels(settings.openRouterApiKey);
+      setModels(fetched);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load models.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [service]);
+
+  return { models, isLoading, error, load };
+}

--- a/src/hooks/use-model-loader.ts
+++ b/src/hooks/use-model-loader.ts
@@ -4,6 +4,16 @@ import type { AiSettingsService } from '@/application/ai/ai-settings-service';
 import { fetchAvailableModels } from '@/application/ai/model-fetcher';
 import type { OpenRouterModel } from '@/domain/ai/types';
 
+function cacheKey(apiKey: string): string {
+  let hash = 0;
+  for (let i = 0; i < apiKey.length; i++) {
+    hash = ((hash << 5) - hash + apiKey.charCodeAt(i)) | 0;
+  }
+  return hash.toString(36);
+}
+
+const modelCache = new Map<string, OpenRouterModel[]>();
+
 export type UseModelLoaderResult = {
   models: OpenRouterModel[];
   isLoading: boolean;
@@ -20,11 +30,19 @@ export function useModelLoader(service: AiSettingsService): UseModelLoaderResult
     const settings = service.loadSettings();
     if (!settings?.openRouterApiKey) return;
 
+    const key = cacheKey(settings.openRouterApiKey);
+    const cached = modelCache.get(key);
+    if (cached) {
+      setModels(cached);
+      return;
+    }
+
     setIsLoading(true);
     setError(null);
 
     try {
       const fetched = await fetchAvailableModels(settings.openRouterApiKey);
+      modelCache.set(key, fetched);
       setModels(fetched);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load models.');

--- a/src/hooks/use-oauth-callback.ts
+++ b/src/hooks/use-oauth-callback.ts
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+
+import { AiSettingsService } from '@/application/ai/ai-settings-service';
+import { LocalAiSettingsRepository } from '@/data/ai/local-ai-settings-repository';
+import { exchangeAuthCodeForApiKey } from '@/lib/openrouter-oauth';
+
+type OAuthCallbackStatus = 'loading' | 'success' | 'error';
+
+export type UseOAuthCallbackResult = {
+  status: OAuthCallbackStatus;
+  errorMessage: string | null;
+};
+
+const REDIRECT_DELAY_MS = 2000;
+
+function createAiSettingsService(): AiSettingsService {
+  return new AiSettingsService(new LocalAiSettingsRepository());
+}
+
+export function useOAuthCallback(): UseOAuthCallbackResult {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const [status, setStatus] = useState<OAuthCallbackStatus>('loading');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    async function processCallback(): Promise<void> {
+      const code = searchParams.get('code');
+      const state = searchParams.get('state');
+      const error = searchParams.get('error');
+
+      if (error) {
+        setErrorMessage(error);
+        setStatus('error');
+        return;
+      }
+
+      if (!code) {
+        setErrorMessage('No authorization code received.');
+        setStatus('error');
+        return;
+      }
+
+      try {
+        const apiKey = await exchangeAuthCodeForApiKey(code, state ?? undefined);
+        const service = createAiSettingsService();
+        service.saveKey(apiKey);
+        setStatus('success');
+        timeoutId = setTimeout(() => router.push('/workspace'), REDIRECT_DELAY_MS);
+      } catch (err) {
+        setErrorMessage(err instanceof Error ? err.message : 'Unknown error');
+        setStatus('error');
+      }
+    }
+
+    void processCallback();
+
+    return () => {
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, [searchParams, router]);
+
+  return { status, errorMessage };
+}

--- a/src/hooks/use-oauth-callback.ts
+++ b/src/hooks/use-oauth-callback.ts
@@ -33,7 +33,13 @@ export function useOAuthCallback(): UseOAuthCallbackResult {
       const error = searchParams.get('error');
 
       if (error) {
-        setErrorMessage(error);
+        const knownErrors: Record<string, string> = {
+          access_denied: 'Access was denied. Please try again.',
+          invalid_scope: 'Invalid permissions requested.',
+          server_error: 'OpenRouter encountered a server error. Please try again later.',
+          temporarily_unavailable: 'OpenRouter is temporarily unavailable. Please try again later.',
+        };
+        setErrorMessage(knownErrors[error] ?? 'Connection failed. Please try again.');
         setStatus('error');
         return;
       }

--- a/src/hooks/use-oauth-callback.ts
+++ b/src/hooks/use-oauth-callback.ts
@@ -55,7 +55,7 @@ export function useOAuthCallback(): UseOAuthCallbackResult {
         const service = createAiSettingsService();
         service.saveKey(apiKey);
         setStatus('success');
-        timeoutId = setTimeout(() => router.push('/workspace'), REDIRECT_DELAY_MS);
+        timeoutId = setTimeout(() => router.replace('/workspace'), REDIRECT_DELAY_MS);
       } catch (err) {
         setErrorMessage(err instanceof Error ? err.message : 'Unknown error');
         setStatus('error');

--- a/src/hooks/use-scene-draft.ts
+++ b/src/hooks/use-scene-draft.ts
@@ -1,0 +1,70 @@
+import { useCallback, useState } from 'react';
+
+import type { SceneDraftService } from '@/application/ai/scene-draft-service';
+import type { BibleEntity } from '@/domain/bible/types';
+import type { SceneBeat } from '@/domain/scene/schemas';
+import type { Scene } from '@/domain/scene/types';
+
+type UseSceneDraftInput = {
+  scene: Scene | null;
+  synopsis: string;
+  beats: SceneBeat[];
+  entities: BibleEntity[];
+  language: string;
+  service: SceneDraftService;
+  onDraftReady: (draft: string) => void;
+};
+
+export type UseSceneDraftResult = {
+  isGenerating: boolean;
+  generateError: string | null;
+  canGenerate: boolean;
+  generate: () => Promise<void>;
+  clearError: () => void;
+};
+
+export function useSceneDraft({
+  scene,
+  synopsis,
+  beats,
+  entities,
+  language,
+  service,
+  onDraftReady,
+}: UseSceneDraftInput): UseSceneDraftResult {
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [generateError, setGenerateError] = useState<string | null>(null);
+
+  const canGenerate = Boolean(synopsis.trim());
+
+  const generate = useCallback(async (): Promise<void> => {
+    if (!canGenerate || !scene) return;
+
+    setIsGenerating(true);
+    setGenerateError(null);
+
+    try {
+      const result = await service.generateDraft({
+        sceneTitle: scene.title,
+        synopsis,
+        beats,
+        entities,
+        language,
+      });
+
+      if (result.state === 'success') {
+        onDraftReady(result.draft);
+      } else if (result.state === 'no-api-key') {
+        setGenerateError('Set your OpenRouter API key in project settings.');
+      } else {
+        setGenerateError(result.message);
+      }
+    } finally {
+      setIsGenerating(false);
+    }
+  }, [canGenerate, scene, synopsis, beats, entities, language, service, onDraftReady]);
+
+  const clearError = useCallback(() => setGenerateError(null), []);
+
+  return { isGenerating, generateError, canGenerate, generate, clearError };
+}

--- a/src/hooks/use-scene-draft.ts
+++ b/src/hooks/use-scene-draft.ts
@@ -55,7 +55,7 @@ export function useSceneDraft({
       if (result.state === 'success') {
         onDraftReady(result.draft);
       } else if (result.state === 'no-api-key') {
-        setGenerateError('Set your OpenRouter API key in project settings.');
+        setGenerateError('Set your OpenRouter API key in workspace AI settings.');
       } else {
         setGenerateError(result.message);
       }

--- a/src/lib/openrouter-oauth.ts
+++ b/src/lib/openrouter-oauth.ts
@@ -1,0 +1,73 @@
+import { generatePKCEPair, type PKCEPair } from '@/lib/pkce';
+
+const OPENROUTER_AUTH_BASE_URL = 'https://openrouter.ai';
+const STORAGE_KEY_PKCE = 'ainkwell:oauth:pkce';
+const STORAGE_KEY_STATE = 'ainkwell:oauth:state';
+const STATE_BYTE_LENGTH = 16;
+
+export interface OAuthExchangeResponse {
+  key: string;
+  user_id: string | null;
+}
+
+function generateRandomState(): string {
+  const array = new Uint8Array(STATE_BYTE_LENGTH);
+  crypto.getRandomValues(array);
+  return Array.from(array, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+export async function initiateOAuthFlow(callbackUrl: string): Promise<void> {
+  const pkce = await generatePKCEPair();
+  const state = generateRandomState();
+
+  sessionStorage.setItem(STORAGE_KEY_PKCE, JSON.stringify(pkce));
+  sessionStorage.setItem(STORAGE_KEY_STATE, state);
+
+  const params = new URLSearchParams({
+    callback_url: callbackUrl,
+    code_challenge: pkce.codeChallenge,
+    code_challenge_method: pkce.codeChallengeMethod,
+    state,
+  });
+
+  window.location.href = `${OPENROUTER_AUTH_BASE_URL}/auth?${params.toString()}`;
+}
+
+export async function exchangeAuthCodeForApiKey(
+  code: string,
+  state?: string,
+): Promise<string> {
+  const storedState = sessionStorage.getItem(STORAGE_KEY_STATE);
+  const storedPKCE = sessionStorage.getItem(STORAGE_KEY_PKCE);
+
+  if (state && storedState !== state) {
+    throw new Error('Invalid state parameter. Please restart the connection flow.');
+  }
+
+  if (!storedPKCE) {
+    throw new Error('Session data not found. Please restart the connection flow.');
+  }
+
+  const pkce: PKCEPair = JSON.parse(storedPKCE);
+
+  const response = await fetch(`${OPENROUTER_AUTH_BASE_URL}/api/v1/auth/keys`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      code,
+      code_verifier: pkce.codeVerifier,
+      code_challenge_method: pkce.codeChallengeMethod,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to exchange auth code: ${response.status}`);
+  }
+
+  const data = (await response.json()) as OAuthExchangeResponse;
+
+  sessionStorage.removeItem(STORAGE_KEY_PKCE);
+  sessionStorage.removeItem(STORAGE_KEY_STATE);
+
+  return data.key;
+}

--- a/src/lib/openrouter-oauth.ts
+++ b/src/lib/openrouter-oauth.ts
@@ -40,7 +40,7 @@ export async function exchangeAuthCodeForApiKey(
   const storedState = sessionStorage.getItem(STORAGE_KEY_STATE);
   const storedPKCE = sessionStorage.getItem(STORAGE_KEY_PKCE);
 
-  if (state && storedState !== state) {
+  if (!state || !storedState || storedState !== state) {
     throw new Error('Invalid state parameter. Please restart the connection flow.');
   }
 

--- a/src/lib/openrouter-oauth.ts
+++ b/src/lib/openrouter-oauth.ts
@@ -48,7 +48,12 @@ export async function exchangeAuthCodeForApiKey(
     throw new Error('Session data not found. Please restart the connection flow.');
   }
 
-  const pkce: PKCEPair = JSON.parse(storedPKCE);
+  let pkce: PKCEPair;
+  try {
+    pkce = JSON.parse(storedPKCE) as PKCEPair;
+  } catch {
+    throw new Error('Invalid session data. Please restart the connection flow.');
+  }
 
   const response = await fetch(`${OPENROUTER_AUTH_BASE_URL}/api/v1/auth/keys`, {
     method: 'POST',
@@ -65,6 +70,10 @@ export async function exchangeAuthCodeForApiKey(
   }
 
   const data = (await response.json()) as OAuthExchangeResponse;
+
+  if (typeof data.key !== 'string' || !data.key) {
+    throw new Error('Invalid response from OpenRouter. Please try again.');
+  }
 
   sessionStorage.removeItem(STORAGE_KEY_PKCE);
   sessionStorage.removeItem(STORAGE_KEY_STATE);

--- a/src/lib/pkce.ts
+++ b/src/lib/pkce.ts
@@ -1,0 +1,32 @@
+export interface PKCEPair {
+  codeVerifier: string;
+  codeChallenge: string;
+  codeChallengeMethod: 'S256';
+}
+
+export function generateCodeVerifier(): string {
+  const array = new Uint8Array(32);
+  crypto.getRandomValues(array);
+  return base64URLEncode(array);
+}
+
+export function generateCodeChallenge(verifier: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(verifier);
+  return crypto.subtle
+    .digest('SHA-256', data)
+    .then((hash) => base64URLEncode(new Uint8Array(hash)));
+}
+
+export async function generatePKCEPair(): Promise<PKCEPair> {
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = await generateCodeChallenge(codeVerifier);
+  return { codeVerifier, codeChallenge, codeChallengeMethod: 'S256' };
+}
+
+function base64URLEncode(array: Uint8Array): string {
+  return btoa(String.fromCharCode(...array))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+}

--- a/src/test/ai/ai-settings-service.test.ts
+++ b/src/test/ai/ai-settings-service.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AiSettingsError, AiSettingsService } from '@/application/ai/ai-settings-service';
+import { LocalAiSettingsRepository } from '@/data/ai/local-ai-settings-repository';
+
+function createService(): AiSettingsService {
+  const repository = new LocalAiSettingsRepository(window.localStorage);
+  return new AiSettingsService(repository);
+}
+
+describe('AiSettingsService', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns null when no key is stored', () => {
+    const service = createService();
+    expect(service.loadSettings()).toBeNull();
+  });
+
+  it('saves and retrieves a trimmed key', () => {
+    const service = createService();
+    service.saveKey('  sk-test-key  ');
+    expect(service.loadSettings()?.openRouterApiKey).toBe('sk-test-key');
+  });
+
+  it('throws AiSettingsError when saving an empty string', () => {
+    const service = createService();
+    expect(() => service.saveKey('')).toThrow(AiSettingsError);
+  });
+
+  it('throws AiSettingsError when saving a whitespace-only string', () => {
+    const service = createService();
+    expect(() => service.saveKey('   ')).toThrow(AiSettingsError);
+  });
+
+  it('hasKey returns false after clearKey', () => {
+    const service = createService();
+    service.saveKey('sk-test-key');
+    service.clearKey();
+    expect(service.hasKey()).toBe(false);
+  });
+
+  it('hasKey returns true after saveKey', () => {
+    const service = createService();
+    service.saveKey('sk-test-key');
+    expect(service.hasKey()).toBe(true);
+  });
+});
+
+describe('AiSettingsService model selection', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns default model when none is saved', () => {
+    const service = createService();
+    expect(service.getSelectedModel()).toBe('google/gemini-3.1-flash-lite-preview');
+  });
+
+  it('returns the saved model after saveModel', () => {
+    const service = createService();
+    service.saveKey('sk-test-key');
+    service.saveModel('anthropic/claude-3-5-sonnet');
+    expect(service.getSelectedModel()).toBe('anthropic/claude-3-5-sonnet');
+  });
+
+  it('preserves the api key when saving a model', () => {
+    const service = createService();
+    service.saveKey('sk-my-key');
+    service.saveModel('openai/gpt-4o');
+    expect(service.hasKey()).toBe(true);
+  });
+});
+
+describe('AiSettingsService.validateKey', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns false for empty string', async () => {
+    const service = createService();
+    expect(await service.validateKey('')).toBe(false);
+  });
+
+  it('returns false for whitespace-only string', async () => {
+    const service = createService();
+    expect(await service.validateKey('   ')).toBe(false);
+  });
+
+  it('returns true when OpenRouter responds with data object', async () => {
+    const service = createService();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: { label: 'test', usage: 0 } }), { status: 200 }),
+    ));
+    expect(await service.validateKey('sk-or-valid')).toBe(true);
+  });
+
+  it('returns false when OpenRouter responds with error field', async () => {
+    const service = createService();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: { code: 401, message: 'Invalid key' } }), { status: 200 }),
+    ));
+    expect(await service.validateKey('sk-or-bad')).toBe(false);
+  });
+
+  it('returns false on non-ok response', async () => {
+    const service = createService();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(null, { status: 401, statusText: 'Unauthorized' }),
+    ));
+    expect(await service.validateKey('sk-or-bad')).toBe(false);
+  });
+
+  it('returns false when fetch throws', async () => {
+    const service = createService();
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')));
+    expect(await service.validateKey('sk-or-bad')).toBe(false);
+  });
+});

--- a/src/test/ai/ai-settings-service.test.ts
+++ b/src/test/ai/ai-settings-service.test.ts
@@ -48,6 +48,37 @@ describe('AiSettingsService', () => {
   });
 });
 
+describe('AiSettingsService key/model preservation', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('preserves selectedModel when saving a new key', () => {
+    const service = createService();
+    service.saveKey('sk-first');
+    service.saveModel('anthropic/claude-3-5-sonnet');
+    service.saveKey('sk-second');
+    expect(service.getSelectedModel()).toBe('anthropic/claude-3-5-sonnet');
+  });
+
+  it('preserves selectedModel when clearing the key', () => {
+    const service = createService();
+    service.saveKey('sk-test-key');
+    service.saveModel('openai/gpt-4o');
+    service.clearKey();
+    expect(service.hasKey()).toBe(false);
+    expect(service.getSelectedModel()).toBe('openai/gpt-4o');
+  });
+
+  it('falls back to clear() when no selectedModel is saved', () => {
+    const service = createService();
+    service.saveKey('sk-test-key');
+    service.clearKey();
+    expect(service.hasKey()).toBe(false);
+    expect(service.loadSettings()).toBeNull();
+  });
+});
+
 describe('AiSettingsService model selection', () => {
   beforeEach(() => {
     window.localStorage.clear();

--- a/src/test/ai/model-fetcher.test.ts
+++ b/src/test/ai/model-fetcher.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatPrice,
+  formatContextLength,
+  extractProvider,
+} from '@/application/ai/model-fetcher';
+
+describe('formatPrice', () => {
+  it('formats non-zero prompt and completion prices per 1K tokens', () => {
+    expect(formatPrice('0.000001', '0.000002')).toBe('$0.001 / $0.002 per 1K tokens');
+  });
+
+  it('shows $0 for zero prices', () => {
+    expect(formatPrice('0', '0')).toBe('$0 / $0 per 1K tokens');
+  });
+
+  it('returns N/A for invalid prices', () => {
+    expect(formatPrice('', '')).toBe('N/A');
+  });
+});
+
+describe('formatContextLength', () => {
+  it('formats millions', () => {
+    expect(formatContextLength(1_000_000)).toBe('1.0M tokens');
+  });
+
+  it('formats thousands', () => {
+    expect(formatContextLength(128_000)).toBe('128K tokens');
+  });
+
+  it('formats small values', () => {
+    expect(formatContextLength(512)).toBe('512 tokens');
+  });
+
+  it('returns N/A for null', () => {
+    expect(formatContextLength(null)).toBe('N/A');
+  });
+});
+
+describe('extractProvider', () => {
+  it('capitalizes the provider from a model id', () => {
+    expect(extractProvider('google/gemini-2.0-flash-001')).toBe('Google');
+  });
+
+  it('handles anthropic', () => {
+    expect(extractProvider('anthropic/claude-3-5-sonnet')).toBe('Anthropic');
+  });
+
+  it('returns empty string for malformed id', () => {
+    expect(extractProvider('')).toBe('');
+  });
+});

--- a/src/test/ai/scene-draft-service.test.ts
+++ b/src/test/ai/scene-draft-service.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AiSettingsService } from '@/application/ai/ai-settings-service';
+import { SceneDraftService } from '@/application/ai/scene-draft-service';
+import { LocalAiSettingsRepository } from '@/data/ai/local-ai-settings-repository';
+import type { BibleEntity } from '@/domain/bible/types';
+import type { SceneBeat } from '@/domain/scene/schemas';
+import type { SceneDraftRequest } from '@/domain/ai/types';
+
+function createService(): { service: SceneDraftService; aiService: AiSettingsService } {
+  const repository = new LocalAiSettingsRepository(window.localStorage);
+  const aiService = new AiSettingsService(repository);
+  const service = new SceneDraftService(aiService);
+  return { service, aiService };
+}
+
+function buildEntity(overrides: Partial<BibleEntity> = {}): BibleEntity {
+  return {
+    id: 'entity-1',
+    projectId: 'project-1',
+    category: 'character',
+    name: 'Aria',
+    summary: 'A skilled warrior',
+    details: '',
+    tags: [],
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function buildBeat(overrides: Partial<SceneBeat> = {}): SceneBeat {
+  return {
+    id: 'beat-1',
+    type: 'action',
+    content: 'The hero draws their sword',
+    ...overrides,
+  };
+}
+
+function buildRequest(overrides: Partial<SceneDraftRequest> = {}): SceneDraftRequest {
+  return {
+    sceneTitle: 'The Final Battle',
+    synopsis: 'The hero faces the villain in a climactic fight.',
+    beats: [buildBeat()],
+    entities: [buildEntity()],
+    language: 'en',
+    ...overrides,
+  };
+}
+
+function makeOkResponse(content: string): Response {
+  return new Response(
+    JSON.stringify({
+      choices: [{ message: { content } }],
+    }),
+    { status: 200 },
+  );
+}
+
+function makeErrorResponse(status: number, statusText: string): Response {
+  return new Response(null, { status, statusText });
+}
+
+describe('SceneDraftService', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns no-api-key state when no key is configured', async () => {
+    const { service } = createService();
+    const result = await service.generateDraft(buildRequest());
+    expect(result).toEqual({ state: 'no-api-key' });
+  });
+
+  it('returns success with draft content on 200 response', async () => {
+    const { service, aiService } = createService();
+    aiService.saveKey('sk-valid-key');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeOkResponse('Once upon a time...')));
+
+    const result = await service.generateDraft(buildRequest());
+    expect(result).toEqual({ state: 'success', draft: 'Once upon a time...' });
+  });
+
+  it('returns api-error on 401 response with message', async () => {
+    const { service, aiService } = createService();
+    aiService.saveKey('sk-invalid-key');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeErrorResponse(401, 'Unauthorized')));
+
+    const result = await service.generateDraft(buildRequest());
+    expect(result).toEqual({ state: 'api-error', message: '401: Unauthorized' });
+  });
+
+  it('returns api-error on 429 response with message', async () => {
+    const { service, aiService } = createService();
+    aiService.saveKey('sk-valid-key');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeErrorResponse(429, 'Too Many Requests')));
+
+    const result = await service.generateDraft(buildRequest());
+    expect(result).toEqual({ state: 'api-error', message: '429: Too Many Requests' });
+  });
+
+  it('returns api-error when fetch throws a network error', async () => {
+    const { service, aiService } = createService();
+    aiService.saveKey('sk-valid-key');
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Failed to fetch')));
+
+    const result = await service.generateDraft(buildRequest());
+    expect(result).toEqual({ state: 'api-error', message: 'Network error. Check your connection.' });
+  });
+
+  it('includes entity names and categories in the request body', async () => {
+    const { service, aiService } = createService();
+    aiService.saveKey('sk-valid-key');
+    const mockFetch = vi.fn().mockResolvedValue(makeOkResponse('prose'));
+    vi.stubGlobal('fetch', mockFetch);
+
+    await service.generateDraft(buildRequest({ entities: [buildEntity({ name: 'Aria', category: 'character' })] }));
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as { messages: Array<{ role: string; content: string }> };
+    const systemMessage = body.messages.find((m) => m.role === 'system')?.content ?? '';
+    expect(systemMessage).toContain('Aria');
+    expect(systemMessage).toContain('character');
+  });
+
+  it('includes beat content in the request body', async () => {
+    const { service, aiService } = createService();
+    aiService.saveKey('sk-valid-key');
+    const mockFetch = vi.fn().mockResolvedValue(makeOkResponse('prose'));
+    vi.stubGlobal('fetch', mockFetch);
+
+    await service.generateDraft(buildRequest({ beats: [buildBeat({ content: 'The hero draws their sword' })] }));
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as { messages: Array<{ role: string; content: string }> };
+    const userMessage = body.messages.find((m) => m.role === 'user')?.content ?? '';
+    expect(userMessage).toContain('The hero draws their sword');
+  });
+
+  it('includes language in the request body', async () => {
+    const { service, aiService } = createService();
+    aiService.saveKey('sk-valid-key');
+    const mockFetch = vi.fn().mockResolvedValue(makeOkResponse('prose'));
+    vi.stubGlobal('fetch', mockFetch);
+
+    await service.generateDraft(buildRequest({ language: 'fr' }));
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as { messages: Array<{ role: string; content: string }> };
+    const systemMessage = body.messages.find((m) => m.role === 'system')?.content ?? '';
+    expect(systemMessage).toContain('fr');
+  });
+
+  it('strips code fences from the returned draft', async () => {
+    const { service, aiService } = createService();
+    aiService.saveKey('sk-valid-key');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeOkResponse('```markdown\nOnce upon a time...\n```')));
+
+    const result = await service.generateDraft(buildRequest());
+    expect(result).toEqual({ state: 'success', draft: 'Once upon a time...' });
+  });
+});

--- a/src/test/project/outline-canvas.test.tsx
+++ b/src/test/project/outline-canvas.test.tsx
@@ -158,7 +158,7 @@ describe('OutlineCanvas', () => {
     );
 
     const openLink = screen.getByRole('link', { name: /Open full editor/i });
-    expect(openLink).toHaveAttribute('href', `/workspace/${projectId}/scene/${sceneId1}`);
+    expect(openLink).toHaveAttribute('href', `/workspace/${projectId}/scene/${sceneId1}?from=outline`);
   });
 
   it('shows actionError when prop is set', () => {


### PR DESCRIPTION
## Summary

- Add **Generate Draft** button to scene editor — calls OpenRouter API to generate prose from synopsis + beats + story bible context
- Add **OpenRouter OAuth PKCE flow** — 100% browser-side, no server needed
- Add **model selector dialog** — searchable list of all OpenRouter models with price/context info, persisted in localStorage
- Move AI Settings panel to global workspace page (not per-project)

## Changes

### Domain & Data
- `domain/ai/types.ts` — add `OpenRouterModel` type, add `selectedModel?` to `AiSettings`
- `data/ai/local-ai-settings-repository.ts` — add `selectedModel` to Zod schema

### Application
- `application/ai/model-fetcher.ts` — `fetchAvailableModels()`, `formatPrice()`, `formatContextLength()`, `extractProvider()`
- `application/ai/ai-settings-service.ts` — add `saveModel()`, `getSelectedModel()` (default: `google/gemini-3.1-flash-lite-preview`)
- `application/ai/scene-draft-service.ts` — use `getSelectedModel()` instead of hardcoded constant

### Hooks
- `hooks/use-scene-draft.ts` — calls `SceneDraftService`, manages loading/error state
- `hooks/use-model-loader.ts` — fetches models from OpenRouter when dialog opens
- `hooks/use-oauth-callback.ts` — handles OAuth callback, exchanges code for API key

### Components
- `components/ai/ai-settings-panel.tsx` — OAuth button, model selector button + dialog
- `components/ai/model-card.tsx` — model card with name, provider, price, context length
- `components/ai/model-selection-dialog.tsx` — searchable dialog, loads 300+ models live
- `components/scene/generate-draft-button.tsx` — disabled without synopsis, shows hint text
- `components/scene/scene-editor-shell.tsx` — wire Generate Draft into editor

### Infrastructure
- `lib/openrouter-oauth.ts` + `lib/pkce.ts` — OAuth 2.0 PKCE helpers
- `app/auth/openrouter/callback/` — OAuth callback page
- `app/workspace/page.tsx` — render AI Settings panel globally

## Test Plan

- [x] 159 unit tests passing (`npm run test:ci`)
- [x] AI Settings panel visible on `/workspace` with no key → model button disabled
- [x] After injecting API key → model button enabled, shows `gemini-3.1-flash-lite-preview`
- [x] Click model button → dialog opens, 346 models load, search filters correctly
- [x] Select model → dialog closes, model saved to localStorage
- [x] Scene with synopsis → Generate Draft button enabled
- [x] Scene without synopsis → Generate Draft button disabled + hint "Add a synopsis to generate"
- [x] 0 console errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- AI-driven scene drafting: Add "Generate Draft" in the scene editor to produce prose from synopsis, beats and story-bible context using OpenRouter.
- OpenRouter OAuth (browser-only PKCE): Client-side PKCE utilities and OAuth helpers (initiate/exchange) plus callback page to obtain and persist OpenRouter API keys without a backend.
- Searchable model selector: Dialog showing provider, price and context length (~300+ models), searchable and persisted to localStorage; model selection defaults to google/gemini-3.1-flash-lite-preview.
- Global AI Settings panel: Workspace-level UI for API key management, OAuth connect, model selection and validation.
- Scene editor wiring: Draft-service integration, GenerateDraftButton (disabled without synopsis), language support, and draft replacement flow in editor UI.
- Services, hooks and domain:
  - AiSettingsService (key validation, save/clear key, save/get selected model).
  - SceneDraftService (builds prompts, calls OpenRouter, handles errors).
  - LocalAiSettingsRepository (localStorage persistence with Zod validation).
  - Hooks: useSceneDraft, useModelLoader (with client-side caching), useOAuthCallback.
  - Model-fetcher utilities: fetchAvailableModels, formatPrice, formatContextLength, extractProvider.
  - Domain types: OpenRouterModel, AiSettings, SceneDraftRequest/Result.
- Infrastructure additions: PKCE generator, OpenRouter OAuth flow, OAuth state & PKCE handling and validation, cached model list per API key.
- Tests & quality: ~159 unit tests added/updated (ai settings, model fetcher, scene draft service); model list load and persistence tested; accessibility and error-handling improvements; no console errors in tests.
- Affected areas: frontend (scene editor, workspace UI, components), client-side authentication (OAuth/PKCE), AI integration (OpenRouter API & model management), and local persistence (localStorage).
- Breaking changes: None — additive feature; existing functionality preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->